### PR TITLE
Put SL2K4 in its own sync unit because VLS was taken out of TMO beamline

### DIFF
--- a/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT).xti
+++ b/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT).xti
@@ -44,6 +44,8 @@
 		<Box File="Power (EK1200).xti" Id="1">
 			<EtherCAT PortABoxInfo="#x00ffffff"/>
 		</Box>
-		<EtherCAT EnableVirtualSwitch="true" MaxSwitchPorts="2" MaxSwitchFrames="120"/>
+		<EtherCAT EnableVirtualSwitch="true" MaxSwitchPorts="2" MaxSwitchFrames="120">
+			<SyncUnit Name="SL2K4" NoDeleteIfUnused="true"/>
+		</EtherCAT>
 	</Device>
 </TcSmItem>

--- a/plc-tmo-motion/_Config/NC/Axes/Axis 18 PF1K4-WFS_TARGET-MMS-Y.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/Axis 18 PF1K4-WFS_TARGET-MMS-Y.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.32" ClassName="CNcAxisDef" SubType="1">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -1358,9 +1358,7 @@ External Setpoint Generation:
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-05" Offset="-358.0066" MaxCount="#x00400000" ReferenceSystem="1">
 				<SoftEndMinControl Enable="true" Range="-99.33"/>
-				<SoftEndMaxControl Enable="true" Range="-9.71"/>
-				<ParameterChanged>14</ParameterChanged>
-				<ParameterChanged>13</ParameterChanged>
+				<SoftEndMaxControl Enable="true" Range="12"/>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>

--- a/plc-tmo-motion/_Config/NC/Axes/Axis 18 PF1K4-WFS_TARGET-MMS-Y.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/Axis 18 PF1K4-WFS_TARGET-MMS-Y.xti
@@ -1358,7 +1358,7 @@ External Setpoint Generation:
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-05" Offset="-358.0066" MaxCount="#x00400000" ReferenceSystem="1">
 				<SoftEndMinControl Enable="true" Range="-99.33"/>
-				<SoftEndMaxControl Enable="true" Range="12"/>
+				<SoftEndMaxControl Enable="true" Range="-9.97777"/>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>


### PR DESCRIPTION
Since VLS has been decabled and taken out of the beamline, I put the SL2K4 Scatter slits in a separate sync unit so that the rest of the scatter slits SL1K4 can run. Once this was done the solution ran and the TMO beamline vacuum came back.