### PR TITLE
changing FZP all targets positions to consistent with Epics value

### DIFF
--- a/plc-tmo-motion/tmo_motion/GVLs/GVL_PMPS.TcGVL
+++ b/plc-tmo-motion/tmo_motion/GVLs/GVL_PMPS.TcGVL
@@ -2,15 +2,15 @@
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <GVL Name="GVL_PMPS" Id="{9b94692b-5571-4165-bb98-ffe5b3549b86}">
     <Declaration><![CDATA[VAR_GLOBAL
-	
+
     // Arbiter linked to the FFO and the MPS
     {attribute 'pytmc' := 'pv: PLC:TMO:MOTION:ARB:01'}
     fbArbiter: FB_Arbiter(1);
 
-	 // Arbiter linked to the FFO and the MPS
+     // Arbiter linked to the FFO and the MPS
     {attribute 'pytmc' := 'pv: PLC:TMO:MOTION:ARB:02'}
     fbArbiter2: FB_Arbiter(2);
-	
+
     // Fast fault for before ST4K4 (Most Devices)
     {attribute 'pytmc' := 'pv: PLC:TMO:MOTION:FFO:01'}
     {attribute 'TcLinkTo' := '.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 1^Output'}
@@ -19,11 +19,11 @@
     {attribute 'pytmc' := 'pv: PLC:TMO:MOTION:FFO:02'}
     {attribute 'TcLinkTo' := '.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output'}
     fbFastFaultOutput2: FB_HardwareFFOutput := (bAutoReset := TRUE, i_sNetID:='172.21.92.73.1.1');
-	
-	{attribute 'TcLinkTo' := 'TIIB[PMPS_PRE]^IO Outputs^bST4K4_IN'}
-	PMPS_ST4K4_IN AT%Q* : BOOL;
-	{attribute 'TcLinkTo' := 'TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT'}
-	PMPS_ST4K4_OUT AT%Q* : BOOL;
+
+    {attribute 'TcLinkTo' := 'TIIB[PMPS_PRE]^IO Outputs^bST4K4_IN'}
+    PMPS_ST4K4_IN AT%Q* : BOOL;
+    {attribute 'TcLinkTo' := 'TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT'}
+    PMPS_ST4K4_OUT AT%Q* : BOOL;
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/plc-tmo-motion/tmo_motion/POUs/FB_SP_ZP.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/FB_SP_ZP.TcPOU
@@ -3,57 +3,57 @@
   <POU Name="FB_SP_ZP" Id="{9e7633b7-c6b9-4709-92c4-d466b7628291}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_SP_ZP
 VAR_IN_out
-	 stXStage: DUT_MotionStage;
-	 stYStage: DUT_MotionStage;
-	 stZStage: DUT_MotionStage;
+     stXStage: DUT_MotionStage;
+     stYStage: DUT_MotionStage;
+     stZStage: DUT_MotionStage;
     fbArbiter: FB_Arbiter;
     fbFFHWO: FB_HardwareFFOutput;
 END_VAR
 VAR_INPUT
-	stOut: DUT_PositionState;
-	stYag: DUT_PositionState;
-	stNe1: DUT_PositionState;
-	stNe2: DUT_PositionState;
+    stOut: DUT_PositionState;
+    stYag: DUT_PositionState;
+    stNe1: DUT_PositionState;
+    stNe2: DUT_PositionState;
     stNe3: DUT_PositionState;
     st3w1: DUT_PositionState;
-	st3w2: DUT_PositionState;
-	stO2: DUT_PositionState;
-	stO1: DUT_PositionState;
-	stTi1: DUT_PositionState;
-	stTi2: DUT_PositionState;
-	stN1: DUT_PositionState;
-	stN2:DUT_PositionState;
-	stC1: DUT_PositionState;
-	stC2: DUT_PositionState;
-	//nTransitionAssertionID: UDINT;
+    st3w2: DUT_PositionState;
+    stO2: DUT_PositionState;
+    stO1: DUT_PositionState;
+    stTi1: DUT_PositionState;
+    stTi2: DUT_PositionState;
+    stN1: DUT_PositionState;
+    stN2:DUT_PositionState;
+    stC1: DUT_PositionState;
+    stC2: DUT_PositionState;
+    //nTransitionAssertionID: UDINT;
     //nUnknownAssertionID: UDINT;
-	
-		  {attribute 'pytmc' := '
+
+          {attribute 'pytmc' := '
         pv: MMS:X:STATE
         io: i
     '}
     fbStates_x: FB_ZonePlate_States;
 
-	   {attribute 'pytmc' := '
+       {attribute 'pytmc' := '
         pv: MMS:Y:STATE
         io: i
     '}
     fbStates_y: FB_ZonePlate_States;
-	
-	zp_enumSet : ENUM_ZonePlate_States;
+
+    zp_enumSet : ENUM_ZonePlate_States;
 END_VAR
 VAR
-	 fbXStage: FB_MotionStage;
-	 fbYStage: FB_MotionStage;
-	 fbZStage: FB_MotionStage;
-	 
-	(*FFO*)
-	
-	FFO: FB_fastFault :=(
-		i_DevName:= 'SP1K4',
-		i_Desc := 'Fault Occures when the X and Y states d not match',
-		i_TypeCode := 16#300 //todo find a type code on confluence
-		);
+     fbXStage: FB_MotionStage;
+     fbYStage: FB_MotionStage;
+     fbZStage: FB_MotionStage;
+
+    (*FFO*)
+
+    FFO: FB_fastFault :=(
+        i_DevName:= 'SP1K4',
+        i_Desc := 'Fault Occures when the X and Y states d not match',
+        i_TypeCode := 16#300 //todo find a type code on confluence
+        );
 
 
 END_VAR
@@ -87,27 +87,27 @@ fbStates_X(
  //   nUnknownAssertionID:=nUnknownAssertionID,
     stMotionStage:=stXStage,
     bEnable:=TRUE,
-	enumSet:= zp_enumSet,
+    enumSet:= zp_enumSet,
     stOut:=stOut,
     stYag :=stYag,
     stNe1:=stNe1,
-	stNe2:=stNe2,
-	stNe3:=stNe3,
-	st3w1:=st3w1,
-	st3w2:=st3w2,
-	stO2:=stO2,
-	stO1:=stO1,
-	stTi1:=stTi1,
-	stTi2:=stTi2,
-	stN1:=stN1,
-	stN2:=stN2,
-	stC1:=stC1,
-	stC2:=stC2,
+    stNe2:=stNe2,
+    stNe3:=stNe3,
+    st3w1:=st3w1,
+    st3w2:=st3w2,
+    stO2:=stO2,
+    stO1:=stO1,
+    stTi1:=stTi1,
+    stTi2:=stTi2,
+    stN1:=stN1,
+    stN2:=stN2,
+    stC1:=stC1,
+    stC2:=stC2,
   ); //TODO ADD all other states
-	
-	
-	
-	
+
+
+
+
 fbStates_Y(
     fbArbiter:=fbArbiter,
     fbFFHWO:=fbFFHWO,
@@ -115,26 +115,26 @@ fbStates_Y(
 //    nUnknownAssertionID:=nUnknownAssertionID,
     stMotionStage:=stYStage,
     bEnable:=TRUE,
-	enumSet:= zp_enumSet,
+    enumSet:= zp_enumSet,
     stOut:=stOut,
     stYag:=stYag,
     stNe1:=stNe1,
-	stNe2:=stNe2,
-	stNe3:=stNe3,
-	st3w1:=st3w1,
-	st3w2:=st3w2,
-	stO2:=stO2,
-	stO1:=stO1,
-	stTi1:=stTi1,
-	stTi2:=stTi2,
-	stN1:=stN1,
-	stN2:=stN2,
-	stC1:=stC1,
-	stC2:=stC2,
+    stNe2:=stNe2,
+    stNe3:=stNe3,
+    st3w1:=st3w1,
+    st3w2:=st3w2,
+    stO2:=stO2,
+    stO1:=stO1,
+    stTi1:=stTi1,
+    stTi2:=stTi2,
+    stN1:=stN1,
+    stN2:=stN2,
+    stC1:=stC1,
+    stC2:=stC2,
 );
 
-	
-	FFO(i_xOK:= (fbStates_X.enumGet = fbStates_Y.enumGet),
+
+    FFO(i_xOK:= (fbStates_X.enumGet = fbStates_Y.enumGet),
     io_fbFFHWO:= fbFFHWO,
     i_xAutoReset := TRUE );]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_2_PMPS_PRE.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_2_PMPS_PRE.TcPOU
@@ -9,11 +9,11 @@ END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[MOTION_GVL.fbStandardPMPSDB(
-	io_fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,
-	bEnable:=TRUE,
-	sPLCName:='plc-tmo-motion',
-	);
-	
+    io_fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,
+    bEnable:=TRUE,
+    sPLCName:='plc-tmo-motion',
+    );
+
 ]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_3_PMPS_POST.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_3_PMPS_POST.TcPOU
@@ -4,27 +4,27 @@
     <Declaration><![CDATA[PROGRAM PRG_3_PMPS_POST
 VAR
     fbArbiterIO: FB_SubSysToArbiter_IO;
-	fb_vetoArbiter: FB_VetoArbiter;
+    fb_vetoArbiter: FB_VetoArbiter;
 
     bST3K4_Veto: BOOL;
-	bM1K1Veto: BOOL;
-	bST4K4_Veto:BOOL;
+    bM1K1Veto: BOOL;
+    bST4K4_Veto:BOOL;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[bST3K4_Veto := PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.ST3K4];
 bST4K4_Veto := PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.ST4K4];
-bM1K1Veto := NOT PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.MR1K1_OUT] 
+bM1K1Veto := NOT PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.MR1K1_OUT]
                 AND PMPS_GVL.stCurrentBeamParameters.aVetoDevices[PMPS.K_Stopper.MR1K1_IN];
 
 fbArbiterIO(
     i_bVeto:=bST3K4_Veto,
     Arbiter:=fbArbiter,
     fbFFHWO:=fbFastFaultOutput1);
-	
+
 fb_vetoArbiter(bVeto:=bST4K4_Veto OR bST3K4_Veto OR bM1K1Veto,
                 HigherAuthority := GVL_PMPS.fbArbiter,
                 LowerAuthority := GVL_PMPS.fbArbiter2,
-                FFO := GVL_PMPS.fbFastFaultOutput2); 
+                FFO := GVL_PMPS.fbFastFaultOutput2);
 
 fbFastFaultOutput1.Execute(i_xVeto:=bST3K4_Veto OR bM1K1Veto);
 fbFastFaultOutput2.Execute(i_xVeto:=bST3K4_Veto OR bM1K1Veto OR bST4K4_Veto); // Eventually, also veto on ST4K4 using OR

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
@@ -29,8 +29,8 @@ fbAL1K4(
     stYStage := Main.M1,
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
-	sPmpsDeviceName := 'AL1K4:L2SI',
-	sTransitionKey := 'AL1K4:L2SI-TRANSITION',
+    sPmpsDeviceName := 'AL1K4:L2SI',
+    sTransitionKey := 'AL1K4:L2SI-TRANSITION',
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
@@ -53,8 +53,8 @@ fbIM3K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M15,
-	sPmpsDeviceName := 'IM3K4:PPM',
-	sTransitionKey := 'IM3K4:PPM-TRANSITION',
+    sPmpsDeviceName := 'IM3K4:PPM',
+    sTransitionKey := 'IM3K4:PPM-TRANSITION',
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -58,8 +58,8 @@ fbIM4K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M16,
-	sPmpsDeviceName := 'IM4K4:PPM',
-	sTransitionKey := 'IM4K4:PPM-TRANSITION',
+    sPmpsDeviceName := 'IM4K4:PPM',
+    sTransitionKey := 'IM4K4:PPM-TRANSITION',
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -53,8 +53,8 @@ fbIM5K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M17,
-	sPmpsDeviceName := 'IM5K4:PPM',
-	sTransitionKey := 'IM5K4:PPM-TRANSITION',
+    sPmpsDeviceName := 'IM5K4:PPM',
+    sTransitionKey := 'IM5K4:PPM-TRANSITION',
 
 );]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -3,7 +3,7 @@
   <POU Name="PRG_IM6K4_PPM" Id="{5922a5f4-dd07-4dd5-8bd1-7240efca9eab}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_IM6K4_PPM
 VAR
-	{attribute 'pytmc' := '
+    {attribute 'pytmc' := '
         pv: IM6K4:PPM
         io: io
     '}
@@ -52,8 +52,8 @@ fbIM6K4(
     fbArbiter := fbArbiter2,
     fbFFHWO := fbFastFaultOutput2,
     stYStage := Main.M27,
-	sPmpsDeviceName := 'IM6K4:PPM',
-	sTransitionKey := 'IM6K4:PPM-TRANSITION',
+    sPmpsDeviceName := 'IM6K4:PPM',
+    sTransitionKey := 'IM6K4:PPM-TRANSITION',
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
@@ -10,7 +10,7 @@ VAR
     fbLI1K4: FB_LIC;
 
     stSiBP: ST_BeamParams := PMPS_GVL.cstFullBeam;
-    
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -46,7 +46,7 @@ fbLI1K4(
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M20,
     sPmpsDeviceName := 'LI1K4:IP1',
-	sTransitionKey := 'LI1K4:IP1-TRANSITION',
+    sTransitionKey := 'LI1K4:IP1-TRANSITION',
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
@@ -63,7 +63,7 @@ fbPF1K4(
     stYStage := Main.M18,
     stZStage := Main.M19,
     sPmpsDeviceName := 'PF1K4:WFS',
-	sTransitionKey := 'PF1K4:WFS-TRANSITION',
+    sTransitionKey := 'PF1K4:WFS-TRANSITION',
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
@@ -3,7 +3,7 @@
   <POU Name="PRG_PF2K4_WFS_TARGET" Id="{eca3a9b8-cbcf-48fb-b835-0fd9af0cb164}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_PF2K4_WFS_TARGET
 VAR
-	{attribute 'pytmc' := '
+    {attribute 'pytmc' := '
         pv: PF2K4:WFS
         io: io
     '}
@@ -62,7 +62,7 @@ fbPF2K4(
     stYStage := Main.M28,
     stZStage := Main.M29,
     sPmpsDeviceName := 'PF2K4:WFS',
-	sTransitionKey := 'PF2K4:WFS-TRANSITION',
+    sTransitionKey := 'PF2K4:WFS-TRANSITION',
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -114,64 +114,64 @@ fbMotionZPZ(stMotionStage:=Main.M36);
 
 fbZPSetup(stPositionState:=fbZPDefault, bSetDefault:=TRUE);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.OUT], sName:='OUT', fPosition:=8);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.OUT], sName:='OUT', fPosition:=15);
 fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.OUT], sName:='OUT', fPosition:=0);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.OUT], sName:='OUT', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.Yag], sName:='YAG', fPosition:=9);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.Yag], sName:='YAG', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.Yag], sName:='YAG', fPosition:=49);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.Yag], sName:='YAG', fPosition:=4.15);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.Yag], sName:='YAG', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP860_1], sName:='FZP-860-Ne1', fPosition:=10);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP860_1], sName:='FZP-860-Ne1', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP860_1], sName:='FZP-860-Ne1', fPosition:=81);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP860_1], sName:='FZP-860-Ne1', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP860_1], sName:='FZP-860-Ne1', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP860_2], sName:='FZP-860-Ne2', fPosition:=11);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP860_2], sName:='FZP-860-Ne2', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP860_2], sName:='FZP-860-Ne2', fPosition:=73);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP860_2], sName:='FZP-860-Ne2', fPosition:=4.15);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP860_2], sName:='FZP-860-Ne2', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP860_3], sName:='FZP-860-Ne3', fPosition:=12);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP860_3], sName:='FZP-860-Ne3', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP860_3], sName:='FZP-860-Ne3', fPosition:=81);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP860_3], sName:='FZP-860-Ne3', fPosition:=4.15);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP860_3], sName:='FZP-860-Ne3', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP750_1], sName:='FZP-750-XPS1', fPosition:=13);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP750_1], sName:='FZP-750-XPS1', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP750_1], sName:='FZP-750-XPS1', fPosition:=65);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP750_1], sName:='FZP-750-XPS1', fPosition:=4.15);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP750_1], sName:='FZP-750-XPS1', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP750_2], sName:='FZP-750-XPS2', fPosition:=14);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP750_2], sName:='FZP-750-XPS2', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP750_2], sName:='FZP-750-XPS2', fPosition:=57);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP750_2], sName:='FZP-750-XPS2', fPosition:=4.15);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP750_2], sName:='FZP-750-XPS2', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP530_1], sName:='FZP-530-O1', fPosition:=15);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP530_1], sName:='FZP-530-O1', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP530_1], sName:='FZP-530-O1', fPosition:=49);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP530_1], sName:='FZP-530-O1', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP530_1], sName:='FZP-530-O1', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP530_2], sName:='FZP-530-O2', fPosition:=16);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP530_2], sName:='FZP-530-O2', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP530_2], sName:='FZP-530-O2', fPosition:=57);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP530_2], sName:='FZP-530-O2', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP530_2], sName:='FZP-530-O2', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP460_1], sName:='FZP-460-Ti1', fPosition:=17);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP460_1], sName:='FZP-460-Ti1', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP460_1], sName:='FZP-460-Ti1', fPosition:=89);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP460_1], sName:='FZP-460-Ti1', fPosition:=4.0);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP460_1], sName:='FZP-460-Ti1', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP460_2], sName:='FZP-460-Ti2', fPosition:=18);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP460_2], sName:='FZP-460-Ti2', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP460_2], sName:='FZP-460-Ti2', fPosition:=97);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP460_2], sName:='FZP-460-Ti2', fPosition:=4.0);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP460_2], sName:='FZP-460-Ti2', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP410_1], sName:='FZP-410-N1', fPosition:=19);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP410_1], sName:='FZP-410-N1', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP410_1], sName:='FZP-410-N1', fPosition:=89);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP410_1], sName:='FZP-410-N1', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP410_1], sName:='FZP-410-N1', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP410_2], sName:='FZP-410-N2', fPosition:=20);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP410_2], sName:='FZP-410-N2', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP410_2], sName:='FZP-410-N2', fPosition:=97);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP410_2], sName:='FZP-410-N2', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP410_2], sName:='FZP-410-N2', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP290_1], sName:='FZP-290-C1', fPosition:=21);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP290_1], sName:='FZP-290-C1', fPosition:=1);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP290_1], sName:='FZP-290-C1', fPosition:=65);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP290_1], sName:='FZP-290-C1', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP290_1], sName:='FZP-290-C1', fPosition:=0);
 
-fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=22);
-fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=0);
+fbZPSetup(stPositionState:=aZPXStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=73);
+fbZPSetup(stPositionState:=aZPYStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=-4.7);
 fbZPSetup(stPositionState:=aZPZStates[ENUM_ZonePlate_States.FZP290_2], sName:='FZP-290-C2', fPosition:=0);
 
 

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_ST4K4_TMO_TERM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_ST4K4_TMO_TERM.TcPOU
@@ -21,11 +21,11 @@ END_VAR
     ibCntrlHold:= TRUE,
     ibOverrideInterlock:= ,
     i_xReset:= ,
-	i_xAutoReset := TRUE,
+    i_xAutoReset := TRUE,
     stPneumaticActuator=> ,
     xMPS_OK=>  ,
     io_fbFFHWO:= fbFastFaultOutput2  ); // Do Stoppers send MPS FAULT?
-	
+
 // For PMPS Veto
 GVL_PMPS.PMPS_ST4K4_IN := ST4K4.i_xInsertedLS;
 GVL_PMPS.PMPS_ST4K4_OUT := ST4K4.i_xRetractedLS;]]></ST>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_TM1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_TM1K4.TcPOU
@@ -62,8 +62,8 @@ fbTM1K4(
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M21,
     stXStage := Main.M22,
-	sPmpsDeviceName := 'TM1K4:ATM',
-	sTransitionKey := 'TM1K4:ATM-TRANSITION',
+    sPmpsDeviceName := 'TM1K4:ATM',
+    sTransitionKey := 'TM1K4:ATM-TRANSITION',
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_TM2K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_TM2K4.TcPOU
@@ -3,7 +3,7 @@
   <POU Name="PRG_TM2K4" Id="{37b34b48-9c31-400a-af8d-201b93d6c030}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_TM2K4
 VAR
-	{attribute 'pytmc' := '
+    {attribute 'pytmc' := '
         pv: TM2K4:ATM
         io: io
     '}
@@ -53,8 +53,8 @@ fbTM2K4(
     fbFFHWO := fbFastFaultOutput2,
     stYStage := Main.M30,
     stXStage := Main.M31,
-	sPmpsDeviceName := 'TM2K4:ATM',
-	sTransitionKey := 'TM2K4:ATM-TRANSITION',
+    sPmpsDeviceName := 'TM2K4:ATM',
+    sTransitionKey := 'TM2K4:ATM-TRANSITION',
      );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/TM1K4/ENUM_TM1K4_States.TcDUT
+++ b/plc-tmo-motion/tmo_motion/POUs/TM1K4/ENUM_TM1K4_States.TcDUT
@@ -4,7 +4,7 @@
     <Declaration><![CDATA[{attribute 'qualified_only'}
 TYPE ENUM_TM1K4_States :
 (
-	// Adapted from ENUM_ATM_States to add TARGET6
+    // Adapted from ENUM_ATM_States to add TARGET6
 
     Unknown := 0,
     OUT := 1,
@@ -14,7 +14,7 @@ TYPE ENUM_TM1K4_States :
     TARGET3a := 5,
     TARGET3b := 6,
     YAG := 7,
-	DIODE := 8
+    DIODE := 8
 );
 END_TYPE
 ]]></Declaration>

--- a/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4.TcPOU
@@ -22,9 +22,9 @@ VAR_INPUT
     stTarget3a: DUT_PositionState;
     stTarget3b: DUT_PositionState;
     stTarget4: DUT_PositionState;    // target 4 is Yag
-	stTarget5: DUT_PositionState;    //target 5 is Diode
+    stTarget5: DUT_PositionState;    //target 5 is Diode
     sPmpsDeviceName: STRING;
-	sTransitionKey: STRING;
+    sTransitionKey: STRING;
 END_VAR
 VAR
     fbYStage: FB_MotionStage;

--- a/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4_States.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4_States.TcPOU
@@ -17,7 +17,7 @@ VAR_INPUT
     stTarget3a: DUT_PositionState;
     stTarget3b: DUT_PositionState;
     stTarget4: DUT_PositionState;
-	stTarget5: DUT_PositionState;
+    stTarget5: DUT_PositionState;
 
     bStatesLock: BOOL;
 END_VAR
@@ -30,7 +30,7 @@ VAR_OUTPUT
 END_VAR
 VAR
     bATMInit: BOOL;
-	stTarget6: INT;
+    stTarget6: INT;
 END_VAR
 VAR CONSTANT
     fInDelta: LREAL := 2;
@@ -52,56 +52,56 @@ END_VAR
     stOut.fAccel := fAccel;
     stOut.fDecel := fOutDecel;
     stOut.bMoveOk := TRUE;
-	
+
     stTarget1a.sName := 'TARGET 1a';
     stTarget1a.fVelocity := fInVelocity;
     stTarget1a.fDelta := fInDelta;
     stTarget1a.fAccel := fAccel;
     stTarget1a.fDecel := fAccel;
     stTarget1a.bMoveOk := TRUE;
-	
+
     stTarget1b.sName := 'TARGET 1b';
     stTarget1b.fVelocity := fInVelocity;
     stTarget1b.fDelta := fInDelta;
     stTarget1b.fAccel := fAccel;
     stTarget1b.fDecel := fAccel;
     stTarget1b.bMoveOk := TRUE;
-	
+
     stTarget2b.sName := 'TARGET 2b';
     stTarget2b.fVelocity := fInVelocity;
     stTarget2b.fDelta := fInDelta;
     stTarget2b.fAccel := fAccel;
     stTarget2b.fDecel := fAccel;
     stTarget2b.bMoveOk := TRUE;
-	
+
     stTarget3a.sName := 'TARGET 3a';
     stTarget3a.fVelocity := fInVelocity;
     stTarget3a.fDelta := fInDelta;
     stTarget3a.fAccel := fAccel;
     stTarget3a.fDecel := fAccel;
     stTarget3a.bMoveOk := TRUE;
-	
+
     stTarget3b.sName := 'TARGET 3b';
     stTarget3b.fVelocity := fInVelocity;
     stTarget3b.fDelta := fInDelta;
     stTarget3b.fAccel := fAccel;
     stTarget3b.fDecel := fAccel;
     stTarget3b.bMoveOk := TRUE;
-	
+
     stTarget4.sName := 'YAG';
     stTarget4.fVelocity := fInVelocity;
     stTarget4.fDelta := fInDelta;
     stTarget4.fAccel := fAccel;
     stTarget4.fDecel := fAccel;
     stTarget4.bMoveOk := TRUE;
-	
-	stTarget5.sName := 'DIODE';
+
+    stTarget5.sName := 'DIODE';
     stTarget5.fVelocity := fInVelocity;
     stTarget5.fDelta := fInDelta;
     stTarget5.fAccel := fAccel;
     stTarget5.fDecel := fAccel;
     stTarget5.bMoveOk := TRUE;
-	
+
     arrStates[1] := stOut;
     arrStates[2] := stTarget1a;
     arrStates[3] := stTarget1b;
@@ -109,8 +109,8 @@ END_VAR
     arrStates[5] := stTarget3a;
     arrStates[6] := stTarget3b;
     arrStates[7] := stTarget4;
-	arrStates[8] := stTarget5;
-	
+    arrStates[8] := stTarget5;
+
 END_IF
 
 setState := enumSet;

--- a/plc-tmo-motion/tmo_motion/POUs/TM2K4/ENUM_TM2K4_States.TcDUT
+++ b/plc-tmo-motion/tmo_motion/POUs/TM2K4/ENUM_TM2K4_States.TcDUT
@@ -4,7 +4,7 @@
     <Declaration><![CDATA[{attribute 'qualified_only'}
 TYPE ENUM_TM2K4_States :
 (
-	// Adapted from ENUM_ATM_States to add TARGET6
+    // Adapted from ENUM_ATM_States to add TARGET6
 
     Unknown := 0,
     OUT := 1,
@@ -12,7 +12,7 @@ TYPE ENUM_TM2K4_States :
     TARGET2 := 3,
     TARGET3 := 4,
     YAG := 5,
-	DIODE := 6
+    DIODE := 6
 );
 END_TYPE
 ]]></Declaration>

--- a/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4.TcPOU
@@ -20,9 +20,9 @@ VAR_INPUT
     stTarget2: DUT_PositionState;
     stTarget3: DUT_PositionState;
     stTarget4: DUT_PositionState;   // target 4 is YAG
-	stTarget5: DUT_PositionState;    // target 5 is Diode
+    stTarget5: DUT_PositionState;    // target 5 is Diode
     sPmpsDeviceName: STRING;
-	sTransitionKey: STRING;
+    sTransitionKey: STRING;
 END_VAR
 VAR
     fbYStage: FB_MotionStage;
@@ -67,7 +67,7 @@ fbStates(
     stTarget2:=stTarget2,
     stTarget3:=stTarget3,
     stTarget4:=stTarget4,
-	stTarget5:=stTarget5,
+    stTarget5:=stTarget5,
 );
 
 fbThermoCouple1();]]></ST>

--- a/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4_States.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4_States.TcPOU
@@ -15,7 +15,7 @@ VAR_INPUT
     stTarget2: DUT_PositionState;
     stTarget3: DUT_PositionState;
     stTarget4: DUT_PositionState;
-	stTarget5: DUT_PositionState;
+    stTarget5: DUT_PositionState;
 
     bStatesLock: BOOL;
 END_VAR
@@ -50,49 +50,49 @@ END_VAR
     stOut.fAccel := fAccel;
     stOut.fDecel := fOutDecel;
     stOut.bMoveOk := TRUE;
-	
+
     stTarget1.sName := 'TARGET 1';
     stTarget1.fVelocity := fInVelocity;
     stTarget1.fDelta := fInDelta;
     stTarget1.fAccel := fAccel;
     stTarget1.fDecel := fAccel;
     stTarget1.bMoveOk := TRUE;
-	
+
     stTarget2.sName := 'TARGET 2';
     stTarget2.fVelocity := fInVelocity;
     stTarget2.fDelta := fInDelta;
     stTarget2.fAccel := fAccel;
     stTarget2.fDecel := fAccel;
     stTarget2.bMoveOk := TRUE;
-	
+
     stTarget3.sName := 'TARGET 3';
     stTarget3.fVelocity := fInVelocity;
     stTarget3.fDelta := fInDelta;
     stTarget3.fAccel := fAccel;
     stTarget3.fDecel := fAccel;
     stTarget3.bMoveOk := TRUE;
-	
+
     stTarget4.sName := 'YAG';
     stTarget4.fVelocity := fInVelocity;
     stTarget4.fDelta := fInDelta;
     stTarget4.fAccel := fAccel;
     stTarget4.fDecel := fAccel;
     stTarget4.bMoveOk := TRUE;
-	
-	stTarget5.sName := 'DIODE';
+
+    stTarget5.sName := 'DIODE';
     stTarget5.fVelocity := fInVelocity;
     stTarget5.fDelta := fInDelta;
     stTarget5.fAccel := fAccel;
     stTarget5.fDecel := fAccel;
     stTarget5.bMoveOk := TRUE;
-	
+
     arrStates[1] := stOut;
     arrStates[2] := stTarget1;
     arrStates[3] := stTarget2;
     arrStates[4] := stTarget3;
     arrStates[5] := stTarget4;
-	arrStates[6] := stTarget5;
-	
+    arrStates[6] := stTarget5;
+
 END_IF
 
 setState := enumSet;

--- a/plc-tmo-motion/tmo_motion/POUs/temp/FB_ZonePlate_States.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/temp/FB_ZonePlate_States.TcPOU
@@ -3,41 +3,41 @@
   <POU Name="FB_ZonePlate_States" Id="{d27e90f5-8a3f-4562-a8f0-f90423b69349}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_ZonePlate_States EXTENDS FB_PositionStateBase_WithPMPS
 VAR_INPUT
-	 {attribute 'pytmc' := '
+     {attribute 'pytmc' := '
         pv: SET
         io: io
     '}
     enumSet: ENUM_ZonePlate_States;
-	stOut: DUT_PositionState;
-	stYag: DUT_PositionState;
-	stNe1: DUT_PositionState;
-	stNe2: DUT_PositionState;
+    stOut: DUT_PositionState;
+    stYag: DUT_PositionState;
+    stNe1: DUT_PositionState;
+    stNe2: DUT_PositionState;
     stNe3: DUT_PositionState;
     st3w1: DUT_PositionState;
-	st3w2: DUT_PositionState;
-	stO1: DUT_PositionState;
-	stO2: DUT_PositionState;
-	stTi1: DUT_PositionState;
-	stTi2: DUT_PositionState;
-	stN1: DUT_PositionState;
-	stN2:DUT_PositionState;
-	stC1: DUT_PositionState;
-	stC2: DUT_PositionState;
-	stW1: DuT_PositionState;
+    st3w2: DUT_PositionState;
+    stO1: DUT_PositionState;
+    stO2: DUT_PositionState;
+    stTi1: DUT_PositionState;
+    stTi2: DUT_PositionState;
+    stN1: DUT_PositionState;
+    stN2:DUT_PositionState;
+    stC1: DUT_PositionState;
+    stC2: DUT_PositionState;
+    stW1: DuT_PositionState;
 END_VAR
 VAR_OUTPUT
-	 {attribute 'pytmc' := '
+     {attribute 'pytmc' := '
         pv: GET
         io: i
     '}
     enumGet: ENUM_ZonePlate_States;
 END_VAR
 VAR
-	bInittwo: BOOL := TRUE;
-	fbStateDefaults: FB_PositionState_Defaults;
-	// These are the default values
+    bInittwo: BOOL := TRUE;
+    fbStateDefaults: FB_PositionState_Defaults;
+    // These are the default values
     // Set values on states prior to passing in for non-default values
-	//TODO correct these default positions
+    //TODO correct these default positions
     fDelta: LREAL := 1;
     fVelocity: LREAL := 5;
     fAccel: LREAL := 200;
@@ -47,82 +47,82 @@ END_VAR
     <Implementation>
       <ST><![CDATA[//State init
 IF (bInittwo) THEN
-	bInittwo := FALSE;
-	//Set theses for every state
-	stOut.sName := 'OUT';
-	stOut.bUseRawCounts:= FALSE;
-	stOut.bValid := TRUE;
-	    fbStateDefaults(
+    bInittwo := FALSE;
+    //Set theses for every state
+    stOut.sName := 'OUT';
+    stOut.bUseRawCounts:= FALSE;
+    stOut.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stOut,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stYag.sName := 'Yag';
-	stYag.bUseRawCounts:= FALSE;
-	stYag.bValid := TRUE;
-	    fbStateDefaults(
+    stYag.sName := 'Yag';
+    stYag.bUseRawCounts:= FALSE;
+    stYag.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stYag,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stNe1.sName := 'Ne1';
-	stNe1.bUseRawCounts:= FALSE;
-	stNe1.bValid := TRUE;
-	    fbStateDefaults(
+    stNe1.sName := 'Ne1';
+    stNe1.bUseRawCounts:= FALSE;
+    stNe1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stNe1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stNe2.sName := 'Ne2';
-	stNe2.bUseRawCounts:= FALSE;
-	stNe2.bValid := TRUE;
-	    fbStateDefaults(
+    stNe2.sName := 'Ne2';
+    stNe2.bUseRawCounts:= FALSE;
+    stNe2.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stNe2,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stNe3.sName := 'Ne3';
-	stNe3.bUseRawCounts:= FALSE;
-	stNe3.bValid := TRUE;
-	    fbStateDefaults(
+    stNe3.sName := 'Ne3';
+    stNe3.bUseRawCounts:= FALSE;
+    stNe3.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stNe3,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	st3w1.sName := '3w1';
-	st3w1.bUseRawCounts:= FALSE;
-	st3w1.bValid := TRUE;
-	    fbStateDefaults(
+    st3w1.sName := '3w1';
+    st3w1.bUseRawCounts:= FALSE;
+    st3w1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=st3w1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	st3w2.sName := '3w2';
-	st3w2.bUseRawCounts:= FALSE;
-	st3w2.bValid := TRUE;
-	    fbStateDefaults(
+    st3w2.sName := '3w2';
+    st3w2.bUseRawCounts:= FALSE;
+    st3w2.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=st3w2,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stO1.sName := 'O1';
-	stO1.bUseRawCounts:= FALSE;
-	stO1.bValid := TRUE;
-	    fbStateDefaults(
+    stO1.sName := 'O1';
+    stO1.bUseRawCounts:= FALSE;
+    stO1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stO1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
@@ -130,70 +130,70 @@ IF (bInittwo) THEN
         fDecelDefault:=fDecel,
     );
     stO2.sName := 'O2';
-	stO2.bUseRawCounts:= FALSE;
-	stO2.bValid := TRUE;
-	    fbStateDefaults(
+    stO2.bUseRawCounts:= FALSE;
+    stO2.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stO2,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
-    ); 
-	
+    );
+
     stTi1.sName := 'Ti1';
-	stTi1.bUseRawCounts:= FALSE;
-	stTi1.bValid := TRUE;
-	    fbStateDefaults(
+    stTi1.bUseRawCounts:= FALSE;
+    stTi1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stTi1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
-    ); 
-	stTi2.sName := 'Ti2';
-	stTi2.bUseRawCounts:= FALSE;
-	stTi2.bValid := TRUE;
-	    fbStateDefaults(
+    );
+    stTi2.sName := 'Ti2';
+    stTi2.bUseRawCounts:= FALSE;
+    stTi2.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stTi2,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stN1.sName := 'N1';
-	stN1.bUseRawCounts:= FALSE;
-	stN1.bValid := TRUE;
-	    fbStateDefaults(
+    stN1.sName := 'N1';
+    stN1.bUseRawCounts:= FALSE;
+    stN1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stN1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stN2.sName := 'N2';
-	stN2.bUseRawCounts:= FALSE;
-	stN2.bValid := TRUE;
-	    fbStateDefaults(
+    stN2.sName := 'N2';
+    stN2.bUseRawCounts:= FALSE;
+    stN2.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stN2,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stC1.sName := 'C1';
-	stC1.bUseRawCounts:= FALSE;
-	stC1.bValid := TRUE;
-	    fbStateDefaults(
+    stC1.sName := 'C1';
+    stC1.bUseRawCounts:= FALSE;
+    stC1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stC1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
         fAccelDefault:=fAccel,
         fDecelDefault:=fDecel,
     );
-	stC2.sName := 'C2';
-	stC2.bUseRawCounts:= FALSE;
-	stC2.bValid := TRUE;
-	    fbStateDefaults(
+    stC2.sName := 'C2';
+    stC2.bUseRawCounts:= FALSE;
+    stC2.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stC2,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
@@ -201,9 +201,9 @@ IF (bInittwo) THEN
         fDecelDefault:=fDecel,
     );
     stW1.sName := 'W1';
-	stW1.bUseRawCounts:= FALSE;
-	stW1.bValid := TRUE;
-	    fbStateDefaults(
+    stW1.bUseRawCounts:= FALSE;
+    stW1.bValid := TRUE;
+        fbStateDefaults(
         stPositionState:=stW1,
         fVeloDefault:=fVelocity,
         fDeltaDefault:=fDelta,
@@ -211,12 +211,12 @@ IF (bInittwo) THEN
         fDecelDefault:=fDecel,
     );
 
-//Add all states 
-	
-	arrStates[1] := stOut;
-	arrStates[2] := stYag;
-	arrStates[3] := stNe1;
-	arrStates[4] := stNe2;
+//Add all states
+
+    arrStates[1] := stOut;
+    arrStates[2] := stYag;
+    arrStates[3] := stNe1;
+    arrStates[4] := stNe2;
     arrStates[5] := stNe3;
     arrStates[6] := st3w1;
     arrStates[7] := st3w2;
@@ -228,8 +228,8 @@ IF (bInittwo) THEN
     arrStates[13] := stN2;
     arrStates[14] := stC1;
     arrStates[15] := stC2;
- //   arrStates[16] := stW1;	
-	
+ //   arrStates[16] := stW1;
+
 END_IF
 
 setState := enumSet;

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -80647,7 +80647,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-14T10:14:06</Value>
+          <Value>2023-08-18T12:08:19</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Mingfu setup all FZP 15 targets positions by Epics with He-Ne laser. I change PLC all targets value to be consistent.
<!--- Describe your changes in detail -->
Change all FZP PMPS states positions to be consistent with epics value.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
TMO wants to setup FZP targets real positions for PMPS fault. Mingfu used He-Ne laser to tune.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Mingfu tested is already in GUI level by He-Ne laser.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

https://jira.slac.stanford.edu/browse/ECS-905
<!--  This can simply be  a comment in the code or updating a docstring -->
Mingfu setup all position by He-Ne laser not X ray.

## Screenshots (if appropriate):

## Pre-merge checklist
- [ x] Code works interactively
- [x ] Code contains descriptive comments
- [x ] Test suite passes locally
- [ x] Libraries are set to fixed versions and not ``Always Newest``
- [ x Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
