### PR TITLE
fixing FZP Y encoder error

### DIFF
--- a/plc-tmo-motion/_Config/NC/Axes/YagZ.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/YagZ.xti
@@ -1331,13 +1331,14 @@ External Setpoint Generation:
 		<Encoder Name="Enc" EncType="4">
 			<EncPara ScaleFactorNumerator="9.6875e-05" Inverse="true" MaxCount="#x0000ffff">
 				<Inc RefSoftSyncMask="#x0000ffff"/>
+				<ParameterChanged>11</ParameterChanged>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{901C2423-655B-45CE-B7E3-21F174F0F99F}" Namespace="MC">NCENCODERSTRUCT_IN2B</Type>
-					<BitOffs>69376</BitOffs>
+					<BitOffs>70336</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
@@ -1375,7 +1376,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{9CC50AB2-5D79-4869-A3C2-1FA7761BAFEA}" Namespace="MC">NCENCODERSTRUCT_OUT2</Type>
-					<BitOffs>109312</BitOffs>
+					<BitOffs>110272</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1407,7 +1408,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>69696</BitOffs>
+					<BitOffs>70656</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
@@ -1445,7 +1446,7 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>109632</BitOffs>
+					<BitOffs>110592</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1498,7 +1499,7 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>FromPlc</Name>
 				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>68352</BitOffs>
+				<BitOffs>69312</BitOffs>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
@@ -1506,7 +1507,7 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>ToPlc</Name>
 				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>107264</BitOffs>
+				<BitOffs>108224</BitOffs>
 				<SubVar>
 					<Name>AxisState</Name>
 					<Comment>

--- a/plc-tmo-motion/_Config/NC/Axes/ZonePlateY.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/ZonePlateY.xti
@@ -1329,7 +1329,7 @@ External Setpoint Generation:
 			<OtherSettings AllowMotionCmdToSlave="true" PulseDistancePos="0.5" PulseDistanceNeg="0.5"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
-			<EncPara ScaleFactorNumerator="5e-05" MaxCount="#xffffffff">
+			<EncPara ScaleFactorNumerator="5e-05" Offset="-214733" MaxCount="#xffffffff">
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 				<ParameterChanged>35</ParameterChanged>
 			</EncPara>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
FZP Y encoder does not work and Yag z, theta do not move
<!--- Describe your changes in detail -->
PLC side we revert encoder polarity for Encoder FZP Y and recheck all connectors and wire 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
FZP motor Y does not work at all, the position reads 0
<!--- If it fixes an open issue, please link to the issue here. -->

https://jira.slac.stanford.edu/browse/ECS-1406

<!--- Please describe in detail how you tested your changes. -->
we can move the encoder Y now without issue
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-1406
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
