### PR TITLE
adding sp1k4-att states and PMPS

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -3697,6 +3697,300 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 					<SubVar>
@@ -8469,11 +8763,40 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -8612,6 +8935,10 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>

--- a/plc-tmo-motion/tmo_motion/DUTs/ENUM_SolidAttenuator_Staes.TcDUT
+++ b/plc-tmo-motion/tmo_motion/DUTs/ENUM_SolidAttenuator_Staes.TcDUT
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <DUT Name="ENUM_SolidAttenuator_Staes" Id="{a9b56f49-37af-4519-bf3c-f4ee10056eb1}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE ENUM_SolidAttenuator_Staes :
+(
+
+    Unknown := 0,
+    OUT := 1,
+    Target1 := 2,
+    Target2 := 3,
+    Target3 := 4,
+    Target4 := 5,
+    Target5 := 6
+
+)UINT;
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/plc-tmo-motion/tmo_motion/DUTs/ENUM_SolidAttenuator_States.TcDUT
+++ b/plc-tmo-motion/tmo_motion/DUTs/ENUM_SolidAttenuator_States.TcDUT
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
-  <DUT Name="ENUM_SolidAttenuator_Staes" Id="{a9b56f49-37af-4519-bf3c-f4ee10056eb1}">
+  <DUT Name="ENUM_SolidAttenuator_States" Id="{a9b56f49-37af-4519-bf3c-f4ee10056eb1}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}
-TYPE ENUM_SolidAttenuator_Staes :
+TYPE ENUM_SolidAttenuator_States :
 (
 
     Unknown := 0,

--- a/plc-tmo-motion/tmo_motion/DUTs/ENUM_ZonePlate_States.TcDUT
+++ b/plc-tmo-motion/tmo_motion/DUTs/ENUM_ZonePlate_States.TcDUT
@@ -4,26 +4,26 @@
     <Declaration><![CDATA[{attribute 'qualified_only'}
 TYPE ENUM_ZonePlate_States :
 (
-	Unknown := 0,
+    Unknown := 0,
     OUT := 1,
-	Yag := 2,
-	FZP860_1 := 3,   //Ne1
-	FZP860_2 := 4,   //Ne2
-	FZP860_3 := 5,   //Ne3
-	FZP750_1 := 6,   //3w1
-	FZP750_2 := 7,   //3w2
-	FZP530_1 := 8,   //o1
-	FZP530_2 := 9,   //o2
-	FZP460_1 := 10,   //Ti1
-	FZP460_2 := 11,   //Ti2
-	FZP410_1 := 12,   //N1
-	FZP410_2 := 13,   //N2
-	FZP290_1 := 14,   // C1
-	FZP290_2 := 15   //C2
-//	FZP250_1 := 16    //w1  ?
-	
-	
-	//TODO: is add all therest
+    Yag := 2,
+    FZP860_1 := 3,   //Ne1
+    FZP860_2 := 4,   //Ne2
+    FZP860_3 := 5,   //Ne3
+    FZP750_1 := 6,   //3w1
+    FZP750_2 := 7,   //3w2
+    FZP530_1 := 8,   //o1
+    FZP530_2 := 9,   //o2
+    FZP460_1 := 10,   //Ti1
+    FZP460_2 := 11,   //Ti2
+    FZP410_1 := 12,   //N1
+    FZP410_2 := 13,   //N2
+    FZP290_1 := 14,   // C1
+    FZP290_2 := 15   //C2
+//	FZP250_1 := 16    //w1
+
+
+
 ) UINT;
 END_TYPE
 ]]></Declaration>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -9,19 +9,19 @@ VAR
     fbMotionZPY: FB_MotionStage;
     fbMotionZPZ: FB_MotionStage;
     fbMotionYAGX: FB_MotionStage;
-    fbMotionYAGY: FB_MotionStage;               
+    fbMotionYAGY: FB_MotionStage;
     fbMotionYAGZ: FB_MotionStage;
     fbMotionYAGR: FB_MotionStage;
     fbMotionTL1: FB_MotionStage;
     fbMotionTL2: FB_MotionStage;
-	fbMotionTLX: FB_MotionStage;
-	fbMotionFoilY: FB_MotionStage;
-    
-	{attribute 'TcLinkTo' := 'TIIB[LensX_EL1004]^Channel 1^Input'}
-	bHallInput1 AT %I* : BOOL;
+    fbMotionTLX: FB_MotionStage;
+    fbMotionFoilY: FB_MotionStage;
 
-	{attribute 'TcLinkTo' := 'TIIB[LensX_EL1004]^Channel 2^Input'}
-	bHallInput2 AT %I* : BOOL;
+    {attribute 'TcLinkTo' := 'TIIB[LensX_EL1004]^Channel 1^Input'}
+    bHallInput1 AT %I* : BOOL;
+
+    {attribute 'TcLinkTo' := 'TIIB[LensX_EL1004]^Channel 2^Input'}
+    bHallInput2 AT %I* : BOOL;
 
     {attribute 'TcLinkTo' := 'TIIB[SP1K4-TL1-EL1124]^Channel 1^Input'}
     bTL1High AT %I*: BOOL;
@@ -35,39 +35,68 @@ VAR
     {attribute 'TcLinkTo' := 'TIIB[SP1K4-TL2-EL1124]^Channel 2^Input'}
     bTL2Low AT %I*: BOOL;
     nTL2LowCycles: UINT;
-    
+
     nNumCyclesNeeded: UINT := 100;
 
-	bInit: BOOL :=TRUE;
+    bInit: BOOL :=TRUE;
 
-	// Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise
-	bAttIn: BOOL;
-	
-	////ZP states start
-	{attribute 'pytmc' := '
+    // Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise
+    bAttIn: BOOL;
+
+    ////ZP states start
+    {attribute 'pytmc' := '
         pv: SP1K4:FZP
     '}
-	fbZPStates: FB_PositionStatePMPS3D;
-	{attribute 'pytmc' := '
+    fbZPStates: FB_PositionStatePMPS3D;
+    {attribute 'pytmc' := '
         pv: SP1K4:FZP:STATE:SET
         io: io
     '}
     zp_enumSet: ENUM_ZonePlate_States;
-	 {attribute 'pytmc' := '
+     {attribute 'pytmc' := '
         pv: SP1K4:FZP:STATE:GET
         io: io
     '}
     zp_enumGet: ENUM_ZonePlate_States;
-	fbZPSetup: FB_StateSetupHelper;
-	fbZPDefault: ST_PositionState := (
-		fDelta:=0.5,
-		fVelocity:=1,
-		bMoveOk:=TRUE,
-		bValid:=TRUE
-	);
-	aZPXStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
-	aZPYStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
-	aZPZStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    fbZPSetup: FB_StateSetupHelper;
+    fbZPDefault: ST_PositionState := (
+        fDelta:=0.5,
+        fVelocity:=1,
+        bMoveOk:=TRUE,
+        bValid:=TRUE
+    );
+    aZPXStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    aZPYStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    aZPZStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
+    ////Solid-ATT states start
+    {attribute 'pytmc' := '
+        pv: SP1K4:ATT
+    '}
+    fbATTStates: FB_PositionStatePMPS2D;
+    {attribute 'pytmc' := '
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    '}
+    att_enumSet: ENUM_SolidAttenuator_Staes;
+     {attribute 'pytmc' := '
+        pv: SP1K4:ATT:STATE:GET
+        io: io
+    '}
+    att_enumGet: ENUM_SolidAttenuator_Staes;
+    fbATTSetup: FB_StateSetupHelper;
+    fbATTDefault: ST_PositionState := (
+        fDelta:=0.5,
+        fVelocity:=1,
+        bMoveOk:=TRUE,
+        bValid:=TRUE
+    );
+    aATTXStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    aATTYStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
+
+
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -77,8 +106,7 @@ Main.M32.bLimitForwardEnable := NOT bHallInput1;
 Main.M32.bLimitBackwardEnable := NOT bHallInput2;
 fbMotionLensX(stMotionStage:=Main.M32);
 
-// AL Foil X
-fbMotionFoilX(stMotionStage:=Main.M33);
+
 //Zone Plate
 fbMotionZPX(stMotionStage:=Main.M34);
 fbMotionZPY(stMotionStage:=Main.M35);
@@ -147,240 +175,124 @@ fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP290_2], sName:='F
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=0);
 
 
-
+bAttIn := att_enumGet <> ENUM_SolidAttenuator_Staes.OUT AND  att_enumGet <> ENUM_SolidAttenuator_Staes.Unknown;
 
 IF bAttIn THEN
-	// Attenuator is in, pick the ATT_IN states
-	aZPXStates[ENUM_ZonePlate_States.OUT].stPMPS.sPmpsState := 'SP1K4:FZP-OUT';
-	aZPXStates[ENUM_ZonePlate_States.Yag].stPMPS.sPmpsState := 'SP1K4:FZP-YAG';
-	aZPXStates[ENUM_ZonePlate_States.FZP860_1].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne1_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP860_2].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne2_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP860_3].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne3_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP750_1].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS1_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP750_2].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS2_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP530_1].stPMPS.sPmpsState := 'SP1K4:FZP-530-O1_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP530_2].stPMPS.sPmpsState := 'SP1K4:FZP-530-O2_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP460_1].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti1_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP460_2].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti2_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP410_1].stPMPS.sPmpsState := 'SP1K4:FZP-410-N1_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP410_2].stPMPS.sPmpsState := 'SP1K4:FZP-410-N2_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP290_1].stPMPS.sPmpsState := 'SP1K4:FZP-290-C1_ATT_IN';
-	aZPXStates[ENUM_ZonePlate_States.FZP290_2].stPMPS.sPmpsState := 'SP1K4:FZP-290-C2_ATT_IN';
-	
+    // Attenuator is in, pick the ATT_IN states
+    aZPXStates[ENUM_ZonePlate_States.OUT].stPMPS.sPmpsState := 'SP1K4:FZP-OUT';
+    aZPXStates[ENUM_ZonePlate_States.Yag].stPMPS.sPmpsState := 'SP1K4:FZP-YAG';
+    aZPXStates[ENUM_ZonePlate_States.FZP860_1].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne1_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP860_2].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne2_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP860_3].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne3_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP750_1].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS1_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP750_2].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS2_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP530_1].stPMPS.sPmpsState := 'SP1K4:FZP-530-O1_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP530_2].stPMPS.sPmpsState := 'SP1K4:FZP-530-O2_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP460_1].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti1_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP460_2].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti2_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP410_1].stPMPS.sPmpsState := 'SP1K4:FZP-410-N1_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP410_2].stPMPS.sPmpsState := 'SP1K4:FZP-410-N2_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP290_1].stPMPS.sPmpsState := 'SP1K4:FZP-290-C1_ATT_IN';
+    aZPXStates[ENUM_ZonePlate_States.FZP290_2].stPMPS.sPmpsState := 'SP1K4:FZP-290-C2_ATT_IN';
+
 ELSE
-	// Attenuator is out, pick the ATT_OUT states
-	aZPXStates[ENUM_ZonePlate_States.OUT].stPMPS.sPmpsState := 'SP1K4:FZP-OUT';
-	aZPXStates[ENUM_ZonePlate_States.Yag].stPMPS.sPmpsState := 'SP1K4:FZP-YAG';
-	aZPXStates[ENUM_ZonePlate_States.FZP860_1].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne1_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP860_2].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne2_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP860_3].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne3_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP750_1].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS1_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP750_2].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS2_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP530_1].stPMPS.sPmpsState := 'SP1K4:FZP-530-O1_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP530_2].stPMPS.sPmpsState := 'SP1K4:FZP-530-O2_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP460_1].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti1_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP460_2].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti2_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP410_1].stPMPS.sPmpsState := 'SP1K4:FZP-410-N1_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP410_2].stPMPS.sPmpsState := 'SP1K4:FZP-410-N2_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP290_1].stPMPS.sPmpsState := 'SP1K4:FZP-290-C1_ATT_OUT';
-	aZPXStates[ENUM_ZonePlate_States.FZP290_2].stPMPS.sPmpsState := 'SP1K4:FZP-290-C2_ATT_OUT';
+    // Attenuator is out, pick the ATT_OUT states
+    aZPXStates[ENUM_ZonePlate_States.OUT].stPMPS.sPmpsState := 'SP1K4:FZP-OUT';
+    aZPXStates[ENUM_ZonePlate_States.Yag].stPMPS.sPmpsState := 'SP1K4:FZP-YAG';
+    aZPXStates[ENUM_ZonePlate_States.FZP860_1].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne1_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP860_2].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne2_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP860_3].stPMPS.sPmpsState := 'SP1K4:FZP-860-Ne3_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP750_1].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS1_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP750_2].stPMPS.sPmpsState := 'SP1K4:FZP-750-XPS2_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP530_1].stPMPS.sPmpsState := 'SP1K4:FZP-530-O1_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP530_2].stPMPS.sPmpsState := 'SP1K4:FZP-530-O2_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP460_1].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti1_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP460_2].stPMPS.sPmpsState := 'SP1K4:FZP-460-Ti2_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP410_1].stPMPS.sPmpsState := 'SP1K4:FZP-410-N1_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP410_2].stPMPS.sPmpsState := 'SP1K4:FZP-410-N2_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP290_1].stPMPS.sPmpsState := 'SP1K4:FZP-290-C1_ATT_OUT';
+    aZPXStates[ENUM_ZonePlate_States.FZP290_2].stPMPS.sPmpsState := 'SP1K4:FZP-290-C2_ATT_OUT';
 END_IF
 
 fbZPStates(
-	stMotionStage1:=Main.M34,
-	stMotionStage2:=Main.M35,
-	stMotionStage3:=Main.M36,
-	astPositionState1:=aZPXStates,
-	astPositionState2:=aZPYStates,
-	astPositionState3:=aZPZStates,
-	eEnumSet:=zp_enumSet,
-	eEnumGet:=zp_enumGet,
-	fbFFHWO:=fbFastFaultOutput1,
-	fbArbiter:=fbArbiter,
-	bEnableMotion:=TRUE,
-	bEnableBeamParams:=TRUE,
-	bEnablePositionLimits:=TRUE,
-	sDeviceName:='SP1K4:FZP',
-	sTransitionKey:='SP1K4:FZP-TRANSITION',
-);
-	
-
-
-{*
- IF (bInit) THEN
-	bInit := FALSE;
-	fb_ZPS.fbStates_x.stout.fPosition := -80;
-	fb_ZPS.fbStates_y.stout.fPosition := -7.7;
-	//fbMotionZPZ.stOut.fPosition := 11;
-//	fb_ZPS.fbStates_x.stOut.nRequestAssertionID := 16#5300;
-//	fb_ZPS.fbStates_y.stOut.nRequestAssertionID := 16#5301;
-	fb_ZPS.fbStates_x.stOut.stPMPS.sPmpsState := 'SP1K4:FZP-OUT_X';
-	fb_ZPS.fbStates_y.stOut.stPMPS.sPmpsState := 'SP1K4:FZP-OUT_Y';
-	
-	fb_ZPS.fbStates_x.stYag.fPosition := -17;
-	fb_ZPS.fbStates_y.stYag.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.stYag.nRequestAssertionID := 16#5302;
-//	fb_ZPS.fbStates_y.stYag.nRequestAssertionID := 16#5303;
-	fb_ZPS.fbStates_x.stYag.stPMPS.sPmpsState := 'SP1K4:FZP-YAG_X';
-	fb_ZPS.fbStates_y.stYag.stPMPS.sPmpsState := 'SP1K4:FZP-YAG_Y';
-	
-	fb_ZPS.fbStates_x.stNe1.fPosition := +13;
-	fb_ZPS.fbStates_y.stNe1.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stNe1.nRequestAssertionID := 16#5304;
-//	fb_ZPS.fbStates_y.stNe1.nRequestAssertionID := 16#5305;
-	fb_ZPS.fbStates_x.stNe1.stPMPS.sPmpsState := 'SP1K4:FZP-860_1_X';
-	fb_ZPS.fbStates_y.stNe1.stPMPS.sPmpsState := 'SP1K4:FZP-860_1_Y';
-	
-	fb_ZPS.fbStates_x.stNe2.fPosition := +3;
-	fb_ZPS.fbStates_y.stNe2.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.stNe2.nRequestAssertionID := 16#5306;
-//	fb_ZPS.fbStates_y.stNe2.nRequestAssertionID := 16#5307;
-	fb_ZPS.fbStates_x.stNe2.stPMPS.sPmpsState := 'SP1K4:FZP-860_2_X';
-	fb_ZPS.fbStates_y.stNe2.stPMPS.sPmpsState := 'SP1K4:FZP-860_2_Y';
-	
-	fb_ZPS.fbStates_x.stNe3.fPosition := +13;
-	fb_ZPS.fbStates_y.stNe3.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.stNe3.nRequestAssertionID := 16#5308;
-//	fb_ZPS.fbStates_y.stNe3.nRequestAssertionID := 16#5309;
-	fb_ZPS.fbStates_x.stNe3.stPMPS.sPmpsState := 'SP1K4:FZP-860_3_X';
-	fb_ZPS.fbStates_y.stNe3.stPMPS.sPmpsState := 'SP1K4:FZP-860_3_Y';
-	
-	fb_ZPS.fbStates_x.st3w1.fPosition := -17;
-	fb_ZPS.fbStates_y.st3w1.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.st3w1.nRequestAssertionID := 16#5310;
-//	fb_ZPS.fbStates_y.st3w1.nRequestAssertionID := 16#5311;
-	fb_ZPS.fbStates_x.st3w1.stPMPS.sPmpsState := 'SP1K4:FZP-750_1_X';
-	fb_ZPS.fbStates_y.st3w1.stPMPS.sPmpsState := 'SP1K4:FZP-750_1_Y';
-	
-	fb_ZPS.fbStates_x.st3w2.fPosition := -7;
-	fb_ZPS.fbStates_y.st3w2.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.st3w2.nRequestAssertionID := 16#5312;
-//	fb_ZPS.fbStates_y.st3w2.nRequestAssertionID := 16#5313;
-	fb_ZPS.fbStates_x.st3w2.stPMPS.sPmpsState := 'SP1K4:FZP-750_2_X';
-	fb_ZPS.fbStates_y.st3w2.stPMPS.sPmpsState := 'SP1K4:FZP-750_2_Y';
-	
-	fb_ZPS.fbStates_x.stO1.fPosition := -27;
-	fb_ZPS.fbStates_y.stO1.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stO1.nRequestAssertionID := 16#5314;
-//	fb_ZPS.fbStates_y.stO1.nRequestAssertionID := 16#5315;
-	fb_ZPS.fbStates_x.stO1.stPMPS.sPmpsState := 'SP1K4:FZP-530_1_X';
-	fb_ZPS.fbStates_y.stO1.stPMPS.sPmpsState := 'SP1K4:FZP-530_1_Y';
-	
-	fb_ZPS.fbStates_x.stO2.fPosition := -17;
-	fb_ZPS.fbStates_y.stO2.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stO2.nRequestAssertionID := 16#5316;
-//	fb_ZPS.fbStates_y.stO2.nRequestAssertionID := 16#5317;
-	fb_ZPS.fbStates_x.stO2.stPMPS.sPmpsState := 'SP1K4:FZP-530_2_X';
-	fb_ZPS.fbStates_y.stO2.stPMPS.sPmpsState := 'SP1K4:FZP-530_2_Y';
-	
-	fb_ZPS.fbStates_x.stTi1.fPosition := +23;
-	fb_ZPS.fbStates_y.stTi1.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.stTi1.nRequestAssertionID := 16#5318;
-//	fb_ZPS.fbStates_y.stTi1.nRequestAssertionID := 16#5319;
-	fb_ZPS.fbStates_x.stTi1.stPMPS.sPmpsState := 'SP1K4:FZP-460_1_X';
-	fb_ZPS.fbStates_y.stTi1.stPMPS.sPmpsState := 'SP1K4:FZP-460_1_Y';
-	
-	fb_ZPS.fbStates_x.stTi2.fPosition := +33;
-	fb_ZPS.fbStates_y.stTi2.fPosition := -2.7;
-//	fb_ZPS.fbStates_x.stTi2.nRequestAssertionID := 16#5320;
-//	fb_ZPS.fbStates_y.stTi2.nRequestAssertionID := 16#5321;
-	fb_ZPS.fbStates_x.stTi2.stPMPS.sPmpsState := 'SP1K4:FZP-460_2_X';
-	fb_ZPS.fbStates_y.stTi2.stPMPS.sPmpsState := 'SP1K4:FZP-460_2_Y';
-	
-	fb_ZPS.fbStates_x.stN1.fPosition := +23;
-	fb_ZPS.fbStates_y.stN1.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stN1.nRequestAssertionID := 16#5322;
-//	fb_ZPS.fbStates_y.stN1.nRequestAssertionID := 16#5323;
-	fb_ZPS.fbStates_x.stN1.stPMPS.sPmpsState := 'SP1K4:FZP-410_1_X';
-	fb_ZPS.fbStates_y.stN1.stPMPS.sPmpsState := 'SP1K4:FZP-410_1_Y';
-	
-	fb_ZPS.fbStates_x.stN2.fPosition := +33;
-	fb_ZPS.fbStates_y.stN2.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stN2.nRequestAssertionID := 16#5324;
-//	fb_ZPS.fbStates_y.stN2.nRequestAssertionID := 16#5325;
-	fb_ZPS.fbStates_x.stN2.stPMPS.sPmpsState := 'SP1K4:FZP-410_2_X';
-	fb_ZPS.fbStates_y.stN2.stPMPS.sPmpsState := 'SP1K4:FZP-410_2_Y';
-	
-	fb_ZPS.fbStates_x.stC1.fPosition := -7;
-	fb_ZPS.fbStates_y.stC1.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stC1.nRequestAssertionID := 16#5326;
-//	fb_ZPS.fbStates_y.stC1.nRequestAssertionID := 16#5327;
-	fb_ZPS.fbStates_x.stC1.stPMPS.sPmpsState := 'SP1K4:FZP-290_1_X';
-	fb_ZPS.fbStates_y.stC1.stPMPS.sPmpsState := 'SP1K4:FZP-290_1_Y';
-	
-	fb_ZPS.fbStates_x.stC2.fPosition := +3;
-	fb_ZPS.fbStates_y.stC2.fPosition := -12.7;
-//	fb_ZPS.fbStates_x.stC2.nRequestAssertionID := 16#5328;
-//	fb_ZPS.fbStates_y.stC2.nRequestAssertionID := 16#5329;
-	fb_ZPS.fbStates_x.stC2.stPMPS.sPmpsState := 'SP1K4:FZP-290_2_X';
-	fb_ZPS.fbStates_y.stC2.stPMPS.sPmpsState := 'SP1K4:FZP-290_2_Y';
-	
-	
-	
-		//TODO write all details for every state
-END_IF
-//TODO Give all positions
-fb_ZPS(
-	stXStage := Main.M34,
-	stYStage := Main.M35, 
-	stZStage := Main.M36,
-	fbArbiter:= fbArbiter, 
-	fbFFHWO:= fbFastFaultOutput1,
- //   sPmpsDeviceName := 'SP1K4:FZP',
-//	sTransitionKey :=  
-(*	bEnable:= TRUE, 
-	bReset:= , 
-	bError=> , 
-	nErrorId=> , 
-	sErrorMessage=> , 
-	bBusy=> , 
-	bDone=> , 
-	fbArbiter:= fbArbiter, 
-	fbFFHWO:= fbFastFaultOutput1, 
-	stTransitionBeam:= , 
-	nTransitionAssertionID:= , 
-	nUnknownAssertionID:= , 
-	bArbiterEnabled:= , 
-	tArbiterTimeout:= , 
-	bMoveOnArbiterTimeout:= , 
-	fStateBoundaryDeadband:= , 
-	bBPOKAutoReset:= , 
-	enumSet:= zp_enumSet , 
-	stOut:=stOut, 
-	stYag:=stYag , 
-	stNe1:= , 
-	stNe2:= , 
-	stNe3:= , 
-	st3w1:= , 
-	st3w2:= , 
-	stO2:= , 
-	stO1:= , 
-	stTi1:= , 
-	stTi2:= , 
-	stN1:= , 
-	stN2:= , 
-	stC1:= , 
-	stC2:= , 
-	enumGet=> *)
+    stMotionStage1:=Main.M34,
+    stMotionStage2:=Main.M35,
+    stMotionStage3:=Main.M36,
+    astPositionState1:=aZPXStates,
+    astPositionState2:=aZPYStates,
+    astPositionState3:=aZPZStates,
+    eEnumSet:=zp_enumSet,
+    eEnumGet:=zp_enumGet,
+    fbFFHWO:=fbFastFaultOutput1,
+    fbArbiter:=fbArbiter,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    bEnablePositionLimits:=TRUE,
+    sDeviceName:='SP1K4:FZP',
+    sTransitionKey:='SP1K4:FZP-TRANSITION',
 );
 
 
-*}
-
+// Foil X (Solid-ATT-X)
+fbMotionFoilX(stMotionStage:=Main.M33);
 
 
 // YAG
 fbMotionYAGX(stMotionStage:=Main.M37);
 fbMotionYAGY(stMotionStage:=Main.M38);
 fbMotionYAGZ(stMotionStage:=Main.M39);
-fbMotionYAGR(stMotionStage:=Main.M40);	
+fbMotionYAGR(stMotionStage:=Main.M40);
 // Thorlabs
 fbMotionTL1(stMotionStage:=Main.M41);
 fbMotionTL2(stMotionStage:=Main.M42);
 //Thorlab-LenX
 fbMotionTLX(stMotionStage:=Main.M43);
-//FOIL Y
+//FOIL Y (Solid-ATT-Y)
 fbMotionFoilY(stMotionStage:=Main.M44);
+
+
+fbATTSetup(stPositionState:=fbATTDefault, bSetDefault:=TRUE);
+
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.OUT], sName:='OUT', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.OUT], sName:='OUT', fPosition:=0);
+
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target1], sName:='TARGET1', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target1], sName:='TARGET1', fPosition:=0);
+
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target2], sName:='TARGET2', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target2], sName:='TARGET2', fPosition:=0);
+
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target3], sName:='TARGET3', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target3], sName:='TARGET3', fPosition:=0);
+
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target4], sName:='TARGET4', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target4], sName:='TARGET4', fPosition:=0);
+
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target5], sName:='TARGET5', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target5], sName:='TARGET5', fPosition:=0);
+
+fbATTStates(
+    stMotionStage1:=Main.M33,
+    stMotionStage2:=Main.M44,
+    astPositionState1:=aATTXStates,
+    astPositionState2:=aATTYStates,
+    eEnumSet:=att_enumSet,
+    eEnumGet:=att_enumGet,
+    fbFFHWO:=fbFastFaultOutput1,
+    fbArbiter:=fbArbiter,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    bEnablePositionLimits:=TRUE,
+    sDeviceName:='SP1K4:ATT',
+    sTransitionKey:='SP1K4:ATT-TRANSITION',
+);
+
+
+
+
+
+
+
 
 IF NOT bTL1High THEN
     nTL1HighCycles := MIN(nTL1HighCycles + 1, nNumCyclesNeeded);

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -78,12 +78,12 @@ VAR
         pv: SP1K4:ATT:STATE:SET
         io: io
     '}
-    att_enumSet: ENUM_SolidAttenuator_Staes;
+    att_enumSet: ENUM_SolidAttenuator_States;
      {attribute 'pytmc' := '
         pv: SP1K4:ATT:STATE:GET
         io: io
     '}
-    att_enumGet: ENUM_SolidAttenuator_Staes;
+    att_enumGet: ENUM_SolidAttenuator_States;
     fbATTSetup: FB_StateSetupHelper;
     fbATTDefault: ST_PositionState := (
         fDelta:=0.5,
@@ -175,7 +175,7 @@ fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP290_2], sName:='F
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=0);
 
 
-bAttIn := att_enumGet <> ENUM_SolidAttenuator_Staes.OUT AND  att_enumGet <> ENUM_SolidAttenuator_Staes.Unknown;
+bAttIn := att_enumGet <> ENUM_SolidAttenuator_States.OUT AND  att_enumGet <> ENUM_SolidAttenuator_States.Unknown;
 
 IF bAttIn THEN
     // Attenuator is in, pick the ATT_IN states
@@ -214,6 +214,7 @@ ELSE
     aZPXStates[ENUM_ZonePlate_States.FZP290_2].stPMPS.sPmpsState := 'SP1K4:FZP-290-C2_ATT_OUT';
 END_IF
 
+
 fbZPStates(
     stMotionStage1:=Main.M34,
     stMotionStage2:=Main.M35,
@@ -250,26 +251,33 @@ fbMotionTLX(stMotionStage:=Main.M43);
 //FOIL Y (Solid-ATT-Y)
 fbMotionFoilY(stMotionStage:=Main.M44);
 
-
+// SP1K4-SOLID-ATT PMPS
 fbATTSetup(stPositionState:=fbATTDefault, bSetDefault:=TRUE);
 
-fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.OUT], sName:='OUT', fPosition:=0);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.OUT], sName:='OUT', fPosition:=0);
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.OUT], sName:='OUT', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.OUT], sName:='OUT', fPosition:=0);
 
-fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target1], sName:='TARGET1', fPosition:=0);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target1], sName:='TARGET1', fPosition:=0);
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target1], sName:='TARGET1', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target1], sName:='TARGET1', fPosition:=0);
 
-fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target2], sName:='TARGET2', fPosition:=0);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target2], sName:='TARGET2', fPosition:=0);
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target2], sName:='TARGET2', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target2], sName:='TARGET2', fPosition:=0);
 
-fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target3], sName:='TARGET3', fPosition:=0);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target3], sName:='TARGET3', fPosition:=0);
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target3], sName:='TARGET3', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target3], sName:='TARGET3', fPosition:=0);
 
-fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target4], sName:='TARGET4', fPosition:=0);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target4], sName:='TARGET4', fPosition:=0);
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target4], sName:='TARGET4', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target4], sName:='TARGET4', fPosition:=0);
 
-fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_Staes.Target5], sName:='TARGET5', fPosition:=0);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_Staes.Target5], sName:='TARGET5', fPosition:=0);
+fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target5], sName:='TARGET5', fPosition:=0);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target5], sName:='TARGET5', fPosition:=0);
+
+aATTXStates[ENUM_SolidAttenuator_States.OUT].stPMPS.sPmpsState := 'SP1K4:ATT-OUT';
+aATTXStates[ENUM_SolidAttenuator_States.Target1].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET1';
+aATTXStates[ENUM_SolidAttenuator_States.Target2].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET2';
+aATTXStates[ENUM_SolidAttenuator_States.Target3].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET3';
+aATTXStates[ENUM_SolidAttenuator_States.Target4].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET4';
+aATTXStates[ENUM_SolidAttenuator_States.Target5].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET5';
 
 fbATTStates(
     stMotionStage1:=Main.M33,

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -21,6 +21,9 @@
     <CompilerDefines>K</CompilerDefines>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="DUTs\ENUM_SolidAttenuator_Staes.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="DUTs\ENUM_ZonePlate_States.TcDUT">
       <SubType>Code</SubType>
     </Compile>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -21,7 +21,7 @@
     <CompilerDefines>K</CompilerDefines>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="DUTs\ENUM_SolidAttenuator_Staes.TcDUT">
+    <Compile Include="DUTs\ENUM_SolidAttenuator_States.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="DUTs\ENUM_ZonePlate_States.TcDUT">

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{5B46E39C-4ABC-F349-FFB0-90A893E75B7E}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{57922ABF-CB1F-4436-D907-6EC80DF55899}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -52688,11 +52688,11 @@ Digital outputs</Comment>
         <Text>FZP290_2</Text>
         <Enum>15</Enum>
         <Comment>C2
-	FZP250_1 := 16    //w1  </Comment>
+	FZP250_1 := 16    //w1</Comment>
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name>ENUM_SolidAttenuator_Staes</Name>
+      <Name>ENUM_SolidAttenuator_States</Name>
       <BitSize>16</BitSize>
       <BaseType>UINT</BaseType>
       <EnumInfo>
@@ -59492,7 +59492,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85458944</ByteSize>
+          <ByteSize>85524480</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -68491,7 +68491,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85458944</ByteSize>
+          <ByteSize>85524480</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -71083,7 +71083,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85458944</ByteSize>
+          <ByteSize>85524480</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -78347,7 +78347,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>PRG_SP1K4.att_enumSet</Name>
             <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_Staes</BaseType>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -78362,7 +78362,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>PRG_SP1K4.att_enumGet</Name>
             <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_Staes</BaseType>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -80567,7 +80567,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85458944</ByteSize>
+          <ByteSize>85524480</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -80647,7 +80647,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-10T14:32:44</Value>
+          <Value>2023-08-14T10:14:06</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{B793D80A-AA9E-744E-2567-C5D6094A4810}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{5B46E39C-4ABC-F349-FFB0-90A893E75B7E}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84350320</GetCodeOffs>
+        <GetCodeOffs>84563784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84350352</GetCodeOffs>
+        <GetCodeOffs>84563816</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84350360</GetCodeOffs>
+        <GetCodeOffs>84563824</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84350344</GetCodeOffs>
+        <GetCodeOffs>84563808</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84350356</GetCodeOffs>
+        <GetCodeOffs>84563820</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84350264</GetCodeOffs>
-        <SetCodeOffs>84350288</SetCodeOffs>
+        <GetCodeOffs>84563728</GetCodeOffs>
+        <SetCodeOffs>84563752</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84350300</GetCodeOffs>
-        <SetCodeOffs>84350312</SetCodeOffs>
+        <GetCodeOffs>84563764</GetCodeOffs>
+        <SetCodeOffs>84563776</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>84350408</GetCodeOffs>
+        <GetCodeOffs>84563872</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84350388</GetCodeOffs>
+        <GetCodeOffs>84563852</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84350476</GetCodeOffs>
+        <GetCodeOffs>84563940</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84350436</GetCodeOffs>
+        <GetCodeOffs>84563900</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84350480</GetCodeOffs>
+        <GetCodeOffs>84563944</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84350504</GetCodeOffs>
+        <GetCodeOffs>84563968</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -52688,8 +52688,40 @@ Digital outputs</Comment>
         <Text>FZP290_2</Text>
         <Enum>15</Enum>
         <Comment>C2
-	FZP250_1 := 16    //w1  ?
-TODO: is add all therest</Comment>
+	FZP250_1 := 16    //w1  </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>ENUM_SolidAttenuator_Staes</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
       </EnumInfo>
     </DataType>
     <DataType>
@@ -52904,6 +52936,339 @@ TODO: is add all therest</Comment>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
         <BitOffs>87120</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</Name>
+      <BitSize>1506368</BitSize>
+      <SubItem>
+        <Name>stMotionStage1</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The 1st motor to move</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage2</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The 2nd motor to move</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState1</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for motor 1, including unused/invalid states.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE:M1
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState2</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for motor 2, including unused/invalid states.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE:M2
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct
+ PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1616</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1664</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>1696</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>2464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>4960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
+        <BitSize>600960</BitSize>
+        <BitOffs>7488</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPMPSCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
+        <BitSize>658112</BitSize>
+        <BitOffs>608448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>75648</BitSize>
+        <BitOffs>1266560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>164160</BitSize>
+        <BitOffs>1342208</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -53674,8 +54039,8 @@ TODO: is add all therest</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84357064</GetCodeOffs>
-        <SetCodeOffs>84357072</SetCodeOffs>
+        <GetCodeOffs>84570552</GetCodeOffs>
+        <SetCodeOffs>84570560</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -54969,31 +55334,31 @@ TODO: is add all therest</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84356632</GetCodeOffs>
+        <GetCodeOffs>84570120</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84356664</GetCodeOffs>
+        <GetCodeOffs>84570152</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84356668</GetCodeOffs>
+        <GetCodeOffs>84570156</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84356656</GetCodeOffs>
+        <GetCodeOffs>84570144</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84356676</GetCodeOffs>
+        <GetCodeOffs>84570164</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -59127,7 +59492,7 @@ TODO: is add all therest</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85262336</ByteSize>
+          <ByteSize>85458944</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -60767,7 +61132,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657686784</BitOffs>
+            <BitOffs>657686976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60779,7 +61144,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657984704</BitOffs>
+            <BitOffs>657984896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60791,7 +61156,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658282624</BitOffs>
+            <BitOffs>658282816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60803,7 +61168,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658580544</BitOffs>
+            <BitOffs>658580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60815,7 +61180,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658878464</BitOffs>
+            <BitOffs>658878656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60827,7 +61192,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659176384</BitOffs>
+            <BitOffs>659176576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60839,7 +61204,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659474304</BitOffs>
+            <BitOffs>659474496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60851,7 +61216,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659772224</BitOffs>
+            <BitOffs>659772416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60863,7 +61228,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660070144</BitOffs>
+            <BitOffs>660070336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60875,7 +61240,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660368064</BitOffs>
+            <BitOffs>660368256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60887,7 +61252,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660665984</BitOffs>
+            <BitOffs>660666176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60899,7 +61264,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660963904</BitOffs>
+            <BitOffs>660964096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60911,7 +61276,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661261824</BitOffs>
+            <BitOffs>661262016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -60923,7 +61288,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662825024</BitOffs>
+            <BitOffs>662825216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -60946,7 +61311,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662832960</BitOffs>
+            <BitOffs>662833152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -60969,7 +61334,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662832968</BitOffs>
+            <BitOffs>662833160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -60992,7 +61357,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662832976</BitOffs>
+            <BitOffs>662833168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61015,7 +61380,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662832992</BitOffs>
+            <BitOffs>662833184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61028,7 +61393,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833024</BitOffs>
+            <BitOffs>662833216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61041,7 +61406,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833088</BitOffs>
+            <BitOffs>662833280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61054,7 +61419,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833104</BitOffs>
+            <BitOffs>662833296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61066,7 +61431,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662850240</BitOffs>
+            <BitOffs>662850432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61089,7 +61454,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858176</BitOffs>
+            <BitOffs>662858368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61112,7 +61477,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858184</BitOffs>
+            <BitOffs>662858376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -61135,7 +61500,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858192</BitOffs>
+            <BitOffs>662858384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61158,7 +61523,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858208</BitOffs>
+            <BitOffs>662858400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61171,7 +61536,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858240</BitOffs>
+            <BitOffs>662858432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61184,7 +61549,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858304</BitOffs>
+            <BitOffs>662858496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61197,7 +61562,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858320</BitOffs>
+            <BitOffs>662858512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61209,7 +61574,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662875456</BitOffs>
+            <BitOffs>662875648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61232,7 +61597,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883392</BitOffs>
+            <BitOffs>662883584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61255,7 +61620,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883400</BitOffs>
+            <BitOffs>662883592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -61278,7 +61643,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883408</BitOffs>
+            <BitOffs>662883600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61301,7 +61666,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883424</BitOffs>
+            <BitOffs>662883616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61314,7 +61679,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883456</BitOffs>
+            <BitOffs>662883648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61327,7 +61692,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883520</BitOffs>
+            <BitOffs>662883712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -61340,7 +61705,436 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883536</BitOffs>
+            <BitOffs>662883728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664587264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bLimitForwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if forward limit hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bLimitBackwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if reverse limit hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHome
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if at homing switch
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664612480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bLimitForwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if forward limit hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bLimitBackwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if reverse limit hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHome
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if at homing switch
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664637696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bLimitForwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if forward limit hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bLimitBackwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if reverse limit hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHome
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if at homing switch
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -61356,7 +62150,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663320864</BitOffs>
+            <BitOffs>665028320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -61377,7 +62171,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663324384</BitOffs>
+            <BitOffs>665031840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -61398,7 +62192,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663324385</BitOffs>
+            <BitOffs>665031841</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -61410,7 +62204,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673522752</BitOffs>
+            <BitOffs>675230272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -61433,7 +62227,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530688</BitOffs>
+            <BitOffs>675238208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -61456,7 +62250,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530696</BitOffs>
+            <BitOffs>675238216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -61479,7 +62273,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530704</BitOffs>
+            <BitOffs>675238224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -61502,7 +62296,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530720</BitOffs>
+            <BitOffs>675238240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -61515,7 +62309,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530752</BitOffs>
+            <BitOffs>675238272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -61528,7 +62322,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530816</BitOffs>
+            <BitOffs>675238336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -61541,7 +62335,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673530832</BitOffs>
+            <BitOffs>675238352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -61553,7 +62347,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673547968</BitOffs>
+            <BitOffs>675255488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -61576,7 +62370,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673555904</BitOffs>
+            <BitOffs>675263424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -61599,7 +62393,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673555912</BitOffs>
+            <BitOffs>675263432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -61622,7 +62416,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673555920</BitOffs>
+            <BitOffs>675263440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -61645,7 +62439,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673555936</BitOffs>
+            <BitOffs>675263456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -61658,7 +62452,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673555968</BitOffs>
+            <BitOffs>675263488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -61671,7 +62465,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673556032</BitOffs>
+            <BitOffs>675263552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -61684,7 +62478,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673556048</BitOffs>
+            <BitOffs>675263568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -61696,7 +62490,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673573184</BitOffs>
+            <BitOffs>675280704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -61719,7 +62513,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581120</BitOffs>
+            <BitOffs>675288640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -61742,7 +62536,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581128</BitOffs>
+            <BitOffs>675288648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -61765,7 +62559,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581136</BitOffs>
+            <BitOffs>675288656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -61788,7 +62582,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581152</BitOffs>
+            <BitOffs>675288672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -61801,7 +62595,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581184</BitOffs>
+            <BitOffs>675288704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -61814,7 +62608,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581248</BitOffs>
+            <BitOffs>675288768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -61827,7 +62621,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673581264</BitOffs>
+            <BitOffs>675288784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -61839,7 +62633,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673598400</BitOffs>
+            <BitOffs>675305920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -61862,7 +62656,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606336</BitOffs>
+            <BitOffs>675313856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -61885,7 +62679,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606344</BitOffs>
+            <BitOffs>675313864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -61908,7 +62702,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606352</BitOffs>
+            <BitOffs>675313872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -61931,7 +62725,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606368</BitOffs>
+            <BitOffs>675313888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -61944,7 +62738,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606400</BitOffs>
+            <BitOffs>675313920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -61957,7 +62751,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606464</BitOffs>
+            <BitOffs>675313984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -61970,7 +62764,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673606480</BitOffs>
+            <BitOffs>675314000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -61982,7 +62776,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673623616</BitOffs>
+            <BitOffs>675331136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -62005,7 +62799,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631552</BitOffs>
+            <BitOffs>675339072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -62028,7 +62822,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631560</BitOffs>
+            <BitOffs>675339080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -62051,7 +62845,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631568</BitOffs>
+            <BitOffs>675339088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -62074,7 +62868,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631584</BitOffs>
+            <BitOffs>675339104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -62087,7 +62881,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631616</BitOffs>
+            <BitOffs>675339136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -62100,7 +62894,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631680</BitOffs>
+            <BitOffs>675339200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -62113,7 +62907,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673631696</BitOffs>
+            <BitOffs>675339216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -62125,7 +62919,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673648832</BitOffs>
+            <BitOffs>675356352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -62148,7 +62942,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656768</BitOffs>
+            <BitOffs>675364288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -62171,7 +62965,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656776</BitOffs>
+            <BitOffs>675364296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -62194,7 +62988,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656784</BitOffs>
+            <BitOffs>675364304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -62217,7 +63011,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656800</BitOffs>
+            <BitOffs>675364320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -62230,7 +63024,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656832</BitOffs>
+            <BitOffs>675364352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -62243,7 +63037,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656896</BitOffs>
+            <BitOffs>675364416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -62256,7 +63050,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673656912</BitOffs>
+            <BitOffs>675364432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -62268,7 +63062,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673674048</BitOffs>
+            <BitOffs>675381568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -62291,7 +63085,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673681984</BitOffs>
+            <BitOffs>675389504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -62314,7 +63108,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673681992</BitOffs>
+            <BitOffs>675389512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -62337,7 +63131,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673682000</BitOffs>
+            <BitOffs>675389520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -62360,7 +63154,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673682016</BitOffs>
+            <BitOffs>675389536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -62373,7 +63167,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673682048</BitOffs>
+            <BitOffs>675389568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -62386,7 +63180,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673682112</BitOffs>
+            <BitOffs>675389632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -62399,7 +63193,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673682128</BitOffs>
+            <BitOffs>675389648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -62411,7 +63205,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673699264</BitOffs>
+            <BitOffs>675406784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -62434,7 +63228,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707200</BitOffs>
+            <BitOffs>675414720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -62457,7 +63251,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707208</BitOffs>
+            <BitOffs>675414728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -62480,7 +63274,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707216</BitOffs>
+            <BitOffs>675414736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -62503,7 +63297,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707232</BitOffs>
+            <BitOffs>675414752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -62516,7 +63310,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707264</BitOffs>
+            <BitOffs>675414784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -62529,7 +63323,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707328</BitOffs>
+            <BitOffs>675414848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -62542,7 +63336,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673707344</BitOffs>
+            <BitOffs>675414864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -62554,7 +63348,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673724480</BitOffs>
+            <BitOffs>675432000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -62577,7 +63371,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732416</BitOffs>
+            <BitOffs>675439936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -62600,7 +63394,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732424</BitOffs>
+            <BitOffs>675439944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -62623,7 +63417,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732432</BitOffs>
+            <BitOffs>675439952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -62646,7 +63440,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732448</BitOffs>
+            <BitOffs>675439968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -62659,7 +63453,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732480</BitOffs>
+            <BitOffs>675440000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -62672,7 +63466,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732544</BitOffs>
+            <BitOffs>675440064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -62685,7 +63479,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673732560</BitOffs>
+            <BitOffs>675440080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -62697,7 +63491,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673749696</BitOffs>
+            <BitOffs>675457216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -62720,7 +63514,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757632</BitOffs>
+            <BitOffs>675465152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -62743,7 +63537,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757640</BitOffs>
+            <BitOffs>675465160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -62766,7 +63560,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757648</BitOffs>
+            <BitOffs>675465168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -62789,7 +63583,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757664</BitOffs>
+            <BitOffs>675465184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -62802,7 +63596,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757696</BitOffs>
+            <BitOffs>675465216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -62815,7 +63609,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757760</BitOffs>
+            <BitOffs>675465280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -62828,7 +63622,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673757776</BitOffs>
+            <BitOffs>675465296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -62840,7 +63634,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673774912</BitOffs>
+            <BitOffs>675482432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -62863,7 +63657,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782848</BitOffs>
+            <BitOffs>675490368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -62886,7 +63680,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782856</BitOffs>
+            <BitOffs>675490376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -62909,7 +63703,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782864</BitOffs>
+            <BitOffs>675490384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -62932,7 +63726,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782880</BitOffs>
+            <BitOffs>675490400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -62945,7 +63739,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782912</BitOffs>
+            <BitOffs>675490432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -62958,7 +63752,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782976</BitOffs>
+            <BitOffs>675490496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -62971,7 +63765,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673782992</BitOffs>
+            <BitOffs>675490512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -62983,7 +63777,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673800128</BitOffs>
+            <BitOffs>675507648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -63006,7 +63800,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808064</BitOffs>
+            <BitOffs>675515584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -63029,7 +63823,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808072</BitOffs>
+            <BitOffs>675515592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -63052,7 +63846,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808080</BitOffs>
+            <BitOffs>675515600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -63075,7 +63869,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808096</BitOffs>
+            <BitOffs>675515616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -63088,7 +63882,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808128</BitOffs>
+            <BitOffs>675515648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -63101,7 +63895,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808192</BitOffs>
+            <BitOffs>675515712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -63114,7 +63908,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673808208</BitOffs>
+            <BitOffs>675515728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -63126,7 +63920,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673825344</BitOffs>
+            <BitOffs>675532864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -63149,7 +63943,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833280</BitOffs>
+            <BitOffs>675540800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -63172,7 +63966,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833288</BitOffs>
+            <BitOffs>675540808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -63195,7 +63989,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833296</BitOffs>
+            <BitOffs>675540816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -63218,7 +64012,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833312</BitOffs>
+            <BitOffs>675540832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -63231,7 +64025,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833344</BitOffs>
+            <BitOffs>675540864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -63244,7 +64038,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833408</BitOffs>
+            <BitOffs>675540928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -63257,7 +64051,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673833424</BitOffs>
+            <BitOffs>675540944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -63269,7 +64063,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673850560</BitOffs>
+            <BitOffs>675558080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -63292,7 +64086,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858496</BitOffs>
+            <BitOffs>675566016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -63315,7 +64109,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858504</BitOffs>
+            <BitOffs>675566024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -63338,7 +64132,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858512</BitOffs>
+            <BitOffs>675566032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -63361,7 +64155,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858528</BitOffs>
+            <BitOffs>675566048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -63374,7 +64168,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858560</BitOffs>
+            <BitOffs>675566080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -63387,7 +64181,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858624</BitOffs>
+            <BitOffs>675566144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -63400,7 +64194,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673858640</BitOffs>
+            <BitOffs>675566160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -63412,7 +64206,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673875776</BitOffs>
+            <BitOffs>675583296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -63435,7 +64229,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883712</BitOffs>
+            <BitOffs>675591232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -63458,7 +64252,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883720</BitOffs>
+            <BitOffs>675591240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -63481,7 +64275,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883728</BitOffs>
+            <BitOffs>675591248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -63504,7 +64298,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883744</BitOffs>
+            <BitOffs>675591264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -63517,7 +64311,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883776</BitOffs>
+            <BitOffs>675591296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -63530,7 +64324,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883840</BitOffs>
+            <BitOffs>675591360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -63543,7 +64337,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673883856</BitOffs>
+            <BitOffs>675591376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -63555,7 +64349,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673900992</BitOffs>
+            <BitOffs>675608512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -63578,7 +64372,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673908928</BitOffs>
+            <BitOffs>675616448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -63601,7 +64395,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673908936</BitOffs>
+            <BitOffs>675616456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -63624,7 +64418,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673908944</BitOffs>
+            <BitOffs>675616464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -63647,7 +64441,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673908960</BitOffs>
+            <BitOffs>675616480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -63660,7 +64454,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673908992</BitOffs>
+            <BitOffs>675616512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -63673,7 +64467,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673909056</BitOffs>
+            <BitOffs>675616576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -63686,7 +64480,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673909072</BitOffs>
+            <BitOffs>675616592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -63698,7 +64492,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673926208</BitOffs>
+            <BitOffs>675633728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -63721,7 +64515,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934144</BitOffs>
+            <BitOffs>675641664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -63744,7 +64538,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934152</BitOffs>
+            <BitOffs>675641672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -63767,7 +64561,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934160</BitOffs>
+            <BitOffs>675641680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -63790,7 +64584,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934176</BitOffs>
+            <BitOffs>675641696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -63803,7 +64597,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934208</BitOffs>
+            <BitOffs>675641728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -63816,7 +64610,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934272</BitOffs>
+            <BitOffs>675641792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -63829,7 +64623,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673934288</BitOffs>
+            <BitOffs>675641808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -63841,7 +64635,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673951424</BitOffs>
+            <BitOffs>675658944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -63864,7 +64658,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959360</BitOffs>
+            <BitOffs>675666880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -63887,7 +64681,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959368</BitOffs>
+            <BitOffs>675666888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -63910,7 +64704,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959376</BitOffs>
+            <BitOffs>675666896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -63933,7 +64727,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959392</BitOffs>
+            <BitOffs>675666912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -63946,7 +64740,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959424</BitOffs>
+            <BitOffs>675666944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -63959,7 +64753,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959488</BitOffs>
+            <BitOffs>675667008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -63972,7 +64766,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673959504</BitOffs>
+            <BitOffs>675667024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -63984,7 +64778,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673976640</BitOffs>
+            <BitOffs>675684160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -64007,7 +64801,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984576</BitOffs>
+            <BitOffs>675692096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -64030,7 +64824,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984584</BitOffs>
+            <BitOffs>675692104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -64053,7 +64847,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984592</BitOffs>
+            <BitOffs>675692112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -64076,7 +64870,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984608</BitOffs>
+            <BitOffs>675692128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -64089,7 +64883,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984640</BitOffs>
+            <BitOffs>675692160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -64102,7 +64896,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984704</BitOffs>
+            <BitOffs>675692224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -64115,7 +64909,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673984720</BitOffs>
+            <BitOffs>675692240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -64127,7 +64921,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674001856</BitOffs>
+            <BitOffs>675709376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -64150,7 +64944,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009792</BitOffs>
+            <BitOffs>675717312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -64173,7 +64967,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009800</BitOffs>
+            <BitOffs>675717320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -64196,7 +64990,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009808</BitOffs>
+            <BitOffs>675717328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -64219,7 +65013,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009824</BitOffs>
+            <BitOffs>675717344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -64232,7 +65026,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009856</BitOffs>
+            <BitOffs>675717376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -64245,7 +65039,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009920</BitOffs>
+            <BitOffs>675717440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -64258,7 +65052,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674009936</BitOffs>
+            <BitOffs>675717456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -64270,7 +65064,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674027072</BitOffs>
+            <BitOffs>675734592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -64293,7 +65087,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035008</BitOffs>
+            <BitOffs>675742528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -64316,7 +65110,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035016</BitOffs>
+            <BitOffs>675742536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -64339,7 +65133,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035024</BitOffs>
+            <BitOffs>675742544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -64362,7 +65156,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035040</BitOffs>
+            <BitOffs>675742560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -64375,7 +65169,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035072</BitOffs>
+            <BitOffs>675742592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -64388,7 +65182,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035136</BitOffs>
+            <BitOffs>675742656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -64401,7 +65195,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674035152</BitOffs>
+            <BitOffs>675742672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -64413,7 +65207,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674052288</BitOffs>
+            <BitOffs>675759808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -64436,7 +65230,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060224</BitOffs>
+            <BitOffs>675767744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -64459,7 +65253,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060232</BitOffs>
+            <BitOffs>675767752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -64482,7 +65276,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060240</BitOffs>
+            <BitOffs>675767760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -64505,7 +65299,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060256</BitOffs>
+            <BitOffs>675767776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -64518,7 +65312,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060288</BitOffs>
+            <BitOffs>675767808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -64531,7 +65325,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060352</BitOffs>
+            <BitOffs>675767872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -64544,7 +65338,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674060368</BitOffs>
+            <BitOffs>675767888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -64556,7 +65350,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674077504</BitOffs>
+            <BitOffs>675785024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -64579,7 +65373,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085440</BitOffs>
+            <BitOffs>675792960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -64602,7 +65396,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085448</BitOffs>
+            <BitOffs>675792968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -64625,7 +65419,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085456</BitOffs>
+            <BitOffs>675792976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -64648,7 +65442,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085472</BitOffs>
+            <BitOffs>675792992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -64661,7 +65455,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085504</BitOffs>
+            <BitOffs>675793024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -64674,7 +65468,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085568</BitOffs>
+            <BitOffs>675793088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -64687,7 +65481,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674085584</BitOffs>
+            <BitOffs>675793104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -64699,7 +65493,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674102720</BitOffs>
+            <BitOffs>675810240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -64722,7 +65516,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110656</BitOffs>
+            <BitOffs>675818176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -64745,7 +65539,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110664</BitOffs>
+            <BitOffs>675818184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -64768,7 +65562,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110672</BitOffs>
+            <BitOffs>675818192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -64791,7 +65585,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110688</BitOffs>
+            <BitOffs>675818208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -64804,7 +65598,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110720</BitOffs>
+            <BitOffs>675818240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -64817,7 +65611,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110784</BitOffs>
+            <BitOffs>675818304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -64830,7 +65624,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674110800</BitOffs>
+            <BitOffs>675818320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -64842,7 +65636,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674127936</BitOffs>
+            <BitOffs>675835456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -64865,7 +65659,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674135872</BitOffs>
+            <BitOffs>675843392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -64888,7 +65682,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674135880</BitOffs>
+            <BitOffs>675843400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -64911,7 +65705,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674135888</BitOffs>
+            <BitOffs>675843408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -64934,7 +65728,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674135904</BitOffs>
+            <BitOffs>675843424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -64947,7 +65741,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674135936</BitOffs>
+            <BitOffs>675843456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -64960,7 +65754,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674136000</BitOffs>
+            <BitOffs>675843520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -64973,7 +65767,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674136016</BitOffs>
+            <BitOffs>675843536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -64985,7 +65779,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674153152</BitOffs>
+            <BitOffs>675860672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -65008,7 +65802,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161088</BitOffs>
+            <BitOffs>675868608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -65031,7 +65825,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161096</BitOffs>
+            <BitOffs>675868616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -65054,7 +65848,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161104</BitOffs>
+            <BitOffs>675868624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -65077,7 +65871,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161120</BitOffs>
+            <BitOffs>675868640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -65090,7 +65884,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161152</BitOffs>
+            <BitOffs>675868672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -65103,7 +65897,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161216</BitOffs>
+            <BitOffs>675868736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -65116,7 +65910,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674161232</BitOffs>
+            <BitOffs>675868752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -65128,7 +65922,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674178368</BitOffs>
+            <BitOffs>675885888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -65151,7 +65945,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186304</BitOffs>
+            <BitOffs>675893824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -65174,7 +65968,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186312</BitOffs>
+            <BitOffs>675893832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -65197,7 +65991,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186320</BitOffs>
+            <BitOffs>675893840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -65220,7 +66014,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186336</BitOffs>
+            <BitOffs>675893856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -65233,7 +66027,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186368</BitOffs>
+            <BitOffs>675893888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -65246,7 +66040,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186432</BitOffs>
+            <BitOffs>675893952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -65259,7 +66053,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674186448</BitOffs>
+            <BitOffs>675893968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -65271,7 +66065,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674203584</BitOffs>
+            <BitOffs>675911104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -65294,7 +66088,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211520</BitOffs>
+            <BitOffs>675919040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -65317,7 +66111,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211528</BitOffs>
+            <BitOffs>675919048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -65340,7 +66134,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211536</BitOffs>
+            <BitOffs>675919056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -65363,7 +66157,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211552</BitOffs>
+            <BitOffs>675919072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -65376,7 +66170,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211584</BitOffs>
+            <BitOffs>675919104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -65389,7 +66183,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211648</BitOffs>
+            <BitOffs>675919168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -65402,7 +66196,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674211664</BitOffs>
+            <BitOffs>675919184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -65414,7 +66208,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674228800</BitOffs>
+            <BitOffs>675936320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -65437,7 +66231,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236736</BitOffs>
+            <BitOffs>675944256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -65460,7 +66254,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236744</BitOffs>
+            <BitOffs>675944264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -65483,7 +66277,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236752</BitOffs>
+            <BitOffs>675944272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -65506,7 +66300,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236768</BitOffs>
+            <BitOffs>675944288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -65519,7 +66313,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236800</BitOffs>
+            <BitOffs>675944320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -65532,7 +66326,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236864</BitOffs>
+            <BitOffs>675944384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -65545,7 +66339,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674236880</BitOffs>
+            <BitOffs>675944400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -65557,7 +66351,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674254016</BitOffs>
+            <BitOffs>675961536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -65580,7 +66374,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674261952</BitOffs>
+            <BitOffs>675969472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -65603,7 +66397,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674261960</BitOffs>
+            <BitOffs>675969480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -65626,7 +66420,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674261968</BitOffs>
+            <BitOffs>675969488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -65649,7 +66443,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674261984</BitOffs>
+            <BitOffs>675969504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -65662,7 +66456,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674262016</BitOffs>
+            <BitOffs>675969536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -65675,7 +66469,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674262080</BitOffs>
+            <BitOffs>675969600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -65688,7 +66482,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674262096</BitOffs>
+            <BitOffs>675969616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -65700,7 +66494,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674279232</BitOffs>
+            <BitOffs>675986752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -65723,7 +66517,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287168</BitOffs>
+            <BitOffs>675994688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -65746,7 +66540,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287176</BitOffs>
+            <BitOffs>675994696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -65769,7 +66563,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287184</BitOffs>
+            <BitOffs>675994704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -65792,7 +66586,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287200</BitOffs>
+            <BitOffs>675994720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -65805,7 +66599,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287232</BitOffs>
+            <BitOffs>675994752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -65818,7 +66612,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287296</BitOffs>
+            <BitOffs>675994816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -65831,7 +66625,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674287312</BitOffs>
+            <BitOffs>675994832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -65843,7 +66637,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674304448</BitOffs>
+            <BitOffs>676011968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -65866,7 +66660,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312384</BitOffs>
+            <BitOffs>676019904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -65889,7 +66683,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312392</BitOffs>
+            <BitOffs>676019912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -65912,7 +66706,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312400</BitOffs>
+            <BitOffs>676019920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -65935,7 +66729,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312416</BitOffs>
+            <BitOffs>676019936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -65948,7 +66742,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312448</BitOffs>
+            <BitOffs>676019968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -65961,7 +66755,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312512</BitOffs>
+            <BitOffs>676020032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -65974,7 +66768,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674312528</BitOffs>
+            <BitOffs>676020048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -65986,7 +66780,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674329664</BitOffs>
+            <BitOffs>676037184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -66009,7 +66803,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337600</BitOffs>
+            <BitOffs>676045120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -66032,7 +66826,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337608</BitOffs>
+            <BitOffs>676045128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -66055,7 +66849,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337616</BitOffs>
+            <BitOffs>676045136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -66078,7 +66872,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337632</BitOffs>
+            <BitOffs>676045152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -66091,7 +66885,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337664</BitOffs>
+            <BitOffs>676045184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -66104,7 +66898,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337728</BitOffs>
+            <BitOffs>676045248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -66117,7 +66911,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674337744</BitOffs>
+            <BitOffs>676045264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -66129,7 +66923,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674354880</BitOffs>
+            <BitOffs>676062400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -66152,7 +66946,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362816</BitOffs>
+            <BitOffs>676070336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -66175,7 +66969,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362824</BitOffs>
+            <BitOffs>676070344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -66198,7 +66992,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362832</BitOffs>
+            <BitOffs>676070352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -66221,7 +67015,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362848</BitOffs>
+            <BitOffs>676070368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -66234,7 +67028,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362880</BitOffs>
+            <BitOffs>676070400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -66247,7 +67041,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362944</BitOffs>
+            <BitOffs>676070464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -66260,7 +67054,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674362960</BitOffs>
+            <BitOffs>676070480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -66272,7 +67066,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674380096</BitOffs>
+            <BitOffs>676087616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -66295,7 +67089,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388032</BitOffs>
+            <BitOffs>676095552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -66318,7 +67112,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388040</BitOffs>
+            <BitOffs>676095560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -66341,7 +67135,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388048</BitOffs>
+            <BitOffs>676095568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -66364,7 +67158,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388064</BitOffs>
+            <BitOffs>676095584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -66377,7 +67171,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388096</BitOffs>
+            <BitOffs>676095616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -66390,7 +67184,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388160</BitOffs>
+            <BitOffs>676095680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -66403,7 +67197,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674388176</BitOffs>
+            <BitOffs>676095696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -66415,7 +67209,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674405312</BitOffs>
+            <BitOffs>676112832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -66438,7 +67232,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413248</BitOffs>
+            <BitOffs>676120768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -66461,7 +67255,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413256</BitOffs>
+            <BitOffs>676120776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -66484,7 +67278,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413264</BitOffs>
+            <BitOffs>676120784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -66507,7 +67301,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413280</BitOffs>
+            <BitOffs>676120800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -66520,7 +67314,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413312</BitOffs>
+            <BitOffs>676120832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -66533,7 +67327,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413376</BitOffs>
+            <BitOffs>676120896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -66546,7 +67340,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674413392</BitOffs>
+            <BitOffs>676120912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -66558,7 +67352,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674430528</BitOffs>
+            <BitOffs>676138048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -66581,7 +67375,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438464</BitOffs>
+            <BitOffs>676145984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -66604,7 +67398,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438472</BitOffs>
+            <BitOffs>676145992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -66627,7 +67421,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438480</BitOffs>
+            <BitOffs>676146000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -66650,7 +67444,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438496</BitOffs>
+            <BitOffs>676146016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -66663,7 +67457,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438528</BitOffs>
+            <BitOffs>676146048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -66676,7 +67470,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438592</BitOffs>
+            <BitOffs>676146112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -66689,7 +67483,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674438608</BitOffs>
+            <BitOffs>676146128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -66701,7 +67495,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674455744</BitOffs>
+            <BitOffs>676163264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -66724,7 +67518,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463680</BitOffs>
+            <BitOffs>676171200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -66747,7 +67541,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463688</BitOffs>
+            <BitOffs>676171208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -66770,7 +67564,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463696</BitOffs>
+            <BitOffs>676171216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -66793,7 +67587,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463712</BitOffs>
+            <BitOffs>676171232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -66806,7 +67600,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463744</BitOffs>
+            <BitOffs>676171264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -66819,7 +67613,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463808</BitOffs>
+            <BitOffs>676171328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -66832,7 +67626,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674463824</BitOffs>
+            <BitOffs>676171344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -66844,7 +67638,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674480960</BitOffs>
+            <BitOffs>676188480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -66867,7 +67661,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674488896</BitOffs>
+            <BitOffs>676196416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -66890,7 +67684,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674488904</BitOffs>
+            <BitOffs>676196424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -66913,7 +67707,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674488912</BitOffs>
+            <BitOffs>676196432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -66936,7 +67730,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674488928</BitOffs>
+            <BitOffs>676196448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -66949,7 +67743,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674488960</BitOffs>
+            <BitOffs>676196480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -66962,7 +67756,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674489024</BitOffs>
+            <BitOffs>676196544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -66975,7 +67769,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674489040</BitOffs>
+            <BitOffs>676196560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -66987,7 +67781,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674506176</BitOffs>
+            <BitOffs>676213696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -67010,7 +67804,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514112</BitOffs>
+            <BitOffs>676221632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -67033,7 +67827,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514120</BitOffs>
+            <BitOffs>676221640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -67056,7 +67850,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514128</BitOffs>
+            <BitOffs>676221648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -67079,7 +67873,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514144</BitOffs>
+            <BitOffs>676221664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -67092,7 +67886,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514176</BitOffs>
+            <BitOffs>676221696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -67105,7 +67899,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514240</BitOffs>
+            <BitOffs>676221760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -67118,7 +67912,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674514256</BitOffs>
+            <BitOffs>676221776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -67130,7 +67924,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674531392</BitOffs>
+            <BitOffs>676238912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -67153,7 +67947,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539328</BitOffs>
+            <BitOffs>676246848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -67176,7 +67970,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539336</BitOffs>
+            <BitOffs>676246856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -67199,7 +67993,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539344</BitOffs>
+            <BitOffs>676246864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -67222,7 +68016,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539360</BitOffs>
+            <BitOffs>676246880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -67235,7 +68029,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539392</BitOffs>
+            <BitOffs>676246912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -67248,7 +68042,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539456</BitOffs>
+            <BitOffs>676246976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -67261,7 +68055,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674539472</BitOffs>
+            <BitOffs>676246992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -67273,7 +68067,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674556608</BitOffs>
+            <BitOffs>676264128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -67296,7 +68090,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564544</BitOffs>
+            <BitOffs>676272064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -67319,7 +68113,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564552</BitOffs>
+            <BitOffs>676272072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -67342,7 +68136,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564560</BitOffs>
+            <BitOffs>676272080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -67365,7 +68159,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564576</BitOffs>
+            <BitOffs>676272096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -67378,7 +68172,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564608</BitOffs>
+            <BitOffs>676272128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -67391,7 +68185,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564672</BitOffs>
+            <BitOffs>676272192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -67404,7 +68198,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674564688</BitOffs>
+            <BitOffs>676272208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -67416,7 +68210,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674581824</BitOffs>
+            <BitOffs>676289344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -67439,7 +68233,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589760</BitOffs>
+            <BitOffs>676297280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -67462,7 +68256,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589768</BitOffs>
+            <BitOffs>676297288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -67485,7 +68279,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589776</BitOffs>
+            <BitOffs>676297296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -67508,7 +68302,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589792</BitOffs>
+            <BitOffs>676297312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -67521,7 +68315,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589824</BitOffs>
+            <BitOffs>676297344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -67534,7 +68328,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589888</BitOffs>
+            <BitOffs>676297408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -67547,7 +68341,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674589904</BitOffs>
+            <BitOffs>676297424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -67559,7 +68353,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674607040</BitOffs>
+            <BitOffs>676314560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -67582,7 +68376,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674614976</BitOffs>
+            <BitOffs>676322496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -67605,7 +68399,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674614984</BitOffs>
+            <BitOffs>676322504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -67628,7 +68422,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674614992</BitOffs>
+            <BitOffs>676322512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -67651,7 +68445,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674615008</BitOffs>
+            <BitOffs>676322528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -67664,7 +68458,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674615040</BitOffs>
+            <BitOffs>676322560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -67677,7 +68471,7 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674615104</BitOffs>
+            <BitOffs>676322624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -67690,14 +68484,14 @@ TODO: is add all therest</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674615120</BitOffs>
+            <BitOffs>676322640</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85262336</ByteSize>
+          <ByteSize>85458944</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -68294,7 +69088,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657685760</BitOffs>
+            <BitOffs>657685952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68306,7 +69100,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657983680</BitOffs>
+            <BitOffs>657983872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68318,7 +69112,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658281600</BitOffs>
+            <BitOffs>658281792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68330,7 +69124,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658579520</BitOffs>
+            <BitOffs>658579712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68342,7 +69136,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658877440</BitOffs>
+            <BitOffs>658877632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68354,7 +69148,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659175360</BitOffs>
+            <BitOffs>659175552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68366,7 +69160,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659473280</BitOffs>
+            <BitOffs>659473472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68378,7 +69172,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659771200</BitOffs>
+            <BitOffs>659771392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68390,7 +69184,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660069120</BitOffs>
+            <BitOffs>660069312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68402,7 +69196,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660367040</BitOffs>
+            <BitOffs>660367232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68414,7 +69208,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660664960</BitOffs>
+            <BitOffs>660665152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68426,7 +69220,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660962880</BitOffs>
+            <BitOffs>660963072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68438,7 +69232,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661260800</BitOffs>
+            <BitOffs>661260992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -68450,7 +69244,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662824000</BitOffs>
+            <BitOffs>662824192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -68473,7 +69267,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662832984</BitOffs>
+            <BitOffs>662833176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -68485,7 +69279,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662849216</BitOffs>
+            <BitOffs>662849408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -68508,7 +69302,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662858200</BitOffs>
+            <BitOffs>662858392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -68520,7 +69314,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662874432</BitOffs>
+            <BitOffs>662874624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -68543,7 +69337,112 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662883416</BitOffs>
+            <BitOffs>662883608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664586240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bBrakeRelease
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if brake released
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664595224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664611456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bBrakeRelease
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if brake released
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664620440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664636672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bBrakeRelease
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if brake released
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664645656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -68562,26 +69461,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663063800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663320032</BitOffs>
+            <BitOffs>665027512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -68597,7 +69477,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663322624</BitOffs>
+            <BitOffs>665030080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -68617,7 +69497,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670228104</BitOffs>
+            <BitOffs>671935560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -68637,7 +69517,26 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671875016</BitOffs>
+            <BitOffs>673582472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>675229120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -68649,7 +69548,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673521728</BitOffs>
+            <BitOffs>675229248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -68672,7 +69571,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673530712</BitOffs>
+            <BitOffs>675238232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -68684,7 +69583,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673546944</BitOffs>
+            <BitOffs>675254464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -68707,7 +69606,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673555928</BitOffs>
+            <BitOffs>675263448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -68719,7 +69618,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673572160</BitOffs>
+            <BitOffs>675279680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -68742,7 +69641,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673581144</BitOffs>
+            <BitOffs>675288664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -68754,7 +69653,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673597376</BitOffs>
+            <BitOffs>675304896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -68777,7 +69676,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673606360</BitOffs>
+            <BitOffs>675313880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -68789,7 +69688,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673622592</BitOffs>
+            <BitOffs>675330112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -68812,7 +69711,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673631576</BitOffs>
+            <BitOffs>675339096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -68824,7 +69723,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673647808</BitOffs>
+            <BitOffs>675355328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -68847,7 +69746,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673656792</BitOffs>
+            <BitOffs>675364312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -68859,7 +69758,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673673024</BitOffs>
+            <BitOffs>675380544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -68882,7 +69781,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673682008</BitOffs>
+            <BitOffs>675389528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -68894,7 +69793,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673698240</BitOffs>
+            <BitOffs>675405760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -68917,7 +69816,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673707224</BitOffs>
+            <BitOffs>675414744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -68929,7 +69828,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673723456</BitOffs>
+            <BitOffs>675430976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -68952,7 +69851,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673732440</BitOffs>
+            <BitOffs>675439960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -68964,7 +69863,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673748672</BitOffs>
+            <BitOffs>675456192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -68987,7 +69886,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673757656</BitOffs>
+            <BitOffs>675465176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -68999,7 +69898,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673773888</BitOffs>
+            <BitOffs>675481408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -69022,7 +69921,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673782872</BitOffs>
+            <BitOffs>675490392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -69034,7 +69933,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673799104</BitOffs>
+            <BitOffs>675506624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -69057,7 +69956,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673808088</BitOffs>
+            <BitOffs>675515608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -69069,7 +69968,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673824320</BitOffs>
+            <BitOffs>675531840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -69092,7 +69991,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673833304</BitOffs>
+            <BitOffs>675540824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -69104,7 +70003,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673849536</BitOffs>
+            <BitOffs>675557056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -69127,7 +70026,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673858520</BitOffs>
+            <BitOffs>675566040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -69139,7 +70038,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673874752</BitOffs>
+            <BitOffs>675582272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -69162,7 +70061,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673883736</BitOffs>
+            <BitOffs>675591256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -69174,7 +70073,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673899968</BitOffs>
+            <BitOffs>675607488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -69197,7 +70096,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673908952</BitOffs>
+            <BitOffs>675616472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -69209,7 +70108,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673925184</BitOffs>
+            <BitOffs>675632704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -69232,7 +70131,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673934168</BitOffs>
+            <BitOffs>675641688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -69244,7 +70143,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673950400</BitOffs>
+            <BitOffs>675657920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -69267,7 +70166,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673959384</BitOffs>
+            <BitOffs>675666904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -69279,7 +70178,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673975616</BitOffs>
+            <BitOffs>675683136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -69302,7 +70201,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673984600</BitOffs>
+            <BitOffs>675692120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -69314,7 +70213,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674000832</BitOffs>
+            <BitOffs>675708352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -69337,7 +70236,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674009816</BitOffs>
+            <BitOffs>675717336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -69349,7 +70248,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674026048</BitOffs>
+            <BitOffs>675733568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -69372,7 +70271,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674035032</BitOffs>
+            <BitOffs>675742552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -69384,7 +70283,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674051264</BitOffs>
+            <BitOffs>675758784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -69407,7 +70306,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674060248</BitOffs>
+            <BitOffs>675767768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -69419,7 +70318,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674076480</BitOffs>
+            <BitOffs>675784000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -69442,7 +70341,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674085464</BitOffs>
+            <BitOffs>675792984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -69454,7 +70353,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674101696</BitOffs>
+            <BitOffs>675809216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -69477,7 +70376,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674110680</BitOffs>
+            <BitOffs>675818200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -69489,7 +70388,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674126912</BitOffs>
+            <BitOffs>675834432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -69512,7 +70411,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674135896</BitOffs>
+            <BitOffs>675843416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -69524,7 +70423,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674152128</BitOffs>
+            <BitOffs>675859648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -69547,7 +70446,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674161112</BitOffs>
+            <BitOffs>675868632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -69559,7 +70458,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674177344</BitOffs>
+            <BitOffs>675884864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -69582,7 +70481,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674186328</BitOffs>
+            <BitOffs>675893848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -69594,7 +70493,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674202560</BitOffs>
+            <BitOffs>675910080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -69617,7 +70516,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674211544</BitOffs>
+            <BitOffs>675919064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -69629,7 +70528,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674227776</BitOffs>
+            <BitOffs>675935296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -69652,7 +70551,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674236760</BitOffs>
+            <BitOffs>675944280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -69664,7 +70563,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674252992</BitOffs>
+            <BitOffs>675960512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -69687,7 +70586,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674261976</BitOffs>
+            <BitOffs>675969496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -69699,7 +70598,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674278208</BitOffs>
+            <BitOffs>675985728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -69722,7 +70621,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674287192</BitOffs>
+            <BitOffs>675994712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -69734,7 +70633,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674303424</BitOffs>
+            <BitOffs>676010944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -69757,7 +70656,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674312408</BitOffs>
+            <BitOffs>676019928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -69769,7 +70668,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674328640</BitOffs>
+            <BitOffs>676036160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -69792,7 +70691,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674337624</BitOffs>
+            <BitOffs>676045144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -69804,7 +70703,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674353856</BitOffs>
+            <BitOffs>676061376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -69827,7 +70726,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674362840</BitOffs>
+            <BitOffs>676070360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -69839,7 +70738,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674379072</BitOffs>
+            <BitOffs>676086592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -69862,7 +70761,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674388056</BitOffs>
+            <BitOffs>676095576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -69874,7 +70773,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674404288</BitOffs>
+            <BitOffs>676111808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -69897,7 +70796,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674413272</BitOffs>
+            <BitOffs>676120792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -69909,7 +70808,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674429504</BitOffs>
+            <BitOffs>676137024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -69932,7 +70831,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674438488</BitOffs>
+            <BitOffs>676146008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -69944,7 +70843,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674454720</BitOffs>
+            <BitOffs>676162240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -69967,7 +70866,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674463704</BitOffs>
+            <BitOffs>676171224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -69979,7 +70878,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674479936</BitOffs>
+            <BitOffs>676187456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -70002,7 +70901,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674488920</BitOffs>
+            <BitOffs>676196440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -70014,7 +70913,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674505152</BitOffs>
+            <BitOffs>676212672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -70037,7 +70936,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674514136</BitOffs>
+            <BitOffs>676221656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -70049,7 +70948,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674530368</BitOffs>
+            <BitOffs>676237888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -70072,7 +70971,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674539352</BitOffs>
+            <BitOffs>676246872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -70084,7 +70983,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674555584</BitOffs>
+            <BitOffs>676263104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -70107,7 +71006,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674564568</BitOffs>
+            <BitOffs>676272088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -70119,7 +71018,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674580800</BitOffs>
+            <BitOffs>676288320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -70142,7 +71041,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674589784</BitOffs>
+            <BitOffs>676297304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -70154,7 +71053,7 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674606016</BitOffs>
+            <BitOffs>676313536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -70177,14 +71076,14 @@ TODO: is add all therest</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674615000</BitOffs>
+            <BitOffs>676322520</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85262336</ByteSize>
+          <ByteSize>85458944</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -77289,91 +78188,91 @@ TODO: is add all therest</Comment>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657684288</BitOffs>
+            <BitOffs>657684480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657982208</BitOffs>
+            <BitOffs>657982400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658280128</BitOffs>
+            <BitOffs>658280320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658578048</BitOffs>
+            <BitOffs>658578240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658875968</BitOffs>
+            <BitOffs>658876160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659173888</BitOffs>
+            <BitOffs>659174080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659471808</BitOffs>
+            <BitOffs>659472000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659769728</BitOffs>
+            <BitOffs>659769920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660067648</BitOffs>
+            <BitOffs>660067840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660365568</BitOffs>
+            <BitOffs>660365760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660663488</BitOffs>
+            <BitOffs>660663680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660961408</BitOffs>
+            <BitOffs>660961600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>661259328</BitOffs>
+            <BitOffs>661259520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>661557248</BitOffs>
+            <BitOffs>661557440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>661557264</BitOffs>
+            <BitOffs>661557456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -77382,7 +78281,7 @@ TODO: is add all therest</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>661557280</BitOffs>
+            <BitOffs>661557472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -77391,14 +78290,14 @@ TODO: is add all therest</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>661557296</BitOffs>
+            <BitOffs>661557488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>661557304</BitOffs>
+            <BitOffs>661557496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates</Name>
@@ -77413,7 +78312,7 @@ TODO: is add all therest</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>661557312</BitOffs>
+            <BitOffs>661557504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -77428,7 +78327,7 @@ TODO: is add all therest</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063744</BitOffs>
+            <BitOffs>663063936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -77443,31 +78342,43 @@ TODO: is add all therest</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063760</BitOffs>
+            <BitOffs>663063952</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>663063776</BitOffs>
+            <Name>PRG_SP1K4.att_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_Staes</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663063968</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>663063784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>663063792</BitOffs>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_Staes</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663063984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>663063808</BitOffs>
+            <BitOffs>663064000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -77491,7 +78402,7 @@ TODO: is add all therest</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>663151616</BitOffs>
+            <BitOffs>663151808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -77501,7 +78412,7 @@ TODO: is add all therest</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663155264</BitOffs>
+            <BitOffs>663155456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -77511,7 +78422,7 @@ TODO: is add all therest</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663209984</BitOffs>
+            <BitOffs>663210176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -77521,55 +78432,108 @@ TODO: is add all therest</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663264704</BitOffs>
+            <BitOffs>663264896</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
+            <Name>PRG_SP1K4.fbATTStates</Name>
+            <Comment>/Solid-ATT states start</Comment>
+            <BitSize>1506368</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</BaseType>
             <Properties>
               <Property>
-                <Name>TcVarGlobal</Name>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT
+    </Value>
               </Property>
             </Properties>
-            <BitOffs>663320048</BitOffs>
+            <BitOffs>663319616</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Name>PRG_SP1K4.fbATTSetup</Name>
+            <BitSize>87808</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>664825984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.fbATTDefault</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>0.5</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <BitOffs>664913792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.aATTXStates</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>664917440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.aATTYStates</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>664972160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663320056</BitOffs>
+            <BitOffs>665027488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>665027496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>665027504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>663320064</BitOffs>
+            <BitOffs>665027520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>663458432</BitOffs>
+            <BitOffs>665165888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>663489280</BitOffs>
+            <BitOffs>665196736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -77588,7 +78552,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>669280896</BitOffs>
+            <BitOffs>670988352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -77607,7 +78571,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>669754368</BitOffs>
+            <BitOffs>671461824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -77637,7 +78601,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>670227840</BitOffs>
+            <BitOffs>671935296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -77667,7 +78631,67 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671874752</BitOffs>
+            <BitOffs>673582208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>675229136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>675229144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>675229152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>675229168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -77696,7 +78720,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673521664</BitOffs>
+            <BitOffs>675229184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -77708,7 +78732,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673546880</BitOffs>
+            <BitOffs>675254400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -77719,7 +78743,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673572096</BitOffs>
+            <BitOffs>675279616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -77730,7 +78754,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673597312</BitOffs>
+            <BitOffs>675304832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -77741,7 +78765,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673622528</BitOffs>
+            <BitOffs>675330048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -77752,7 +78776,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673647744</BitOffs>
+            <BitOffs>675355264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -77763,7 +78787,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673672960</BitOffs>
+            <BitOffs>675380480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -77774,7 +78798,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673698176</BitOffs>
+            <BitOffs>675405696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -77803,7 +78827,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673723392</BitOffs>
+            <BitOffs>675430912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -77831,7 +78855,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673748608</BitOffs>
+            <BitOffs>675456128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -77858,7 +78882,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673773824</BitOffs>
+            <BitOffs>675481344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -77885,7 +78909,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673799040</BitOffs>
+            <BitOffs>675506560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -77912,7 +78936,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673824256</BitOffs>
+            <BitOffs>675531776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -77924,7 +78948,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673849472</BitOffs>
+            <BitOffs>675556992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -77953,7 +78977,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673874688</BitOffs>
+            <BitOffs>675582208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -77982,7 +79006,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673899904</BitOffs>
+            <BitOffs>675607424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -78011,7 +79035,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673925120</BitOffs>
+            <BitOffs>675632640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -78040,7 +79064,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673950336</BitOffs>
+            <BitOffs>675657856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -78065,7 +79089,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673975552</BitOffs>
+            <BitOffs>675683072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -78094,7 +79118,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674000768</BitOffs>
+            <BitOffs>675708288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -78123,7 +79147,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674025984</BitOffs>
+            <BitOffs>675733504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -78148,7 +79172,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674051200</BitOffs>
+            <BitOffs>675758720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -78176,7 +79200,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674076416</BitOffs>
+            <BitOffs>675783936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -78203,7 +79227,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674101632</BitOffs>
+            <BitOffs>675809152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -78230,7 +79254,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674126848</BitOffs>
+            <BitOffs>675834368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -78257,7 +79281,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674152064</BitOffs>
+            <BitOffs>675859584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -78286,7 +79310,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674177280</BitOffs>
+            <BitOffs>675884800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -78315,7 +79339,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674202496</BitOffs>
+            <BitOffs>675910016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -78340,7 +79364,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674227712</BitOffs>
+            <BitOffs>675935232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -78369,7 +79393,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674252928</BitOffs>
+            <BitOffs>675960448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -78394,7 +79418,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674278144</BitOffs>
+            <BitOffs>675985664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -78431,7 +79455,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674303360</BitOffs>
+            <BitOffs>676010880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -78476,7 +79500,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674328576</BitOffs>
+            <BitOffs>676036096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -78517,7 +79541,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674353792</BitOffs>
+            <BitOffs>676061312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -78558,7 +79582,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674379008</BitOffs>
+            <BitOffs>676086528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -78599,7 +79623,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674404224</BitOffs>
+            <BitOffs>676111744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -78640,7 +79664,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674429440</BitOffs>
+            <BitOffs>676136960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -78681,7 +79705,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674454656</BitOffs>
+            <BitOffs>676162176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -78722,7 +79746,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674479872</BitOffs>
+            <BitOffs>676187392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -78763,7 +79787,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674505088</BitOffs>
+            <BitOffs>676212608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -78799,7 +79823,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674530304</BitOffs>
+            <BitOffs>676237824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -78835,7 +79859,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674555520</BitOffs>
+            <BitOffs>676263040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -78871,7 +79895,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674580736</BitOffs>
+            <BitOffs>676288256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -78916,7 +79940,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674605952</BitOffs>
+            <BitOffs>676313472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -78946,7 +79970,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674631168</BitOffs>
+            <BitOffs>676338688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -78976,37 +80000,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674631232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>674631296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>674631312</BitOffs>
+            <BitOffs>676338752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -79020,7 +80014,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674631328</BitOffs>
+            <BitOffs>676338816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -79034,7 +80028,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674631360</BitOffs>
+            <BitOffs>676338848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -79048,7 +80042,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674631392</BitOffs>
+            <BitOffs>676338880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -79062,7 +80056,21 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674631424</BitOffs>
+            <BitOffs>676338912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>676340960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -79080,21 +80088,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674633472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>674634496</BitOffs>
+            <BitOffs>676340992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -79108,7 +80102,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674634528</BitOffs>
+            <BitOffs>676342016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -79129,7 +80123,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674634560</BitOffs>
+            <BitOffs>676342048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -79198,7 +80192,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674647936</BitOffs>
+            <BitOffs>676355424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -79267,7 +80261,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674648064</BitOffs>
+            <BitOffs>676355552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -79336,7 +80330,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674648192</BitOffs>
+            <BitOffs>676355680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -79405,7 +80399,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674648320</BitOffs>
+            <BitOffs>676355808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -79474,7 +80468,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674648448</BitOffs>
+            <BitOffs>676355936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -79543,7 +80537,7 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674648576</BitOffs>
+            <BitOffs>676356064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -79566,14 +80560,14 @@ TODO: is add all therest</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674678912</BitOffs>
+            <BitOffs>676386400</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85262336</ByteSize>
+          <ByteSize>85458944</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -79653,15 +80647,15 @@ TODO: is add all therest</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-08T16:09:23</Value>
+          <Value>2023-08-10T14:32:44</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>851968</Value>
+          <Value>856064</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>83918848</Value>
+          <Value>84131840</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add SP1K4 solid attenuator states and PMPS states
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists ask to add sp1k4 solid attenuator by FOIL X and Y

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Not yet. Targets have not installed and I only tested the FOIL x and y in PLC level. Will test them after GUI build.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

(https://jira.slac.stanford.edu/browse/ECS-1576)

<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
