### PR TITLE
Switch SL1K4 to use SL1K0

### DIFF
--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SL1K4_SCATTER.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SL1K4_SCATTER.TcPOU
@@ -73,7 +73,7 @@ fbSL1K4(stTopBlade:=  Main.M11,
         io_fbFFHWO := GVL_PMPS.fbFastFaultOutput2,
         fbArbiter := GVL_PMPS.fbArbiter);
 
-fbSL1K4.M_CheckPMPS(2);
+fbSL1K4.M_CheckPMPS(PMPS.K_Apertures.SL1K0);
 
 
 


### PR DESCRIPTION
Index 2 (previous) was referring to SL2K0 which is almost always wide open. SL1K4 being anything less than that would cause a fault. Switching to SL1K0 means SL1K4 could at least be narrowed somewhat more.