### PR TITLE
Implement Flow Meter for Imagers IM3/4/5/6K4

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -2082,14 +2082,6 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bHallInput1</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -2526,6 +2518,22 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.bHallInput1</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bHallInput2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1High</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1Low</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
 					<Comment>
 						<![CDATA[IO]]>
@@ -2537,11 +2545,11 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
+					<Name>PRG_SP1K4.bTL2High</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1Low</Name>
+					<Name>PRG_SP1K4.bTL2Low</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -2657,14 +2665,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL2High</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL2Low</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -8815,6 +8815,10 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 					<SubVar>
@@ -8950,10 +8954,6 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -9545,6 +9545,9 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^Main.M15.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
 			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM3K4-PPM (EK1100)^IM3K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM3K4-PPM (EK1100)^IM3K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
@@ -9633,6 +9636,9 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^Main.M27.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
 			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
@@ -9714,6 +9720,9 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL2004-E3">
 				<Link VarA="PlcTask Outputs^Main.M17.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1326,7 +1326,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1429,7 +1432,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1532,7 +1538,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1635,7 +1644,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1738,7 +1750,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -2067,6 +2082,14 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.bHallInput1</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bHallInput2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -2283,14 +2306,6 @@ External Setpoint Generation:
 							<![CDATA[status of aperture, false if error or in motion]]>
 						</Comment>
 					</SubVar>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput1</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -9556,6 +9571,9 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL2004-E3">
 				<Link VarA="PlcTask Outputs^Main.M16.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM3K4: FB_PPM;
     fStartupVelo: LREAL := 12;
 END_VAR

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM4K4: FB_PPM;
     fStartupVelo: LREAL := 15;
 END_VAR
@@ -60,6 +61,7 @@ fbIM4K4(
     stYStage := Main.M16,
     sPmpsDeviceName := 'IM4K4:PPM',
     sTransitionKey := 'IM4K4:PPM-TRANSITION',
+    fFlowOffset := 0.4
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM5K4: FB_PPM;
     fStartupVelo: LREAL := 12;
 END_VAR
@@ -55,6 +56,7 @@ fbIM5K4(
     stYStage := Main.M17,
     sPmpsDeviceName := 'IM5K4:PPM',
     sTransitionKey := 'IM5K4:PPM-TRANSITION',
+    fFlowOffset := 0.8,
 
 );]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM6K4: FB_PPM;
     fStartupVelo: LREAL := 13;
 END_VAR
@@ -54,6 +55,7 @@ fbIM6K4(
     stYStage := Main.M27,
     sPmpsDeviceName := 'IM6K4:PPM',
     sTransitionKey := 'IM6K4:PPM-TRANSITION',
+    fFlowOffset := 0.6,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -190,13 +190,13 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="LCLS General">
-      <Resolution>LCLS General-nrw, 0.0.0 (SLAC)</Resolution>
+      <Resolution>LCLS General, 2.9.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 3.0.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls2-cc-lib">
-      <Resolution>lcls2-cc-lib-nrw, 0.0.0 (SLAC)</Resolution>
+      <Resolution>lcls2-cc-lib, 2.1.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -190,13 +190,13 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="LCLS General">
-      <Resolution>LCLS General, 2.8.2 (SLAC)</Resolution>
+      <Resolution>LCLS General-nrw, 0.0.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 3.0.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls2-cc-lib">
-      <Resolution>lcls2-cc-lib, 2.0.0 (SLAC)</Resolution>
+      <Resolution>lcls2-cc-lib-nrw, 0.0.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FD0E8A9B-CCC0-123B-9666-164D017FD4BA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{9795EEB8-ADFC-3ED1-612F-683F01A973DE}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84564192</GetCodeOffs>
+        <GetCodeOffs>84564156</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84564224</GetCodeOffs>
+        <GetCodeOffs>84564188</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84564232</GetCodeOffs>
+        <GetCodeOffs>84564196</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84564216</GetCodeOffs>
+        <GetCodeOffs>84564180</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84564228</GetCodeOffs>
+        <GetCodeOffs>84564192</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84564136</GetCodeOffs>
-        <SetCodeOffs>84564160</SetCodeOffs>
+        <GetCodeOffs>84564100</GetCodeOffs>
+        <SetCodeOffs>84564124</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84564172</GetCodeOffs>
-        <SetCodeOffs>84564184</SetCodeOffs>
+        <GetCodeOffs>84564136</GetCodeOffs>
+        <SetCodeOffs>84564148</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>84564280</GetCodeOffs>
+        <GetCodeOffs>84564244</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84564260</GetCodeOffs>
+        <GetCodeOffs>84564224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84564348</GetCodeOffs>
+        <GetCodeOffs>84564312</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84564308</GetCodeOffs>
+        <GetCodeOffs>84564272</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84564352</GetCodeOffs>
+        <GetCodeOffs>84564316</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84564376</GetCodeOffs>
+        <GetCodeOffs>84564340</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -49529,6 +49529,89 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name>ENUM_ZonePlate_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Yag</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_1</Text>
+        <Enum>3</Enum>
+        <Comment>Ne1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_2</Text>
+        <Enum>4</Enum>
+        <Comment>Ne2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_3</Text>
+        <Enum>5</Enum>
+        <Comment>Ne3</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_1</Text>
+        <Enum>6</Enum>
+        <Comment>3w1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_2</Text>
+        <Enum>7</Enum>
+        <Comment>3w2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_1</Text>
+        <Enum>8</Enum>
+        <Comment>o1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_2</Text>
+        <Enum>9</Enum>
+        <Comment>o2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_1</Text>
+        <Enum>10</Enum>
+        <Comment>Ti1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_2</Text>
+        <Enum>11</Enum>
+        <Comment>Ti2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_1</Text>
+        <Enum>12</Enum>
+        <Comment>N1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_2</Text>
+        <Enum>13</Enum>
+        <Comment>N2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_1</Text>
+        <Enum>14</Enum>
+        <Comment> C1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_2</Text>
+        <Enum>15</Enum>
+        <Comment>C2
+	FZP250_1 := 16    //w1</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Name>
       <BitSize>32</BitSize>
       <SubItem>
@@ -52644,122 +52727,6 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name>ENUM_ZonePlate_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Yag</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_1</Text>
-        <Enum>3</Enum>
-        <Comment>Ne1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_2</Text>
-        <Enum>4</Enum>
-        <Comment>Ne2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_3</Text>
-        <Enum>5</Enum>
-        <Comment>Ne3</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_1</Text>
-        <Enum>6</Enum>
-        <Comment>3w1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_2</Text>
-        <Enum>7</Enum>
-        <Comment>3w2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_1</Text>
-        <Enum>8</Enum>
-        <Comment>o1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_2</Text>
-        <Enum>9</Enum>
-        <Comment>o2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_1</Text>
-        <Enum>10</Enum>
-        <Comment>Ti1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_2</Text>
-        <Enum>11</Enum>
-        <Comment>Ti2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_1</Text>
-        <Enum>12</Enum>
-        <Comment>N1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_2</Text>
-        <Enum>13</Enum>
-        <Comment>N2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_1</Text>
-        <Enum>14</Enum>
-        <Comment> C1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_2</Text>
-        <Enum>15</Enum>
-        <Comment>C2
-	FZP250_1 := 16    //w1</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
       <BitSize>87808</BitSize>
       <SubItem>
@@ -53311,6 +53278,39 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
@@ -54074,8 +54074,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84570940</GetCodeOffs>
-        <SetCodeOffs>84570948</SetCodeOffs>
+        <GetCodeOffs>84570904</GetCodeOffs>
+        <SetCodeOffs>84570912</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -55369,31 +55369,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84570508</GetCodeOffs>
+        <GetCodeOffs>84570472</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84570540</GetCodeOffs>
+        <GetCodeOffs>84570504</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84570544</GetCodeOffs>
+        <GetCodeOffs>84570508</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84570532</GetCodeOffs>
+        <GetCodeOffs>84570496</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84570552</GetCodeOffs>
+        <GetCodeOffs>84570516</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -59538,7 +59538,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639777536</BitOffs>
+            <BitOffs>639777216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -59551,7 +59551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640746720</BitOffs>
+            <BitOffs>640746400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59563,7 +59563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640768064</BitOffs>
+            <BitOffs>640767744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -59575,7 +59575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641745120</BitOffs>
+            <BitOffs>641744800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59594,7 +59594,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937480</BitOffs>
+            <BitOffs>641937160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59606,7 +59606,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937488</BitOffs>
+            <BitOffs>641937168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59618,7 +59618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937496</BitOffs>
+            <BitOffs>641937176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59630,7 +59630,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937504</BitOffs>
+            <BitOffs>641937184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59643,7 +59643,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937760</BitOffs>
+            <BitOffs>641937440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59656,7 +59656,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642323872</BitOffs>
+            <BitOffs>642323552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
@@ -59669,7 +59669,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324960</BitOffs>
+            <BitOffs>642324640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -59688,7 +59688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642325512</BitOffs>
+            <BitOffs>642325192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -59700,7 +59700,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642325520</BitOffs>
+            <BitOffs>642325200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -59712,7 +59712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642325528</BitOffs>
+            <BitOffs>642325208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -59724,7 +59724,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642325536</BitOffs>
+            <BitOffs>642325216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59736,7 +59736,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642344256</BitOffs>
+            <BitOffs>642343936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -59748,7 +59748,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643321312</BitOffs>
+            <BitOffs>643320992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59767,7 +59767,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643513672</BitOffs>
+            <BitOffs>643513352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59779,7 +59779,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643513680</BitOffs>
+            <BitOffs>643513360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59791,7 +59791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643513688</BitOffs>
+            <BitOffs>643513368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59803,7 +59803,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643513696</BitOffs>
+            <BitOffs>643513376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59816,7 +59816,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643513952</BitOffs>
+            <BitOffs>643513632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59829,7 +59829,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900064</BitOffs>
+            <BitOffs>643899744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
@@ -59842,7 +59842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643901152</BitOffs>
+            <BitOffs>643900832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -59861,7 +59861,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643901704</BitOffs>
+            <BitOffs>643901384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -59873,7 +59873,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643901712</BitOffs>
+            <BitOffs>643901392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -59885,7 +59885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643901720</BitOffs>
+            <BitOffs>643901400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -59897,7 +59897,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643901728</BitOffs>
+            <BitOffs>643901408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59909,7 +59909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643920448</BitOffs>
+            <BitOffs>643920128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -59921,7 +59921,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644897504</BitOffs>
+            <BitOffs>644897184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59940,7 +59940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645089864</BitOffs>
+            <BitOffs>645089544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59952,7 +59952,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645089872</BitOffs>
+            <BitOffs>645089552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59964,7 +59964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645089880</BitOffs>
+            <BitOffs>645089560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59976,7 +59976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645089888</BitOffs>
+            <BitOffs>645089568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59989,7 +59989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645090144</BitOffs>
+            <BitOffs>645089824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60002,7 +60002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645476256</BitOffs>
+            <BitOffs>645475936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
@@ -60015,7 +60015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645477344</BitOffs>
+            <BitOffs>645477024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -60034,7 +60034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645477896</BitOffs>
+            <BitOffs>645477576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60046,7 +60046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645477904</BitOffs>
+            <BitOffs>645477584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -60058,7 +60058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645477912</BitOffs>
+            <BitOffs>645477592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -60070,7 +60070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645477920</BitOffs>
+            <BitOffs>645477600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60082,7 +60082,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645496640</BitOffs>
+            <BitOffs>645496320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -60094,7 +60094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646473696</BitOffs>
+            <BitOffs>646473376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60113,7 +60113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646666056</BitOffs>
+            <BitOffs>646665736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60125,7 +60125,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646666064</BitOffs>
+            <BitOffs>646665744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60137,7 +60137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646666072</BitOffs>
+            <BitOffs>646665752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60149,7 +60149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646666080</BitOffs>
+            <BitOffs>646665760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60162,7 +60162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646666336</BitOffs>
+            <BitOffs>646666016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60175,7 +60175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647052448</BitOffs>
+            <BitOffs>647052128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
@@ -60188,7 +60188,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647053536</BitOffs>
+            <BitOffs>647053216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -60207,7 +60207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647054088</BitOffs>
+            <BitOffs>647053768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60219,7 +60219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647054096</BitOffs>
+            <BitOffs>647053776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -60231,7 +60231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647054104</BitOffs>
+            <BitOffs>647053784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -60243,7 +60243,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647054112</BitOffs>
+            <BitOffs>647053792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60255,7 +60255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647072832</BitOffs>
+            <BitOffs>647072512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -60267,7 +60267,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648049888</BitOffs>
+            <BitOffs>648049568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60286,7 +60286,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648242248</BitOffs>
+            <BitOffs>648241928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60298,7 +60298,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648242256</BitOffs>
+            <BitOffs>648241936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60310,7 +60310,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648242264</BitOffs>
+            <BitOffs>648241944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60322,7 +60322,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648242272</BitOffs>
+            <BitOffs>648241952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60335,7 +60335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648242528</BitOffs>
+            <BitOffs>648242208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60348,7 +60348,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648628640</BitOffs>
+            <BitOffs>648628320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
@@ -60361,7 +60361,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648629728</BitOffs>
+            <BitOffs>648629408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -60380,7 +60380,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648630280</BitOffs>
+            <BitOffs>648629960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60392,7 +60392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648630288</BitOffs>
+            <BitOffs>648629968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -60404,7 +60404,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648630296</BitOffs>
+            <BitOffs>648629976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -60416,7 +60416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648630304</BitOffs>
+            <BitOffs>648629984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60428,7 +60428,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649472</BitOffs>
+            <BitOffs>648649152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60440,7 +60440,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649654848</BitOffs>
+            <BitOffs>649654528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60452,7 +60452,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649952768</BitOffs>
+            <BitOffs>649952448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -60476,7 +60476,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937288</BitOffs>
+            <BitOffs>650936968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -60488,7 +60488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937296</BitOffs>
+            <BitOffs>650936976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -60500,7 +60500,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937304</BitOffs>
+            <BitOffs>650936984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -60512,7 +60512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937312</BitOffs>
+            <BitOffs>650936992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -60536,7 +60536,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937544</BitOffs>
+            <BitOffs>650937224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -60548,7 +60548,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937552</BitOffs>
+            <BitOffs>650937232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -60560,7 +60560,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937560</BitOffs>
+            <BitOffs>650937240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -60572,7 +60572,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650937568</BitOffs>
+            <BitOffs>650937248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60584,7 +60584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650965312</BitOffs>
+            <BitOffs>650964992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60596,7 +60596,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651263232</BitOffs>
+            <BitOffs>651262912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -60620,7 +60620,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652247752</BitOffs>
+            <BitOffs>652247432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -60632,7 +60632,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652247760</BitOffs>
+            <BitOffs>652247440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -60644,7 +60644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652247768</BitOffs>
+            <BitOffs>652247448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -60656,7 +60656,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652247776</BitOffs>
+            <BitOffs>652247456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -60680,7 +60680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652248008</BitOffs>
+            <BitOffs>652247688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -60692,7 +60692,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652248016</BitOffs>
+            <BitOffs>652247696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -60704,7 +60704,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652248024</BitOffs>
+            <BitOffs>652247704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -60716,7 +60716,127 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652248032</BitOffs>
+            <BitOffs>652247712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>652253760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>652551680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>652849600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653147520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653593216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653600320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653898240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>654196160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>654494080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>654939776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -60732,7 +60852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652250480</BitOffs>
+            <BitOffs>654939920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -60748,152 +60868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652250488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>652254080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>652552000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>652849920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>653147840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>653593536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>653600640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>653898560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>654196480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>654494400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>654940096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
-            <Comment>IO</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>655052576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>655052584</BitOffs>
+            <BitOffs>654939928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1High</Name>
@@ -60909,7 +60884,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655053088</BitOffs>
+            <BitOffs>654943392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1Low</Name>
@@ -60925,7 +60900,64 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655053096</BitOffs>
+            <BitOffs>654943400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
+            <Comment>IO</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>655052320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>655052328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL2High</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>655052848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL2Low</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>655052856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60937,7 +60969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655086336</BitOffs>
+            <BitOffs>655086080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60949,7 +60981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655384256</BitOffs>
+            <BitOffs>655384000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -60973,7 +61005,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656375688</BitOffs>
+            <BitOffs>656375432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -60985,7 +61017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656375696</BitOffs>
+            <BitOffs>656375440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -60997,7 +61029,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656375704</BitOffs>
+            <BitOffs>656375448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -61009,39 +61041,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656375712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL2High</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>656376240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL2Low</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>656376248</BitOffs>
+            <BitOffs>656375456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61053,7 +61053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656402176</BitOffs>
+            <BitOffs>656401920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61065,7 +61065,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656700096</BitOffs>
+            <BitOffs>656699840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -61089,7 +61089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657684232</BitOffs>
+            <BitOffs>657683976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -61101,7 +61101,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657684240</BitOffs>
+            <BitOffs>657683984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -61113,7 +61113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657684248</BitOffs>
+            <BitOffs>657683992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -61125,7 +61125,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657684256</BitOffs>
+            <BitOffs>657684000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61137,7 +61137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657690432</BitOffs>
+            <BitOffs>657690176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61149,7 +61149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657988352</BitOffs>
+            <BitOffs>657988096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61161,7 +61161,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658286272</BitOffs>
+            <BitOffs>658286016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61173,7 +61173,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658584192</BitOffs>
+            <BitOffs>658583936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61185,7 +61185,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658882112</BitOffs>
+            <BitOffs>658881856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61197,7 +61197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659180032</BitOffs>
+            <BitOffs>659179776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61209,7 +61209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659477952</BitOffs>
+            <BitOffs>659477696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61221,7 +61221,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659775872</BitOffs>
+            <BitOffs>659775616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61233,7 +61233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660073792</BitOffs>
+            <BitOffs>660073536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61245,7 +61245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660371712</BitOffs>
+            <BitOffs>660371456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61257,7 +61257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660669632</BitOffs>
+            <BitOffs>660669376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61269,7 +61269,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660967552</BitOffs>
+            <BitOffs>660967296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61281,7 +61281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661265472</BitOffs>
+            <BitOffs>661265216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61293,7 +61293,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662828672</BitOffs>
+            <BitOffs>662828416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61316,7 +61316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836608</BitOffs>
+            <BitOffs>662836352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61339,7 +61339,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836616</BitOffs>
+            <BitOffs>662836360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -61362,7 +61362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836624</BitOffs>
+            <BitOffs>662836368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61385,7 +61385,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836640</BitOffs>
+            <BitOffs>662836384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61398,7 +61398,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836672</BitOffs>
+            <BitOffs>662836416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61411,7 +61411,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836736</BitOffs>
+            <BitOffs>662836480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61424,7 +61424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662836752</BitOffs>
+            <BitOffs>662836496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61436,7 +61436,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662853888</BitOffs>
+            <BitOffs>662853632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61459,7 +61459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861824</BitOffs>
+            <BitOffs>662861568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61482,7 +61482,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861832</BitOffs>
+            <BitOffs>662861576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -61505,7 +61505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861840</BitOffs>
+            <BitOffs>662861584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61528,7 +61528,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861856</BitOffs>
+            <BitOffs>662861600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61541,7 +61541,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861888</BitOffs>
+            <BitOffs>662861632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61554,7 +61554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861952</BitOffs>
+            <BitOffs>662861696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61567,7 +61567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662861968</BitOffs>
+            <BitOffs>662861712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61579,7 +61579,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662879104</BitOffs>
+            <BitOffs>662878848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61602,7 +61602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887040</BitOffs>
+            <BitOffs>662886784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61625,7 +61625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887048</BitOffs>
+            <BitOffs>662886792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -61648,7 +61648,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887056</BitOffs>
+            <BitOffs>662886800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61671,7 +61671,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887072</BitOffs>
+            <BitOffs>662886816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61684,7 +61684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887104</BitOffs>
+            <BitOffs>662886848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61697,7 +61697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887168</BitOffs>
+            <BitOffs>662886912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -61710,7 +61710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662887184</BitOffs>
+            <BitOffs>662886928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61722,7 +61722,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664590720</BitOffs>
+            <BitOffs>664590400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61745,7 +61745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598656</BitOffs>
+            <BitOffs>664598336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61768,7 +61768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598664</BitOffs>
+            <BitOffs>664598344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -61791,7 +61791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598672</BitOffs>
+            <BitOffs>664598352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61814,7 +61814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598688</BitOffs>
+            <BitOffs>664598368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61827,7 +61827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598720</BitOffs>
+            <BitOffs>664598400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61840,7 +61840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598784</BitOffs>
+            <BitOffs>664598464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61853,7 +61853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664598800</BitOffs>
+            <BitOffs>664598480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61865,7 +61865,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664615936</BitOffs>
+            <BitOffs>664615616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61888,7 +61888,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664623872</BitOffs>
+            <BitOffs>664623552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61911,7 +61911,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664623880</BitOffs>
+            <BitOffs>664623560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -61934,7 +61934,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664623888</BitOffs>
+            <BitOffs>664623568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61957,7 +61957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664623904</BitOffs>
+            <BitOffs>664623584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61970,7 +61970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664623936</BitOffs>
+            <BitOffs>664623616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61983,7 +61983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664624000</BitOffs>
+            <BitOffs>664623680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61996,7 +61996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664624016</BitOffs>
+            <BitOffs>664623696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62008,7 +62008,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664641152</BitOffs>
+            <BitOffs>664640832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62031,7 +62031,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649088</BitOffs>
+            <BitOffs>664648768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62054,7 +62054,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649096</BitOffs>
+            <BitOffs>664648776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -62077,7 +62077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649104</BitOffs>
+            <BitOffs>664648784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62100,7 +62100,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649120</BitOffs>
+            <BitOffs>664648800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -62113,7 +62113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649152</BitOffs>
+            <BitOffs>664648832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -62126,7 +62126,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649216</BitOffs>
+            <BitOffs>664648896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62139,7 +62139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664649232</BitOffs>
+            <BitOffs>664648912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -62155,7 +62155,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665031776</BitOffs>
+            <BitOffs>665031520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -62176,7 +62176,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665035296</BitOffs>
+            <BitOffs>665035040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -62197,7 +62197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665035297</BitOffs>
+            <BitOffs>665035041</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -62209,7 +62209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675233728</BitOffs>
+            <BitOffs>675233408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -62232,7 +62232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241664</BitOffs>
+            <BitOffs>675241344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -62255,7 +62255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241672</BitOffs>
+            <BitOffs>675241352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -62278,7 +62278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241680</BitOffs>
+            <BitOffs>675241360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -62301,7 +62301,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241696</BitOffs>
+            <BitOffs>675241376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -62314,7 +62314,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241728</BitOffs>
+            <BitOffs>675241408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -62327,7 +62327,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241792</BitOffs>
+            <BitOffs>675241472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -62340,7 +62340,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675241808</BitOffs>
+            <BitOffs>675241488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -62352,7 +62352,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258944</BitOffs>
+            <BitOffs>675258624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -62375,7 +62375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675266880</BitOffs>
+            <BitOffs>675266560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -62398,7 +62398,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675266888</BitOffs>
+            <BitOffs>675266568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -62421,7 +62421,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675266896</BitOffs>
+            <BitOffs>675266576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -62444,7 +62444,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675266912</BitOffs>
+            <BitOffs>675266592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -62457,7 +62457,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675266944</BitOffs>
+            <BitOffs>675266624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -62470,7 +62470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675267008</BitOffs>
+            <BitOffs>675266688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -62483,7 +62483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675267024</BitOffs>
+            <BitOffs>675266704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -62495,7 +62495,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284160</BitOffs>
+            <BitOffs>675283840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -62518,7 +62518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292096</BitOffs>
+            <BitOffs>675291776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -62541,7 +62541,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292104</BitOffs>
+            <BitOffs>675291784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -62564,7 +62564,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292112</BitOffs>
+            <BitOffs>675291792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -62587,7 +62587,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292128</BitOffs>
+            <BitOffs>675291808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -62600,7 +62600,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292160</BitOffs>
+            <BitOffs>675291840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -62613,7 +62613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292224</BitOffs>
+            <BitOffs>675291904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -62626,7 +62626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675292240</BitOffs>
+            <BitOffs>675291920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -62638,7 +62638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309376</BitOffs>
+            <BitOffs>675309056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -62661,7 +62661,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317312</BitOffs>
+            <BitOffs>675316992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -62684,7 +62684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317320</BitOffs>
+            <BitOffs>675317000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -62707,7 +62707,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317328</BitOffs>
+            <BitOffs>675317008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -62730,7 +62730,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317344</BitOffs>
+            <BitOffs>675317024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -62743,7 +62743,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317376</BitOffs>
+            <BitOffs>675317056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -62756,7 +62756,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317440</BitOffs>
+            <BitOffs>675317120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -62769,7 +62769,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675317456</BitOffs>
+            <BitOffs>675317136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -62781,7 +62781,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675334592</BitOffs>
+            <BitOffs>675334272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -62804,7 +62804,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342528</BitOffs>
+            <BitOffs>675342208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -62827,7 +62827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342536</BitOffs>
+            <BitOffs>675342216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -62850,7 +62850,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342544</BitOffs>
+            <BitOffs>675342224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -62873,7 +62873,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342560</BitOffs>
+            <BitOffs>675342240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -62886,7 +62886,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342592</BitOffs>
+            <BitOffs>675342272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -62899,7 +62899,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342656</BitOffs>
+            <BitOffs>675342336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -62912,7 +62912,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675342672</BitOffs>
+            <BitOffs>675342352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -62924,7 +62924,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675359808</BitOffs>
+            <BitOffs>675359488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -62947,7 +62947,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367744</BitOffs>
+            <BitOffs>675367424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -62970,7 +62970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367752</BitOffs>
+            <BitOffs>675367432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -62993,7 +62993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367760</BitOffs>
+            <BitOffs>675367440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -63016,7 +63016,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367776</BitOffs>
+            <BitOffs>675367456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -63029,7 +63029,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367808</BitOffs>
+            <BitOffs>675367488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -63042,7 +63042,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367872</BitOffs>
+            <BitOffs>675367552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -63055,7 +63055,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675367888</BitOffs>
+            <BitOffs>675367568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -63067,7 +63067,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675385024</BitOffs>
+            <BitOffs>675384704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -63090,7 +63090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675392960</BitOffs>
+            <BitOffs>675392640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -63113,7 +63113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675392968</BitOffs>
+            <BitOffs>675392648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -63136,7 +63136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675392976</BitOffs>
+            <BitOffs>675392656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -63159,7 +63159,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675392992</BitOffs>
+            <BitOffs>675392672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -63172,7 +63172,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675393024</BitOffs>
+            <BitOffs>675392704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -63185,7 +63185,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675393088</BitOffs>
+            <BitOffs>675392768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -63198,7 +63198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675393104</BitOffs>
+            <BitOffs>675392784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -63210,7 +63210,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675410240</BitOffs>
+            <BitOffs>675409920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -63233,7 +63233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418176</BitOffs>
+            <BitOffs>675417856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -63256,7 +63256,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418184</BitOffs>
+            <BitOffs>675417864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -63279,7 +63279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418192</BitOffs>
+            <BitOffs>675417872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -63302,7 +63302,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418208</BitOffs>
+            <BitOffs>675417888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -63315,7 +63315,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418240</BitOffs>
+            <BitOffs>675417920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -63328,7 +63328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418304</BitOffs>
+            <BitOffs>675417984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -63341,7 +63341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675418320</BitOffs>
+            <BitOffs>675418000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -63353,7 +63353,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675435456</BitOffs>
+            <BitOffs>675435136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -63376,7 +63376,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443392</BitOffs>
+            <BitOffs>675443072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -63399,7 +63399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443400</BitOffs>
+            <BitOffs>675443080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -63422,7 +63422,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443408</BitOffs>
+            <BitOffs>675443088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -63445,7 +63445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443424</BitOffs>
+            <BitOffs>675443104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -63458,7 +63458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443456</BitOffs>
+            <BitOffs>675443136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -63471,7 +63471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443520</BitOffs>
+            <BitOffs>675443200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -63484,7 +63484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675443536</BitOffs>
+            <BitOffs>675443216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -63496,7 +63496,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675460672</BitOffs>
+            <BitOffs>675460352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -63519,7 +63519,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468608</BitOffs>
+            <BitOffs>675468288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -63542,7 +63542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468616</BitOffs>
+            <BitOffs>675468296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -63565,7 +63565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468624</BitOffs>
+            <BitOffs>675468304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -63588,7 +63588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468640</BitOffs>
+            <BitOffs>675468320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -63601,7 +63601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468672</BitOffs>
+            <BitOffs>675468352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -63614,7 +63614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468736</BitOffs>
+            <BitOffs>675468416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -63627,7 +63627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675468752</BitOffs>
+            <BitOffs>675468432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -63639,7 +63639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675485888</BitOffs>
+            <BitOffs>675485568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -63662,7 +63662,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493824</BitOffs>
+            <BitOffs>675493504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -63685,7 +63685,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493832</BitOffs>
+            <BitOffs>675493512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -63708,7 +63708,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493840</BitOffs>
+            <BitOffs>675493520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -63731,7 +63731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493856</BitOffs>
+            <BitOffs>675493536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -63744,7 +63744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493888</BitOffs>
+            <BitOffs>675493568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -63757,7 +63757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493952</BitOffs>
+            <BitOffs>675493632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -63770,7 +63770,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675493968</BitOffs>
+            <BitOffs>675493648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -63782,7 +63782,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675511104</BitOffs>
+            <BitOffs>675510784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -63805,7 +63805,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519040</BitOffs>
+            <BitOffs>675518720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -63828,7 +63828,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519048</BitOffs>
+            <BitOffs>675518728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -63851,7 +63851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519056</BitOffs>
+            <BitOffs>675518736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -63874,7 +63874,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519072</BitOffs>
+            <BitOffs>675518752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -63887,7 +63887,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519104</BitOffs>
+            <BitOffs>675518784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -63900,7 +63900,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519168</BitOffs>
+            <BitOffs>675518848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -63913,7 +63913,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675519184</BitOffs>
+            <BitOffs>675518864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -63925,7 +63925,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675536320</BitOffs>
+            <BitOffs>675536000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -63948,7 +63948,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544256</BitOffs>
+            <BitOffs>675543936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -63971,7 +63971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544264</BitOffs>
+            <BitOffs>675543944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -63994,7 +63994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544272</BitOffs>
+            <BitOffs>675543952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -64017,7 +64017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544288</BitOffs>
+            <BitOffs>675543968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -64030,7 +64030,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544320</BitOffs>
+            <BitOffs>675544000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -64043,7 +64043,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544384</BitOffs>
+            <BitOffs>675544064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -64056,7 +64056,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675544400</BitOffs>
+            <BitOffs>675544080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -64068,7 +64068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675561536</BitOffs>
+            <BitOffs>675561216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -64091,7 +64091,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569472</BitOffs>
+            <BitOffs>675569152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -64114,7 +64114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569480</BitOffs>
+            <BitOffs>675569160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -64137,7 +64137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569488</BitOffs>
+            <BitOffs>675569168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -64160,7 +64160,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569504</BitOffs>
+            <BitOffs>675569184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -64173,7 +64173,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569536</BitOffs>
+            <BitOffs>675569216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -64186,7 +64186,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569600</BitOffs>
+            <BitOffs>675569280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -64199,7 +64199,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675569616</BitOffs>
+            <BitOffs>675569296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -64211,7 +64211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675586752</BitOffs>
+            <BitOffs>675586432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -64234,7 +64234,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594688</BitOffs>
+            <BitOffs>675594368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -64257,7 +64257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594696</BitOffs>
+            <BitOffs>675594376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -64280,7 +64280,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594704</BitOffs>
+            <BitOffs>675594384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -64303,7 +64303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594720</BitOffs>
+            <BitOffs>675594400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -64316,7 +64316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594752</BitOffs>
+            <BitOffs>675594432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -64329,7 +64329,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594816</BitOffs>
+            <BitOffs>675594496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -64342,7 +64342,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675594832</BitOffs>
+            <BitOffs>675594512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -64354,7 +64354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675611968</BitOffs>
+            <BitOffs>675611648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -64377,7 +64377,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675619904</BitOffs>
+            <BitOffs>675619584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -64400,7 +64400,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675619912</BitOffs>
+            <BitOffs>675619592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -64423,7 +64423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675619920</BitOffs>
+            <BitOffs>675619600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -64446,7 +64446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675619936</BitOffs>
+            <BitOffs>675619616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -64459,7 +64459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675619968</BitOffs>
+            <BitOffs>675619648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -64472,7 +64472,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675620032</BitOffs>
+            <BitOffs>675619712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -64485,7 +64485,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675620048</BitOffs>
+            <BitOffs>675619728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -64497,7 +64497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675637184</BitOffs>
+            <BitOffs>675636864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -64520,7 +64520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645120</BitOffs>
+            <BitOffs>675644800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -64543,7 +64543,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645128</BitOffs>
+            <BitOffs>675644808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -64566,7 +64566,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645136</BitOffs>
+            <BitOffs>675644816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -64589,7 +64589,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645152</BitOffs>
+            <BitOffs>675644832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -64602,7 +64602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645184</BitOffs>
+            <BitOffs>675644864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -64615,7 +64615,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645248</BitOffs>
+            <BitOffs>675644928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -64628,7 +64628,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675645264</BitOffs>
+            <BitOffs>675644944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -64640,7 +64640,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675662400</BitOffs>
+            <BitOffs>675662080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -64663,7 +64663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670336</BitOffs>
+            <BitOffs>675670016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -64686,7 +64686,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670344</BitOffs>
+            <BitOffs>675670024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -64709,7 +64709,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670352</BitOffs>
+            <BitOffs>675670032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -64732,7 +64732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670368</BitOffs>
+            <BitOffs>675670048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -64745,7 +64745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670400</BitOffs>
+            <BitOffs>675670080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -64758,7 +64758,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670464</BitOffs>
+            <BitOffs>675670144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -64771,7 +64771,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675670480</BitOffs>
+            <BitOffs>675670160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -64783,7 +64783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675687616</BitOffs>
+            <BitOffs>675687296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -64806,7 +64806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695552</BitOffs>
+            <BitOffs>675695232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -64829,7 +64829,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695560</BitOffs>
+            <BitOffs>675695240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -64852,7 +64852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695568</BitOffs>
+            <BitOffs>675695248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -64875,7 +64875,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695584</BitOffs>
+            <BitOffs>675695264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -64888,7 +64888,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695616</BitOffs>
+            <BitOffs>675695296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -64901,7 +64901,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695680</BitOffs>
+            <BitOffs>675695360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -64914,7 +64914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675695696</BitOffs>
+            <BitOffs>675695376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -64926,7 +64926,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675712832</BitOffs>
+            <BitOffs>675712512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -64949,7 +64949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720768</BitOffs>
+            <BitOffs>675720448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -64972,7 +64972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720776</BitOffs>
+            <BitOffs>675720456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -64995,7 +64995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720784</BitOffs>
+            <BitOffs>675720464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -65018,7 +65018,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720800</BitOffs>
+            <BitOffs>675720480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -65031,7 +65031,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720832</BitOffs>
+            <BitOffs>675720512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -65044,7 +65044,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720896</BitOffs>
+            <BitOffs>675720576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -65057,7 +65057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675720912</BitOffs>
+            <BitOffs>675720592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -65069,7 +65069,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675738048</BitOffs>
+            <BitOffs>675737728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -65092,7 +65092,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675745984</BitOffs>
+            <BitOffs>675745664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -65115,7 +65115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675745992</BitOffs>
+            <BitOffs>675745672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -65138,7 +65138,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675746000</BitOffs>
+            <BitOffs>675745680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -65161,7 +65161,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675746016</BitOffs>
+            <BitOffs>675745696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -65174,7 +65174,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675746048</BitOffs>
+            <BitOffs>675745728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -65187,7 +65187,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675746112</BitOffs>
+            <BitOffs>675745792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -65200,7 +65200,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675746128</BitOffs>
+            <BitOffs>675745808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -65212,7 +65212,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675763264</BitOffs>
+            <BitOffs>675762944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -65235,7 +65235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771200</BitOffs>
+            <BitOffs>675770880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -65258,7 +65258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771208</BitOffs>
+            <BitOffs>675770888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -65281,7 +65281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771216</BitOffs>
+            <BitOffs>675770896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -65304,7 +65304,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771232</BitOffs>
+            <BitOffs>675770912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -65317,7 +65317,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771264</BitOffs>
+            <BitOffs>675770944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -65330,7 +65330,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771328</BitOffs>
+            <BitOffs>675771008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -65343,7 +65343,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675771344</BitOffs>
+            <BitOffs>675771024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -65355,7 +65355,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675788480</BitOffs>
+            <BitOffs>675788160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -65378,7 +65378,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796416</BitOffs>
+            <BitOffs>675796096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -65401,7 +65401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796424</BitOffs>
+            <BitOffs>675796104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -65424,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796432</BitOffs>
+            <BitOffs>675796112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -65447,7 +65447,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796448</BitOffs>
+            <BitOffs>675796128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -65460,7 +65460,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796480</BitOffs>
+            <BitOffs>675796160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -65473,7 +65473,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796544</BitOffs>
+            <BitOffs>675796224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -65486,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675796560</BitOffs>
+            <BitOffs>675796240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -65498,7 +65498,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675813696</BitOffs>
+            <BitOffs>675813376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -65521,7 +65521,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821632</BitOffs>
+            <BitOffs>675821312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -65544,7 +65544,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821640</BitOffs>
+            <BitOffs>675821320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -65567,7 +65567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821648</BitOffs>
+            <BitOffs>675821328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -65590,7 +65590,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821664</BitOffs>
+            <BitOffs>675821344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -65603,7 +65603,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821696</BitOffs>
+            <BitOffs>675821376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -65616,7 +65616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821760</BitOffs>
+            <BitOffs>675821440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -65629,7 +65629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675821776</BitOffs>
+            <BitOffs>675821456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -65641,7 +65641,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675838912</BitOffs>
+            <BitOffs>675838592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -65664,7 +65664,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846848</BitOffs>
+            <BitOffs>675846528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -65687,7 +65687,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846856</BitOffs>
+            <BitOffs>675846536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -65710,7 +65710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846864</BitOffs>
+            <BitOffs>675846544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -65733,7 +65733,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846880</BitOffs>
+            <BitOffs>675846560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -65746,7 +65746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846912</BitOffs>
+            <BitOffs>675846592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -65759,7 +65759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846976</BitOffs>
+            <BitOffs>675846656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -65772,7 +65772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675846992</BitOffs>
+            <BitOffs>675846672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -65784,7 +65784,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675864128</BitOffs>
+            <BitOffs>675863808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -65807,7 +65807,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872064</BitOffs>
+            <BitOffs>675871744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -65830,7 +65830,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872072</BitOffs>
+            <BitOffs>675871752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -65853,7 +65853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872080</BitOffs>
+            <BitOffs>675871760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -65876,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872096</BitOffs>
+            <BitOffs>675871776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -65889,7 +65889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872128</BitOffs>
+            <BitOffs>675871808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -65902,7 +65902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872192</BitOffs>
+            <BitOffs>675871872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -65915,7 +65915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675872208</BitOffs>
+            <BitOffs>675871888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -65927,7 +65927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675889344</BitOffs>
+            <BitOffs>675889024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -65950,7 +65950,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897280</BitOffs>
+            <BitOffs>675896960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -65973,7 +65973,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897288</BitOffs>
+            <BitOffs>675896968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -65996,7 +65996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897296</BitOffs>
+            <BitOffs>675896976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -66019,7 +66019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897312</BitOffs>
+            <BitOffs>675896992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -66032,7 +66032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897344</BitOffs>
+            <BitOffs>675897024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -66045,7 +66045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897408</BitOffs>
+            <BitOffs>675897088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -66058,7 +66058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675897424</BitOffs>
+            <BitOffs>675897104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -66070,7 +66070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675914560</BitOffs>
+            <BitOffs>675914240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -66093,7 +66093,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922496</BitOffs>
+            <BitOffs>675922176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -66116,7 +66116,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922504</BitOffs>
+            <BitOffs>675922184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -66139,7 +66139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922512</BitOffs>
+            <BitOffs>675922192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -66162,7 +66162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922528</BitOffs>
+            <BitOffs>675922208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -66175,7 +66175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922560</BitOffs>
+            <BitOffs>675922240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -66188,7 +66188,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922624</BitOffs>
+            <BitOffs>675922304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -66201,7 +66201,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675922640</BitOffs>
+            <BitOffs>675922320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -66213,7 +66213,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675939776</BitOffs>
+            <BitOffs>675939456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -66236,7 +66236,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947712</BitOffs>
+            <BitOffs>675947392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -66259,7 +66259,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947720</BitOffs>
+            <BitOffs>675947400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -66282,7 +66282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947728</BitOffs>
+            <BitOffs>675947408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -66305,7 +66305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947744</BitOffs>
+            <BitOffs>675947424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -66318,7 +66318,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947776</BitOffs>
+            <BitOffs>675947456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -66331,7 +66331,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947840</BitOffs>
+            <BitOffs>675947520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -66344,7 +66344,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675947856</BitOffs>
+            <BitOffs>675947536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -66356,7 +66356,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675964992</BitOffs>
+            <BitOffs>675964672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -66379,7 +66379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675972928</BitOffs>
+            <BitOffs>675972608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -66402,7 +66402,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675972936</BitOffs>
+            <BitOffs>675972616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -66425,7 +66425,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675972944</BitOffs>
+            <BitOffs>675972624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -66448,7 +66448,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675972960</BitOffs>
+            <BitOffs>675972640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -66461,7 +66461,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675972992</BitOffs>
+            <BitOffs>675972672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -66474,7 +66474,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675973056</BitOffs>
+            <BitOffs>675972736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -66487,7 +66487,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675973072</BitOffs>
+            <BitOffs>675972752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -66499,7 +66499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675990208</BitOffs>
+            <BitOffs>675989888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -66522,7 +66522,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998144</BitOffs>
+            <BitOffs>675997824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -66545,7 +66545,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998152</BitOffs>
+            <BitOffs>675997832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -66568,7 +66568,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998160</BitOffs>
+            <BitOffs>675997840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -66591,7 +66591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998176</BitOffs>
+            <BitOffs>675997856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -66604,7 +66604,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998208</BitOffs>
+            <BitOffs>675997888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -66617,7 +66617,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998272</BitOffs>
+            <BitOffs>675997952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -66630,7 +66630,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675998288</BitOffs>
+            <BitOffs>675997968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -66642,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676015424</BitOffs>
+            <BitOffs>676015104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -66665,7 +66665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023360</BitOffs>
+            <BitOffs>676023040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -66688,7 +66688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023368</BitOffs>
+            <BitOffs>676023048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -66711,7 +66711,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023376</BitOffs>
+            <BitOffs>676023056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -66734,7 +66734,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023392</BitOffs>
+            <BitOffs>676023072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -66747,7 +66747,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023424</BitOffs>
+            <BitOffs>676023104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -66760,7 +66760,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023488</BitOffs>
+            <BitOffs>676023168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -66773,7 +66773,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676023504</BitOffs>
+            <BitOffs>676023184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -66785,7 +66785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676040640</BitOffs>
+            <BitOffs>676040320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -66808,7 +66808,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048576</BitOffs>
+            <BitOffs>676048256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -66831,7 +66831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048584</BitOffs>
+            <BitOffs>676048264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -66854,7 +66854,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048592</BitOffs>
+            <BitOffs>676048272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -66877,7 +66877,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048608</BitOffs>
+            <BitOffs>676048288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -66890,7 +66890,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048640</BitOffs>
+            <BitOffs>676048320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -66903,7 +66903,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048704</BitOffs>
+            <BitOffs>676048384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -66916,7 +66916,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676048720</BitOffs>
+            <BitOffs>676048400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -66928,7 +66928,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676065856</BitOffs>
+            <BitOffs>676065536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -66951,7 +66951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073792</BitOffs>
+            <BitOffs>676073472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -66974,7 +66974,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073800</BitOffs>
+            <BitOffs>676073480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -66997,7 +66997,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073808</BitOffs>
+            <BitOffs>676073488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -67020,7 +67020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073824</BitOffs>
+            <BitOffs>676073504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -67033,7 +67033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073856</BitOffs>
+            <BitOffs>676073536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -67046,7 +67046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073920</BitOffs>
+            <BitOffs>676073600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -67059,7 +67059,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676073936</BitOffs>
+            <BitOffs>676073616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -67071,7 +67071,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676091072</BitOffs>
+            <BitOffs>676090752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -67094,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099008</BitOffs>
+            <BitOffs>676098688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -67117,7 +67117,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099016</BitOffs>
+            <BitOffs>676098696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -67140,7 +67140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099024</BitOffs>
+            <BitOffs>676098704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -67163,7 +67163,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099040</BitOffs>
+            <BitOffs>676098720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -67176,7 +67176,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099072</BitOffs>
+            <BitOffs>676098752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -67189,7 +67189,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099136</BitOffs>
+            <BitOffs>676098816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -67202,7 +67202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676099152</BitOffs>
+            <BitOffs>676098832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -67214,7 +67214,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676116288</BitOffs>
+            <BitOffs>676115968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -67237,7 +67237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124224</BitOffs>
+            <BitOffs>676123904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -67260,7 +67260,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124232</BitOffs>
+            <BitOffs>676123912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -67283,7 +67283,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124240</BitOffs>
+            <BitOffs>676123920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -67306,7 +67306,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124256</BitOffs>
+            <BitOffs>676123936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -67319,7 +67319,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124288</BitOffs>
+            <BitOffs>676123968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -67332,7 +67332,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124352</BitOffs>
+            <BitOffs>676124032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -67345,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676124368</BitOffs>
+            <BitOffs>676124048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -67357,7 +67357,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676141504</BitOffs>
+            <BitOffs>676141184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -67380,7 +67380,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149440</BitOffs>
+            <BitOffs>676149120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -67403,7 +67403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149448</BitOffs>
+            <BitOffs>676149128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -67426,7 +67426,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149456</BitOffs>
+            <BitOffs>676149136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -67449,7 +67449,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149472</BitOffs>
+            <BitOffs>676149152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -67462,7 +67462,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149504</BitOffs>
+            <BitOffs>676149184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -67475,7 +67475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149568</BitOffs>
+            <BitOffs>676149248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -67488,7 +67488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676149584</BitOffs>
+            <BitOffs>676149264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -67500,7 +67500,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676166720</BitOffs>
+            <BitOffs>676166400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -67523,7 +67523,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174656</BitOffs>
+            <BitOffs>676174336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -67546,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174664</BitOffs>
+            <BitOffs>676174344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -67569,7 +67569,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174672</BitOffs>
+            <BitOffs>676174352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -67592,7 +67592,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174688</BitOffs>
+            <BitOffs>676174368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -67605,7 +67605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174720</BitOffs>
+            <BitOffs>676174400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -67618,7 +67618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174784</BitOffs>
+            <BitOffs>676174464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -67631,7 +67631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676174800</BitOffs>
+            <BitOffs>676174480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -67643,7 +67643,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676191936</BitOffs>
+            <BitOffs>676191616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -67666,7 +67666,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676199872</BitOffs>
+            <BitOffs>676199552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -67689,7 +67689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676199880</BitOffs>
+            <BitOffs>676199560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -67712,7 +67712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676199888</BitOffs>
+            <BitOffs>676199568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -67735,7 +67735,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676199904</BitOffs>
+            <BitOffs>676199584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -67748,7 +67748,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676199936</BitOffs>
+            <BitOffs>676199616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -67761,7 +67761,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676200000</BitOffs>
+            <BitOffs>676199680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -67774,7 +67774,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676200016</BitOffs>
+            <BitOffs>676199696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -67786,7 +67786,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676217152</BitOffs>
+            <BitOffs>676216832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -67809,7 +67809,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225088</BitOffs>
+            <BitOffs>676224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -67832,7 +67832,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225096</BitOffs>
+            <BitOffs>676224776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -67855,7 +67855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225104</BitOffs>
+            <BitOffs>676224784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -67878,7 +67878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225120</BitOffs>
+            <BitOffs>676224800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -67891,7 +67891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225152</BitOffs>
+            <BitOffs>676224832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -67904,7 +67904,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225216</BitOffs>
+            <BitOffs>676224896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -67917,7 +67917,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676225232</BitOffs>
+            <BitOffs>676224912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -67929,7 +67929,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676242368</BitOffs>
+            <BitOffs>676242048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -67952,7 +67952,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250304</BitOffs>
+            <BitOffs>676249984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -67975,7 +67975,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250312</BitOffs>
+            <BitOffs>676249992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -67998,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250320</BitOffs>
+            <BitOffs>676250000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -68021,7 +68021,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250336</BitOffs>
+            <BitOffs>676250016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -68034,7 +68034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250368</BitOffs>
+            <BitOffs>676250048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -68047,7 +68047,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250432</BitOffs>
+            <BitOffs>676250112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -68060,7 +68060,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676250448</BitOffs>
+            <BitOffs>676250128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -68072,7 +68072,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676267584</BitOffs>
+            <BitOffs>676267264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -68095,7 +68095,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275520</BitOffs>
+            <BitOffs>676275200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -68118,7 +68118,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275528</BitOffs>
+            <BitOffs>676275208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -68141,7 +68141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275536</BitOffs>
+            <BitOffs>676275216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -68164,7 +68164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275552</BitOffs>
+            <BitOffs>676275232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -68177,7 +68177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275584</BitOffs>
+            <BitOffs>676275264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -68190,7 +68190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275648</BitOffs>
+            <BitOffs>676275328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -68203,7 +68203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676275664</BitOffs>
+            <BitOffs>676275344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -68215,7 +68215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676292800</BitOffs>
+            <BitOffs>676292480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -68238,7 +68238,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300736</BitOffs>
+            <BitOffs>676300416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -68261,7 +68261,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300744</BitOffs>
+            <BitOffs>676300424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -68284,7 +68284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300752</BitOffs>
+            <BitOffs>676300432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -68307,7 +68307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300768</BitOffs>
+            <BitOffs>676300448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -68320,7 +68320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300800</BitOffs>
+            <BitOffs>676300480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -68333,7 +68333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300864</BitOffs>
+            <BitOffs>676300544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -68346,7 +68346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676300880</BitOffs>
+            <BitOffs>676300560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -68358,7 +68358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676318016</BitOffs>
+            <BitOffs>676317696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -68381,7 +68381,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676325952</BitOffs>
+            <BitOffs>676325632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -68404,7 +68404,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676325960</BitOffs>
+            <BitOffs>676325640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -68427,7 +68427,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676325968</BitOffs>
+            <BitOffs>676325648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -68450,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676325984</BitOffs>
+            <BitOffs>676325664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -68463,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676326016</BitOffs>
+            <BitOffs>676325696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -68476,7 +68476,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676326080</BitOffs>
+            <BitOffs>676325760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -68489,7 +68489,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676326096</BitOffs>
+            <BitOffs>676325776</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -68507,7 +68507,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639776512</BitOffs>
+            <BitOffs>639776192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -68519,7 +68519,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640746624</BitOffs>
+            <BitOffs>640746304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -68531,7 +68531,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640746640</BitOffs>
+            <BitOffs>640746320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -68544,7 +68544,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640747584</BitOffs>
+            <BitOffs>640747264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68556,7 +68556,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640767040</BitOffs>
+            <BitOffs>640766720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -68568,7 +68568,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642323744</BitOffs>
+            <BitOffs>642323424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -68588,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642323760</BitOffs>
+            <BitOffs>642323440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68601,7 +68601,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642324736</BitOffs>
+            <BitOffs>642324416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68613,7 +68613,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642343232</BitOffs>
+            <BitOffs>642342912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -68625,7 +68625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643899936</BitOffs>
+            <BitOffs>643899616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -68645,7 +68645,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643899952</BitOffs>
+            <BitOffs>643899632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68658,7 +68658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643900928</BitOffs>
+            <BitOffs>643900608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68670,7 +68670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643919424</BitOffs>
+            <BitOffs>643919104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -68682,7 +68682,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645476128</BitOffs>
+            <BitOffs>645475808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -68702,7 +68702,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645476144</BitOffs>
+            <BitOffs>645475824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68715,7 +68715,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645477120</BitOffs>
+            <BitOffs>645476800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68727,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645495616</BitOffs>
+            <BitOffs>645495296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -68739,7 +68739,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647052320</BitOffs>
+            <BitOffs>647052000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -68759,7 +68759,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647052336</BitOffs>
+            <BitOffs>647052016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68772,7 +68772,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647053312</BitOffs>
+            <BitOffs>647052992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68784,7 +68784,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647071808</BitOffs>
+            <BitOffs>647071488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -68796,7 +68796,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648628512</BitOffs>
+            <BitOffs>648628192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -68816,7 +68816,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648628528</BitOffs>
+            <BitOffs>648628208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68829,7 +68829,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648629504</BitOffs>
+            <BitOffs>648629184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68841,7 +68841,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648648448</BitOffs>
+            <BitOffs>648648128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68853,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649653824</BitOffs>
+            <BitOffs>649653504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68865,7 +68865,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649951744</BitOffs>
+            <BitOffs>649951424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68877,7 +68877,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>650964288</BitOffs>
+            <BitOffs>650963968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68889,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651262208</BitOffs>
+            <BitOffs>651261888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68901,7 +68901,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652253056</BitOffs>
+            <BitOffs>652252736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68913,7 +68913,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652550976</BitOffs>
+            <BitOffs>652550656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68925,7 +68925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652848896</BitOffs>
+            <BitOffs>652848576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68937,7 +68937,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653146816</BitOffs>
+            <BitOffs>653146496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -68949,7 +68949,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653593440</BitOffs>
+            <BitOffs>653593120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68961,7 +68961,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653599616</BitOffs>
+            <BitOffs>653599296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68973,7 +68973,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653897536</BitOffs>
+            <BitOffs>653897216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68985,7 +68985,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654195456</BitOffs>
+            <BitOffs>654195136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68997,7 +68997,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654493376</BitOffs>
+            <BitOffs>654493056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -69009,7 +69009,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654940000</BitOffs>
+            <BitOffs>654939680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -69021,7 +69021,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655052592</BitOffs>
+            <BitOffs>655052336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -69033,7 +69033,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655052600</BitOffs>
+            <BitOffs>655052344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69045,7 +69045,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655085312</BitOffs>
+            <BitOffs>655085056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69057,7 +69057,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655383232</BitOffs>
+            <BitOffs>655382976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69069,7 +69069,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656401152</BitOffs>
+            <BitOffs>656400896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69081,7 +69081,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656699072</BitOffs>
+            <BitOffs>656698816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69093,7 +69093,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657689408</BitOffs>
+            <BitOffs>657689152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69105,7 +69105,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657987328</BitOffs>
+            <BitOffs>657987072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69117,7 +69117,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658285248</BitOffs>
+            <BitOffs>658284992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69129,7 +69129,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658583168</BitOffs>
+            <BitOffs>658582912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69141,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658881088</BitOffs>
+            <BitOffs>658880832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69153,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659179008</BitOffs>
+            <BitOffs>659178752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69165,7 +69165,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659476928</BitOffs>
+            <BitOffs>659476672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69177,7 +69177,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659774848</BitOffs>
+            <BitOffs>659774592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69189,7 +69189,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660072768</BitOffs>
+            <BitOffs>660072512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69201,7 +69201,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660370688</BitOffs>
+            <BitOffs>660370432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69213,7 +69213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660668608</BitOffs>
+            <BitOffs>660668352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69225,7 +69225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660966528</BitOffs>
+            <BitOffs>660966272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69237,7 +69237,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661264448</BitOffs>
+            <BitOffs>661264192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -69249,7 +69249,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662827648</BitOffs>
+            <BitOffs>662827392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -69272,7 +69272,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662836632</BitOffs>
+            <BitOffs>662836376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -69284,7 +69284,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662852864</BitOffs>
+            <BitOffs>662852608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -69307,7 +69307,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662861848</BitOffs>
+            <BitOffs>662861592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -69319,7 +69319,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662878080</BitOffs>
+            <BitOffs>662877824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -69342,7 +69342,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662887064</BitOffs>
+            <BitOffs>662886808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -69354,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664589696</BitOffs>
+            <BitOffs>664589376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -69377,7 +69377,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664598680</BitOffs>
+            <BitOffs>664598360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -69389,7 +69389,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664614912</BitOffs>
+            <BitOffs>664614592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -69412,7 +69412,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664623896</BitOffs>
+            <BitOffs>664623576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -69424,7 +69424,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664640128</BitOffs>
+            <BitOffs>664639808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -69447,7 +69447,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664649112</BitOffs>
+            <BitOffs>664648792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -69466,7 +69466,26 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665030968</BitOffs>
+            <BitOffs>664829176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>665030688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -69482,7 +69501,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665033536</BitOffs>
+            <BitOffs>665033280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -69502,7 +69521,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671939016</BitOffs>
+            <BitOffs>671938760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -69522,26 +69541,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673585928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675232576</BitOffs>
+            <BitOffs>673585672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -69553,7 +69553,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675232704</BitOffs>
+            <BitOffs>675232384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -69576,7 +69576,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675241688</BitOffs>
+            <BitOffs>675241368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -69588,7 +69588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675257920</BitOffs>
+            <BitOffs>675257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -69611,7 +69611,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675266904</BitOffs>
+            <BitOffs>675266584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -69623,7 +69623,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675283136</BitOffs>
+            <BitOffs>675282816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -69646,7 +69646,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675292120</BitOffs>
+            <BitOffs>675291800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -69658,7 +69658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675308352</BitOffs>
+            <BitOffs>675308032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -69681,7 +69681,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675317336</BitOffs>
+            <BitOffs>675317016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -69693,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675333568</BitOffs>
+            <BitOffs>675333248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -69716,7 +69716,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675342552</BitOffs>
+            <BitOffs>675342232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -69728,7 +69728,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675358784</BitOffs>
+            <BitOffs>675358464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -69751,7 +69751,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675367768</BitOffs>
+            <BitOffs>675367448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -69763,7 +69763,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675384000</BitOffs>
+            <BitOffs>675383680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -69786,7 +69786,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675392984</BitOffs>
+            <BitOffs>675392664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -69798,7 +69798,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675409216</BitOffs>
+            <BitOffs>675408896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -69821,7 +69821,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675418200</BitOffs>
+            <BitOffs>675417880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -69833,7 +69833,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675434432</BitOffs>
+            <BitOffs>675434112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -69856,7 +69856,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675443416</BitOffs>
+            <BitOffs>675443096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -69868,7 +69868,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675459648</BitOffs>
+            <BitOffs>675459328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -69891,7 +69891,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675468632</BitOffs>
+            <BitOffs>675468312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -69903,7 +69903,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675484864</BitOffs>
+            <BitOffs>675484544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -69926,7 +69926,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675493848</BitOffs>
+            <BitOffs>675493528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -69938,7 +69938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675510080</BitOffs>
+            <BitOffs>675509760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -69961,7 +69961,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675519064</BitOffs>
+            <BitOffs>675518744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -69973,7 +69973,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675535296</BitOffs>
+            <BitOffs>675534976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -69996,7 +69996,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675544280</BitOffs>
+            <BitOffs>675543960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -70008,7 +70008,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675560512</BitOffs>
+            <BitOffs>675560192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -70031,7 +70031,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675569496</BitOffs>
+            <BitOffs>675569176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -70043,7 +70043,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675585728</BitOffs>
+            <BitOffs>675585408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -70066,7 +70066,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675594712</BitOffs>
+            <BitOffs>675594392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -70078,7 +70078,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675610944</BitOffs>
+            <BitOffs>675610624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -70101,7 +70101,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675619928</BitOffs>
+            <BitOffs>675619608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -70113,7 +70113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675636160</BitOffs>
+            <BitOffs>675635840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -70136,7 +70136,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675645144</BitOffs>
+            <BitOffs>675644824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -70148,7 +70148,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675661376</BitOffs>
+            <BitOffs>675661056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -70171,7 +70171,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675670360</BitOffs>
+            <BitOffs>675670040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -70183,7 +70183,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675686592</BitOffs>
+            <BitOffs>675686272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -70206,7 +70206,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675695576</BitOffs>
+            <BitOffs>675695256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -70218,7 +70218,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675711808</BitOffs>
+            <BitOffs>675711488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -70241,7 +70241,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675720792</BitOffs>
+            <BitOffs>675720472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -70253,7 +70253,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675737024</BitOffs>
+            <BitOffs>675736704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -70276,7 +70276,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675746008</BitOffs>
+            <BitOffs>675745688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -70288,7 +70288,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675762240</BitOffs>
+            <BitOffs>675761920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -70311,7 +70311,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675771224</BitOffs>
+            <BitOffs>675770904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -70323,7 +70323,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675787456</BitOffs>
+            <BitOffs>675787136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -70346,7 +70346,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675796440</BitOffs>
+            <BitOffs>675796120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -70358,7 +70358,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675812672</BitOffs>
+            <BitOffs>675812352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -70381,7 +70381,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675821656</BitOffs>
+            <BitOffs>675821336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -70393,7 +70393,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675837888</BitOffs>
+            <BitOffs>675837568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -70416,7 +70416,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675846872</BitOffs>
+            <BitOffs>675846552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -70428,7 +70428,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675863104</BitOffs>
+            <BitOffs>675862784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -70451,7 +70451,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675872088</BitOffs>
+            <BitOffs>675871768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -70463,7 +70463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675888320</BitOffs>
+            <BitOffs>675888000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -70486,7 +70486,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675897304</BitOffs>
+            <BitOffs>675896984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -70498,7 +70498,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675913536</BitOffs>
+            <BitOffs>675913216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -70521,7 +70521,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675922520</BitOffs>
+            <BitOffs>675922200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -70533,7 +70533,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675938752</BitOffs>
+            <BitOffs>675938432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -70556,7 +70556,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675947736</BitOffs>
+            <BitOffs>675947416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -70568,7 +70568,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675963968</BitOffs>
+            <BitOffs>675963648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -70591,7 +70591,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675972952</BitOffs>
+            <BitOffs>675972632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -70603,7 +70603,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675989184</BitOffs>
+            <BitOffs>675988864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -70626,7 +70626,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675998168</BitOffs>
+            <BitOffs>675997848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -70638,7 +70638,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676014400</BitOffs>
+            <BitOffs>676014080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -70661,7 +70661,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676023384</BitOffs>
+            <BitOffs>676023064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -70673,7 +70673,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676039616</BitOffs>
+            <BitOffs>676039296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -70696,7 +70696,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676048600</BitOffs>
+            <BitOffs>676048280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -70708,7 +70708,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676064832</BitOffs>
+            <BitOffs>676064512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -70731,7 +70731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676073816</BitOffs>
+            <BitOffs>676073496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -70743,7 +70743,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676090048</BitOffs>
+            <BitOffs>676089728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -70766,7 +70766,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676099032</BitOffs>
+            <BitOffs>676098712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -70778,7 +70778,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676115264</BitOffs>
+            <BitOffs>676114944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -70801,7 +70801,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676124248</BitOffs>
+            <BitOffs>676123928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -70813,7 +70813,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676140480</BitOffs>
+            <BitOffs>676140160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -70836,7 +70836,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676149464</BitOffs>
+            <BitOffs>676149144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -70848,7 +70848,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676165696</BitOffs>
+            <BitOffs>676165376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -70871,7 +70871,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676174680</BitOffs>
+            <BitOffs>676174360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -70883,7 +70883,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676190912</BitOffs>
+            <BitOffs>676190592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -70906,7 +70906,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676199896</BitOffs>
+            <BitOffs>676199576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -70918,7 +70918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676216128</BitOffs>
+            <BitOffs>676215808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -70941,7 +70941,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676225112</BitOffs>
+            <BitOffs>676224792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -70953,7 +70953,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676241344</BitOffs>
+            <BitOffs>676241024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -70976,7 +70976,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676250328</BitOffs>
+            <BitOffs>676250008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -70988,7 +70988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676266560</BitOffs>
+            <BitOffs>676266240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -71011,7 +71011,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676275544</BitOffs>
+            <BitOffs>676275224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -71023,7 +71023,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676291776</BitOffs>
+            <BitOffs>676291456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -71046,7 +71046,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676300760</BitOffs>
+            <BitOffs>676300440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -71058,7 +71058,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676316992</BitOffs>
+            <BitOffs>676316672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -71081,7 +71081,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676325976</BitOffs>
+            <BitOffs>676325656</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -76398,73 +76398,6 @@ Digital outputs</Comment>
             <BitOffs>8538368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Version.stLibVersion_lcls2_cc_lib_nrw</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8538656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.fbPmpsFileReader</Name>
-            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
-            <BitSize>928128</BitSize>
-            <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8538944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
-            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
-            <BitSize>27744</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)DB
-        io: io
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9467072</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>MOTION_GVL.nMaxStates</Name>
             <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
             <BitSize>16</BitSize>
@@ -76474,7 +76407,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494816</BitOffs>
+            <BitOffs>8538656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MotionConstants.MAX_STATE_MOTORS</Name>
@@ -76493,7 +76426,38 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494832</BitOffs>
+            <BitOffs>8538672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbPmpsFileReader</Name>
+            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
+            <BitSize>928128</BitSize>
+            <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8538688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
+            <BitSize>27744</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)DB
+        io: io
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9466816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -76513,7 +76477,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494848</BitOffs>
+            <BitOffs>9494560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -76533,7 +76497,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9496608</BitOffs>
+            <BitOffs>9496320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -76558,7 +76522,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9498368</BitOffs>
+            <BitOffs>9498080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -76570,7 +76534,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499392</BitOffs>
+            <BitOffs>9499104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -76585,35 +76549,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9499456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9499520</BitOffs>
+            <BitOffs>9499136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -76627,7 +76563,35 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499584</BitOffs>
+            <BitOffs>9499168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9499200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9499264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -76642,7 +76606,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499616</BitOffs>
+            <BitOffs>9499328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
@@ -76657,7 +76621,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499648</BitOffs>
+            <BitOffs>9499360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -76671,7 +76635,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499664</BitOffs>
+            <BitOffs>9499376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stAttenuators</Name>
@@ -76692,7 +76656,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499680</BitOffs>
+            <BitOffs>9499392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cstFullBeam</Name>
@@ -76712,7 +76676,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499744</BitOffs>
+            <BitOffs>9499456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cst0RateBeam</Name>
@@ -76732,7 +76696,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9501504</BitOffs>
+            <BitOffs>9501216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -76757,7 +76721,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503264</BitOffs>
+            <BitOffs>9502976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -76772,7 +76736,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503280</BitOffs>
+            <BitOffs>9502992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -76791,7 +76755,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503296</BitOffs>
+            <BitOffs>9503008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
@@ -76805,7 +76769,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504320</BitOffs>
+            <BitOffs>9504032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
@@ -76820,7 +76784,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504336</BitOffs>
+            <BitOffs>9504048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -76847,7 +76811,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504352</BitOffs>
+            <BitOffs>9504064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -77002,7 +76966,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504384</BitOffs>
+            <BitOffs>9504096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -77157,7 +77121,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9505408</BitOffs>
+            <BitOffs>9505120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -77172,7 +77136,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506432</BitOffs>
+            <BitOffs>9506144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -77187,7 +77151,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506464</BitOffs>
+            <BitOffs>9506176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -77198,7 +77162,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506496</BitOffs>
+            <BitOffs>9506208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
@@ -77212,7 +77176,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506752</BitOffs>
+            <BitOffs>9506464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -77226,7 +77190,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506768</BitOffs>
+            <BitOffs>9506480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -77240,7 +77204,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506784</BitOffs>
+            <BitOffs>9506496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -77267,7 +77231,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506800</BitOffs>
+            <BitOffs>9506512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -77282,7 +77246,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506808</BitOffs>
+            <BitOffs>9506520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -77297,7 +77261,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506816</BitOffs>
+            <BitOffs>9506528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -77312,7 +77276,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506848</BitOffs>
+            <BitOffs>9506560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -77330,7 +77294,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508896</BitOffs>
+            <BitOffs>9508608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -77342,7 +77306,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508912</BitOffs>
+            <BitOffs>9508624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -77354,7 +77318,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508920</BitOffs>
+            <BitOffs>9508632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -77370,7 +77334,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508928</BitOffs>
+            <BitOffs>9508640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
@@ -77381,7 +77345,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508960</BitOffs>
+            <BitOffs>9508672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -77393,7 +77357,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631336160</BitOffs>
+            <BitOffs>631335872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -77405,7 +77369,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631336192</BitOffs>
+            <BitOffs>631335904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -77419,7 +77383,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631338240</BitOffs>
+            <BitOffs>631337952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
@@ -77430,7 +77394,7 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>631338248</BitOffs>
+            <BitOffs>631337960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -77446,7 +77410,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631338256</BitOffs>
+            <BitOffs>631337968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -77461,7 +77425,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631338272</BitOffs>
+            <BitOffs>631337984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -77487,7 +77451,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631370272</BitOffs>
+            <BitOffs>631369984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -77499,7 +77463,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631386272</BitOffs>
+            <BitOffs>631385984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -77535,7 +77499,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707136</BitOffs>
+            <BitOffs>639706848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -77571,7 +77535,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707424</BitOffs>
+            <BitOffs>639707136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -77582,7 +77546,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707712</BitOffs>
+            <BitOffs>639707424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -77596,7 +77560,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714688</BitOffs>
+            <BitOffs>639714432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -77610,7 +77574,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714752</BitOffs>
+            <BitOffs>639714496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -77646,67 +77610,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>639766240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>639766248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <BitOffs>639766256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL2K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>639766264</BitOffs>
+            <BitOffs>639714560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
@@ -77726,17 +77630,67 @@ Digital outputs</Comment>
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
               </Property>
             </Properties>
-            <BitOffs>639766272</BitOffs>
+            <BitOffs>639765952</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>-15</Value>
+              <Value>0</Value>
             </Default>
-            <BitOffs>640749408</BitOffs>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>640749088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>640749096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <BitOffs>640749104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL2K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>640749112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
@@ -77765,7 +77719,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw := TIIB[IM2K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>640749440</BitOffs>
+            <BitOffs>640749120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fStartupVelo</Name>
@@ -77774,7 +77728,7 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>642325568</BitOffs>
+            <BitOffs>642325248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
@@ -77800,10 +77754,11 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>642325632</BitOffs>
+            <BitOffs>642325312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fStartupVelo</Name>
@@ -77812,7 +77767,7 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>643901760</BitOffs>
+            <BitOffs>643901440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
@@ -77842,7 +77797,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>643901824</BitOffs>
+            <BitOffs>643901504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fStartupVelo</Name>
@@ -77851,7 +77806,7 @@ Digital outputs</Comment>
             <Default>
               <Value>15</Value>
             </Default>
-            <BitOffs>645477952</BitOffs>
+            <BitOffs>645477632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
@@ -77877,10 +77832,11 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>645478016</BitOffs>
+            <BitOffs>645477696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fStartupVelo</Name>
@@ -77889,7 +77845,7 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>647054144</BitOffs>
+            <BitOffs>647053824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
@@ -77915,10 +77871,11 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>647054208</BitOffs>
+            <BitOffs>647053888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fStartupVelo</Name>
@@ -77927,17 +77884,17 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>648630336</BitOffs>
+            <BitOffs>648630016</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>648630880</BitOffs>
+            <BitOffs>648630560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
@@ -77952,23 +77909,23 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>648630912</BitOffs>
+            <BitOffs>648630592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>649626496</BitOffs>
+            <BitOffs>649626176</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>649628896</BitOffs>
+            <BitOffs>649628576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
@@ -77994,23 +77951,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649628928</BitOffs>
+            <BitOffs>649628608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>650937600</BitOffs>
+            <BitOffs>650937280</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>650939360</BitOffs>
+            <BitOffs>650939040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -78036,28 +77993,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>650939392</BitOffs>
+            <BitOffs>650939072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>652248064</BitOffs>
+            <BitOffs>652247744</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
             <Default>
-              <Value>0</Value>
+              <Value>-15</Value>
             </Default>
-            <BitOffs>652250464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>652250472</BitOffs>
+            <BitOffs>652250144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -78072,7 +78024,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>652250496</BitOffs>
+            <BitOffs>652250176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -78083,7 +78035,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>653593664</BitOffs>
+            <BitOffs>653593344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -78098,7 +78050,32 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653597056</BitOffs>
+            <BitOffs>653596736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>654939904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>654939912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>654939936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -78109,17 +78086,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>654940224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>654943296</BitOffs>
+            <BitOffs>654939968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -78129,7 +78096,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654943328</BitOffs>
+            <BitOffs>654943040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -78139,7 +78106,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654943360</BitOffs>
+            <BitOffs>654943072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -78149,7 +78116,13 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654943392</BitOffs>
+            <BitOffs>654943104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL1HighCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>654943408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -78168,13 +78141,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654943680</BitOffs>
+            <BitOffs>654943424</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.nTL1HighCycles</Name>
+            <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>655053104</BitOffs>
+            <BitOffs>655052832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -78196,13 +78169,19 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>655053120</BitOffs>
+            <BitOffs>655052864</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.nTL1LowCycles</Name>
+            <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>656376224</BitOffs>
+            <BitOffs>656375968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL2LowCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>656375984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -78224,97 +78203,85 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>656376256</BitOffs>
+            <BitOffs>656376000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657687936</BitOffs>
+            <BitOffs>657687680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657985856</BitOffs>
+            <BitOffs>657985600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658283776</BitOffs>
+            <BitOffs>658283520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658581696</BitOffs>
+            <BitOffs>658581440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658879616</BitOffs>
+            <BitOffs>658879360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659177536</BitOffs>
+            <BitOffs>659177280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659475456</BitOffs>
+            <BitOffs>659475200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659773376</BitOffs>
+            <BitOffs>659773120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660071296</BitOffs>
+            <BitOffs>660071040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660369216</BitOffs>
+            <BitOffs>660368960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660667136</BitOffs>
+            <BitOffs>660666880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660965056</BitOffs>
+            <BitOffs>660964800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>661262976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL2HighCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>661560896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL2LowCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>661560912</BitOffs>
+            <BitOffs>661262720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -78323,7 +78290,7 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>661560928</BitOffs>
+            <BitOffs>661560640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -78332,29 +78299,14 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>661560944</BitOffs>
+            <BitOffs>661560656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>661560952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.fbZPStates</Name>
-            <Comment>/ZP states start</Comment>
-            <BitSize>1506432</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>661560960</BitOffs>
+            <BitOffs>661560664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -78369,7 +78321,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663067392</BitOffs>
+            <BitOffs>661560672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -78384,43 +78336,28 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663067408</BitOffs>
+            <BitOffs>661560688</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.att_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Name>PRG_SP1K4.fbZPStates</Name>
+            <Comment>/ZP states start</Comment>
+            <BitSize>1506432</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: SP1K4:ATT:STATE:SET
-        io: io
+        pv: SP1K4:FZP
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663067424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>663067440</BitOffs>
+            <BitOffs>661560704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>663067456</BitOffs>
+            <BitOffs>663067136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -78444,7 +78381,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>663155264</BitOffs>
+            <BitOffs>663154944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -78454,7 +78391,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663158912</BitOffs>
+            <BitOffs>663158592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -78464,7 +78401,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663213632</BitOffs>
+            <BitOffs>663213312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -78474,7 +78411,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663268352</BitOffs>
+            <BitOffs>663268032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -78489,13 +78426,61 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663323072</BitOffs>
+            <BitOffs>663322752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>664829120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>664829136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>664829152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>664829160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>664829168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>664829440</BitOffs>
+            <BitOffs>664829184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -78519,7 +78504,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>664917248</BitOffs>
+            <BitOffs>664916992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -78529,7 +78514,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>664920896</BitOffs>
+            <BitOffs>664920640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -78539,43 +78524,55 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>664975616</BitOffs>
+            <BitOffs>664975360</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support an FPU</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>665030944</BitOffs>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>665030704</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support an FPU</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>665030952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>665030960</BitOffs>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>665030712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>665030976</BitOffs>
+            <BitOffs>665030720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>665169344</BitOffs>
+            <BitOffs>665169088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>665200192</BitOffs>
+            <BitOffs>665199936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -78594,7 +78591,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>670991808</BitOffs>
+            <BitOffs>670991552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -78613,7 +78610,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671465280</BitOffs>
+            <BitOffs>671465024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -78643,7 +78640,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671938752</BitOffs>
+            <BitOffs>671938496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -78673,67 +78670,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673585664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675232592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675232600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675232608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675232624</BitOffs>
+            <BitOffs>673585408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -78762,7 +78699,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675232640</BitOffs>
+            <BitOffs>675232320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -78774,7 +78711,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675257856</BitOffs>
+            <BitOffs>675257536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -78785,7 +78722,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675283072</BitOffs>
+            <BitOffs>675282752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -78796,7 +78733,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675308288</BitOffs>
+            <BitOffs>675307968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -78807,7 +78744,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675333504</BitOffs>
+            <BitOffs>675333184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -78818,7 +78755,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675358720</BitOffs>
+            <BitOffs>675358400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -78829,7 +78766,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675383936</BitOffs>
+            <BitOffs>675383616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -78840,7 +78777,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675409152</BitOffs>
+            <BitOffs>675408832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -78869,7 +78806,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675434368</BitOffs>
+            <BitOffs>675434048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -78897,7 +78834,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675459584</BitOffs>
+            <BitOffs>675459264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -78924,7 +78861,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675484800</BitOffs>
+            <BitOffs>675484480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -78951,7 +78888,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675510016</BitOffs>
+            <BitOffs>675509696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -78978,7 +78915,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675535232</BitOffs>
+            <BitOffs>675534912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -78990,7 +78927,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675560448</BitOffs>
+            <BitOffs>675560128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -79019,7 +78956,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675585664</BitOffs>
+            <BitOffs>675585344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -79048,7 +78985,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675610880</BitOffs>
+            <BitOffs>675610560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -79077,7 +79014,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675636096</BitOffs>
+            <BitOffs>675635776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -79106,7 +79043,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675661312</BitOffs>
+            <BitOffs>675660992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -79131,7 +79068,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675686528</BitOffs>
+            <BitOffs>675686208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -79160,7 +79097,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675711744</BitOffs>
+            <BitOffs>675711424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -79189,7 +79126,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675736960</BitOffs>
+            <BitOffs>675736640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -79214,7 +79151,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675762176</BitOffs>
+            <BitOffs>675761856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -79242,7 +79179,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675787392</BitOffs>
+            <BitOffs>675787072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -79269,7 +79206,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675812608</BitOffs>
+            <BitOffs>675812288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -79296,7 +79233,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675837824</BitOffs>
+            <BitOffs>675837504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -79323,7 +79260,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675863040</BitOffs>
+            <BitOffs>675862720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -79352,7 +79289,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675888256</BitOffs>
+            <BitOffs>675887936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -79381,7 +79318,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675913472</BitOffs>
+            <BitOffs>675913152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -79406,7 +79343,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675938688</BitOffs>
+            <BitOffs>675938368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -79435,7 +79372,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675963904</BitOffs>
+            <BitOffs>675963584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -79460,7 +79397,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675989120</BitOffs>
+            <BitOffs>675988800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -79497,7 +79434,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676014336</BitOffs>
+            <BitOffs>676014016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -79542,7 +79479,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676039552</BitOffs>
+            <BitOffs>676039232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -79583,7 +79520,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676064768</BitOffs>
+            <BitOffs>676064448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -79624,7 +79561,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676089984</BitOffs>
+            <BitOffs>676089664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -79665,7 +79602,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676115200</BitOffs>
+            <BitOffs>676114880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -79706,7 +79643,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676140416</BitOffs>
+            <BitOffs>676140096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -79747,7 +79684,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676165632</BitOffs>
+            <BitOffs>676165312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -79788,7 +79725,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676190848</BitOffs>
+            <BitOffs>676190528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -79829,7 +79766,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676216064</BitOffs>
+            <BitOffs>676215744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -79865,7 +79802,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676241280</BitOffs>
+            <BitOffs>676240960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -79901,7 +79838,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676266496</BitOffs>
+            <BitOffs>676266176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -79937,7 +79874,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676291712</BitOffs>
+            <BitOffs>676291392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -79982,7 +79919,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676316928</BitOffs>
+            <BitOffs>676316608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -80012,7 +79949,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342144</BitOffs>
+            <BitOffs>676341824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -80042,7 +79979,37 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342208</BitOffs>
+            <BitOffs>676341888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>676341952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>676341968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -80056,7 +80023,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342272</BitOffs>
+            <BitOffs>676341984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -80070,7 +80037,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342304</BitOffs>
+            <BitOffs>676342016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -80084,7 +80051,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342336</BitOffs>
+            <BitOffs>676342048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -80098,21 +80065,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>676344416</BitOffs>
+            <BitOffs>676342080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -80130,7 +80083,21 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676344448</BitOffs>
+            <BitOffs>676344128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>676345152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -80144,7 +80111,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676345472</BitOffs>
+            <BitOffs>676345184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -80165,7 +80132,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676345504</BitOffs>
+            <BitOffs>676345216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -80234,7 +80201,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676358880</BitOffs>
+            <BitOffs>676358592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -80303,7 +80270,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676359008</BitOffs>
+            <BitOffs>676358720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -80372,7 +80339,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676359136</BitOffs>
+            <BitOffs>676358848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -80441,7 +80408,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676359264</BitOffs>
+            <BitOffs>676358976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -80510,7 +80477,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676359392</BitOffs>
+            <BitOffs>676359104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -80579,7 +80546,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676359520</BitOffs>
+            <BitOffs>676359232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -80602,7 +80569,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676389856</BitOffs>
+            <BitOffs>676389568</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -80689,7 +80656,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-21T16:31:22</Value>
+          <Value>2023-08-22T09:38:39</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{019B9B34-B5E0-94EB-1305-41F0A47AF844}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FD0E8A9B-CCC0-123B-9666-164D017FD4BA}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84563784</GetCodeOffs>
+        <GetCodeOffs>84564192</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84563816</GetCodeOffs>
+        <GetCodeOffs>84564224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563824</GetCodeOffs>
+        <GetCodeOffs>84564232</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563808</GetCodeOffs>
+        <GetCodeOffs>84564216</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563820</GetCodeOffs>
+        <GetCodeOffs>84564228</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563728</GetCodeOffs>
-        <SetCodeOffs>84563752</SetCodeOffs>
+        <GetCodeOffs>84564136</GetCodeOffs>
+        <SetCodeOffs>84564160</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563764</GetCodeOffs>
-        <SetCodeOffs>84563776</SetCodeOffs>
+        <GetCodeOffs>84564172</GetCodeOffs>
+        <SetCodeOffs>84564184</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>84563872</GetCodeOffs>
+        <GetCodeOffs>84564280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563852</GetCodeOffs>
+        <GetCodeOffs>84564260</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563940</GetCodeOffs>
+        <GetCodeOffs>84564348</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563900</GetCodeOffs>
+        <GetCodeOffs>84564308</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563944</GetCodeOffs>
+        <GetCodeOffs>84564352</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84563968</GetCodeOffs>
+        <GetCodeOffs>84564376</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -43109,7 +43109,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">FB_AnalogInput</Name>
-      <BitSize>320</BitSize>
+      <BitSize>448</BitSize>
       <SubItem>
         <Name>iRaw</Name>
         <Type>INT</Type>
@@ -43167,15 +43167,64 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>fResolution</Name>
+        <Type>LREAL</Type>
+        <Comment> Value to scale the end result to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RES
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fOffset</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: OFF
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>fReal</Name>
         <Type>LREAL</Type>
         <Comment> The real value read from the output</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
+        <BitOffs>320</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
             <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: VAL
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -43183,7 +43232,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fScale</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
+        <BitOffs>384</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -43305,7 +43354,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls2_cc_lib">FB_REF_Laser</Name>
-      <BitSize>1088</BitSize>
+      <BitSize>1216</BitSize>
       <SubItem>
         <Name>bShutdown</Name>
         <Type>BOOL</Type>
@@ -43364,14 +43413,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGetLasPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>320</BitSize>
+        <BitSize>448</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetLasPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogOutput</Type>
         <BitSize>576</BitSize>
-        <BitOffs>512</BitOffs>
+        <BitOffs>640</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -43382,7 +43431,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls2_cc_lib">FB_REF</Name>
-      <BitSize>981568</BitSize>
+      <BitSize>981696</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -43491,7 +43540,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbLaser</Name>
         <Type Namespace="lcls2_cc_lib">FB_REF_Laser</Type>
-        <BitSize>1088</BitSize>
+        <BitSize>1216</BitSize>
         <BitOffs>980224</BitOffs>
         <Properties>
           <Property>
@@ -43507,13 +43556,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>981312</BitOffs>
+        <BitOffs>981440</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bStatesLock</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>981320</BitOffs>
+        <BitOffs>981448</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -43522,7 +43571,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fVelo</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>981376</BitOffs>
+        <BitOffs>981504</BitOffs>
         <Default>
           <Value>10</Value>
         </Default>
@@ -43531,7 +43580,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>981440</BitOffs>
+        <BitOffs>981568</BitOffs>
         <Default>
           <Value>10</Value>
         </Default>
@@ -43540,7 +43589,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fDelta</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>981504</BitOffs>
+        <BitOffs>981632</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -44149,7 +44198,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls2_cc_lib">FB_PPM_PowerMeter</Name>
-      <BitSize>578496</BitSize>
+      <BitSize>578624</BitSize>
       <SubItem>
         <Name>iVoltageINT</Name>
         <Type>INT</Type>
@@ -44331,26 +44380,26 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGetPMVoltage</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>320</BitSize>
+        <BitSize>448</BitSize>
         <BitOffs>192640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbVoltageBuffer</Name>
         <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <BitSize>128512</BitSize>
-        <BitOffs>192960</BitOffs>
+        <BitOffs>193088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbCalibBaseBuffer</Name>
         <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <BitSize>128512</BitSize>
-        <BitOffs>321472</BitOffs>
+        <BitOffs>321600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbCalibMJBuffer</Name>
         <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <BitSize>128512</BitSize>
-        <BitOffs>449984</BitOffs>
+        <BitOffs>450112</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -44361,7 +44410,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls2_cc_lib">FB_PPM_Gige</Name>
-      <BitSize>1088</BitSize>
+      <BitSize>1216</BitSize>
       <SubItem>
         <Name>iIlluminatorINT</Name>
         <Type>INT</Type>
@@ -44412,20 +44461,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGetIllPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>320</BitSize>
+        <BitSize>448</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetIllPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogOutput</Type>
         <BitSize>576</BitSize>
-        <BitOffs>448</BitOffs>
+        <BitOffs>576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bGigeInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1152</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -44438,52 +44487,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_L2SI_Flowmeter</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>fRaw</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MA
-        io: input
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fFlowRate</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: FLOW
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls2_cc_lib">FB_PPM</Name>
-      <BitSize>1575488</BitSize>
+      <BitSize>1576128</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -44593,16 +44598,28 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>fFlowOffset</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>16064</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>fbYStage</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
         <BitSize>297920</BitSize>
-        <BitOffs>16064</BitOffs>
+        <BitOffs>16128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbStates</Name>
         <Type Namespace="lcls2_cc_lib">FB_PPM_States</Type>
         <BitSize>681600</BitSize>
-        <BitOffs>313984</BitOffs>
+        <BitOffs>314048</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -44616,8 +44633,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbPowerMeter</Name>
         <Type Namespace="lcls2_cc_lib">FB_PPM_PowerMeter</Type>
-        <BitSize>578496</BitSize>
-        <BitOffs>995584</BitOffs>
+        <BitSize>578624</BitSize>
+        <BitOffs>995648</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -44630,8 +44647,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGige</Name>
         <Type Namespace="lcls2_cc_lib">FB_PPM_Gige</Type>
-        <BitSize>1088</BitSize>
-        <BitOffs>1574080</BitOffs>
+        <BitSize>1216</BitSize>
+        <BitOffs>1574272</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -44643,14 +44660,32 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>fbFlowMeter</Name>
-        <Type Namespace="lcls2_cc_lib">FB_L2SI_Flowmeter</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1575168</BitOffs>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>1575488</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.iTermBits</Name>
+            <Value>12</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMax</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMin</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fResolution</Name>
+            <Value>0.1</Value>
+          </SubItem>
+        </Default>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: SFM
+        pv: FWM
     </Value>
           </Property>
         </Properties>
@@ -44659,7 +44694,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbYagThermoCouple</Name>
         <Type Namespace="LCLS_General">FB_ThermoCouple</Type>
         <BitSize>192</BitSize>
-        <BitOffs>1575296</BitOffs>
+        <BitOffs>1575936</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -54039,8 +54074,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84570552</GetCodeOffs>
-        <SetCodeOffs>84570560</SetCodeOffs>
+        <GetCodeOffs>84570940</GetCodeOffs>
+        <SetCodeOffs>84570948</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -54841,9 +54876,9 @@ Digital outputs</Comment>
         <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
         <Comment>Message or Alarm{Cleared,Confirmed,Raised} event information
 
-		Note that elements here do not follow the usual Hungarian notation / 
-		variable-type-prefixing naming convention due to the member names being
-		used directly in the generation of the JSON document.</Comment>
+        Note that elements here do not follow the usual Hungarian notation / 
+        variable-type-prefixing naming convention due to the member names being
+        used directly in the generation of the JSON document.</Comment>
         <BitSize>648</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
@@ -54853,8 +54888,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Schema
-		io: i
-		field: DESC Schema string</Value>
+        io: i
+        field: DESC Schema string</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54867,8 +54902,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Timestamp 
-		io: i
-		field: DESC Unix timestamp</Value>
+        io: i
+        field: DESC Unix timestamp</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54881,8 +54916,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Hostname 
-		io: i
-		field: DESC PLC Hostname</Value>
+        io: i
+        field: DESC PLC Hostname</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54895,12 +54930,12 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Severity
-		io: i
-		field: DESC TcEventSeverity	
-		field: ZRST Verbose
-		field: ONST Info
-		field: TWST Warning
-		field: THST Error</Value>
+        io: i
+        field: DESC TcEventSeverity	
+        field: ZRST Verbose
+        field: ONST Info
+        field: TWST Warning
+        field: THST Error</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54913,8 +54948,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: MessageID
-		io: i
-		field: DESC TwinCAT Message ID</Value>
+        io: i
+        field: DESC TwinCAT Message ID</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54927,8 +54962,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: EventClass
-		io: i
-		field: DESC TwinCAT Event class</Value>
+        io: i
+        field: DESC TwinCAT Event class</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54941,7 +54976,7 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Message
-		io: i</Value>
+        io: i</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54956,7 +54991,7 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Source
-		io: i</Value>
+        io: i</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54971,8 +55006,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: EventType
-		io: i
-		field: DESC The event type</Value>
+        io: i
+        field: DESC The event type</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -54985,8 +55020,8 @@ Digital outputs</Comment>
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: MessageJSON
-		io: i
-		field: DESC Metadata with the message</Value>
+        io: i
+        field: DESC Metadata with the message</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -55334,31 +55369,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84570120</GetCodeOffs>
+        <GetCodeOffs>84570508</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84570152</GetCodeOffs>
+        <GetCodeOffs>84570540</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84570156</GetCodeOffs>
+        <GetCodeOffs>84570544</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84570144</GetCodeOffs>
+        <GetCodeOffs>84570532</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84570164</GetCodeOffs>
+        <GetCodeOffs>84570552</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -59503,7 +59538,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639777216</BitOffs>
+            <BitOffs>639777536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -59516,7 +59551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640746400</BitOffs>
+            <BitOffs>640746720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59528,7 +59563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640767680</BitOffs>
+            <BitOffs>640768064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -59540,7 +59575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641744736</BitOffs>
+            <BitOffs>641745120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59559,7 +59594,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937096</BitOffs>
+            <BitOffs>641937480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59571,7 +59606,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937104</BitOffs>
+            <BitOffs>641937488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59583,7 +59618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937112</BitOffs>
+            <BitOffs>641937496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59595,7 +59630,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937120</BitOffs>
+            <BitOffs>641937504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59608,7 +59643,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937376</BitOffs>
+            <BitOffs>641937760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59621,26 +59656,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642323360</BitOffs>
+            <BitOffs>642323872</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324320</BitOffs>
+            <BitOffs>642324960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -59659,7 +59688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324552</BitOffs>
+            <BitOffs>642325512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -59671,7 +59700,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324560</BitOffs>
+            <BitOffs>642325520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -59683,7 +59712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324568</BitOffs>
+            <BitOffs>642325528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -59695,7 +59724,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324576</BitOffs>
+            <BitOffs>642325536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59707,7 +59736,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642343232</BitOffs>
+            <BitOffs>642344256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -59719,7 +59748,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643320288</BitOffs>
+            <BitOffs>643321312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59738,7 +59767,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512648</BitOffs>
+            <BitOffs>643513672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59750,7 +59779,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512656</BitOffs>
+            <BitOffs>643513680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59762,7 +59791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512664</BitOffs>
+            <BitOffs>643513688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59774,7 +59803,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512672</BitOffs>
+            <BitOffs>643513696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59787,7 +59816,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512928</BitOffs>
+            <BitOffs>643513952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59800,26 +59829,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643898912</BitOffs>
+            <BitOffs>643900064</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643899872</BitOffs>
+            <BitOffs>643901152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -59838,7 +59861,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900104</BitOffs>
+            <BitOffs>643901704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -59850,7 +59873,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900112</BitOffs>
+            <BitOffs>643901712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -59862,7 +59885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900120</BitOffs>
+            <BitOffs>643901720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -59874,7 +59897,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900128</BitOffs>
+            <BitOffs>643901728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59886,7 +59909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643918784</BitOffs>
+            <BitOffs>643920448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -59898,7 +59921,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644895840</BitOffs>
+            <BitOffs>644897504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59917,7 +59940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088200</BitOffs>
+            <BitOffs>645089864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59929,7 +59952,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088208</BitOffs>
+            <BitOffs>645089872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59941,7 +59964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088216</BitOffs>
+            <BitOffs>645089880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59953,7 +59976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088224</BitOffs>
+            <BitOffs>645089888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59966,7 +59989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088480</BitOffs>
+            <BitOffs>645090144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59979,26 +60002,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645474464</BitOffs>
+            <BitOffs>645476256</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475424</BitOffs>
+            <BitOffs>645477344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -60017,7 +60034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475656</BitOffs>
+            <BitOffs>645477896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60029,7 +60046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475664</BitOffs>
+            <BitOffs>645477904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -60041,7 +60058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475672</BitOffs>
+            <BitOffs>645477912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -60053,7 +60070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475680</BitOffs>
+            <BitOffs>645477920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60065,7 +60082,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645494336</BitOffs>
+            <BitOffs>645496640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -60077,7 +60094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646471392</BitOffs>
+            <BitOffs>646473696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60096,7 +60113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663752</BitOffs>
+            <BitOffs>646666056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60108,7 +60125,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663760</BitOffs>
+            <BitOffs>646666064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60120,7 +60137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663768</BitOffs>
+            <BitOffs>646666072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60132,7 +60149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663776</BitOffs>
+            <BitOffs>646666080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60145,7 +60162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646664032</BitOffs>
+            <BitOffs>646666336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60158,26 +60175,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647050016</BitOffs>
+            <BitOffs>647052448</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647050976</BitOffs>
+            <BitOffs>647053536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -60196,7 +60207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051208</BitOffs>
+            <BitOffs>647054088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60208,7 +60219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051216</BitOffs>
+            <BitOffs>647054096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -60220,7 +60231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051224</BitOffs>
+            <BitOffs>647054104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -60232,7 +60243,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051232</BitOffs>
+            <BitOffs>647054112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60244,7 +60255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647069888</BitOffs>
+            <BitOffs>647072832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -60256,7 +60267,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648046944</BitOffs>
+            <BitOffs>648049888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60275,7 +60286,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239304</BitOffs>
+            <BitOffs>648242248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60287,7 +60298,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239312</BitOffs>
+            <BitOffs>648242256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60299,7 +60310,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239320</BitOffs>
+            <BitOffs>648242264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60311,7 +60322,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239328</BitOffs>
+            <BitOffs>648242272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60324,7 +60335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239584</BitOffs>
+            <BitOffs>648242528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60337,26 +60348,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648625568</BitOffs>
+            <BitOffs>648628640</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626528</BitOffs>
+            <BitOffs>648629728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -60375,7 +60380,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626760</BitOffs>
+            <BitOffs>648630280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60387,7 +60392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626768</BitOffs>
+            <BitOffs>648630288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -60399,7 +60404,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626776</BitOffs>
+            <BitOffs>648630296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -60411,7 +60416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626784</BitOffs>
+            <BitOffs>648630304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60423,7 +60428,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648645952</BitOffs>
+            <BitOffs>648649472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60435,7 +60440,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649651328</BitOffs>
+            <BitOffs>649654848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60447,7 +60452,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649949248</BitOffs>
+            <BitOffs>649952768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -60471,7 +60476,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933768</BitOffs>
+            <BitOffs>650937288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -60483,7 +60488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933776</BitOffs>
+            <BitOffs>650937296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -60495,7 +60500,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933784</BitOffs>
+            <BitOffs>650937304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -60507,7 +60512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933792</BitOffs>
+            <BitOffs>650937312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -60531,7 +60536,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934024</BitOffs>
+            <BitOffs>650937544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -60543,7 +60548,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934032</BitOffs>
+            <BitOffs>650937552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -60555,7 +60560,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934040</BitOffs>
+            <BitOffs>650937560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -60567,7 +60572,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934048</BitOffs>
+            <BitOffs>650937568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60579,7 +60584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650961792</BitOffs>
+            <BitOffs>650965312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60591,7 +60596,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651259712</BitOffs>
+            <BitOffs>651263232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -60615,7 +60620,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244232</BitOffs>
+            <BitOffs>652247752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -60627,7 +60632,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244240</BitOffs>
+            <BitOffs>652247760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -60639,7 +60644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244248</BitOffs>
+            <BitOffs>652247768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -60651,7 +60656,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244256</BitOffs>
+            <BitOffs>652247776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -60675,7 +60680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244488</BitOffs>
+            <BitOffs>652248008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -60687,7 +60692,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244496</BitOffs>
+            <BitOffs>652248016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -60699,7 +60704,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244504</BitOffs>
+            <BitOffs>652248024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -60711,67 +60716,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>652250560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>652548480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>652846400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>653144320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>653590016</BitOffs>
+            <BitOffs>652248032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -60787,7 +60732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653593584</BitOffs>
+            <BitOffs>652250480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -60803,7 +60748,67 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653593592</BitOffs>
+            <BitOffs>652250488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>652254080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>652552000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>652849920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653147840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653593536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60815,7 +60820,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653597184</BitOffs>
+            <BitOffs>653600640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60827,7 +60832,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653895104</BitOffs>
+            <BitOffs>653898560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60839,7 +60844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654193024</BitOffs>
+            <BitOffs>654196480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60851,7 +60856,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654490944</BitOffs>
+            <BitOffs>654494400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
@@ -60863,7 +60868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654936640</BitOffs>
+            <BitOffs>654940096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -60876,7 +60881,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655049120</BitOffs>
+            <BitOffs>655052576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -60888,7 +60893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655049128</BitOffs>
+            <BitOffs>655052584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1High</Name>
@@ -60904,7 +60909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655049632</BitOffs>
+            <BitOffs>655053088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1Low</Name>
@@ -60920,7 +60925,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655049640</BitOffs>
+            <BitOffs>655053096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60932,7 +60937,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655082880</BitOffs>
+            <BitOffs>655086336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60944,7 +60949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655380800</BitOffs>
+            <BitOffs>655384256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -60968,7 +60973,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372232</BitOffs>
+            <BitOffs>656375688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -60980,7 +60985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372240</BitOffs>
+            <BitOffs>656375696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -60992,7 +60997,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372248</BitOffs>
+            <BitOffs>656375704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -61004,7 +61009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372256</BitOffs>
+            <BitOffs>656375712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2High</Name>
@@ -61020,7 +61025,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372784</BitOffs>
+            <BitOffs>656376240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2Low</Name>
@@ -61036,7 +61041,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372792</BitOffs>
+            <BitOffs>656376248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61048,7 +61053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656398720</BitOffs>
+            <BitOffs>656402176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61060,7 +61065,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656696640</BitOffs>
+            <BitOffs>656700096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -61084,7 +61089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680776</BitOffs>
+            <BitOffs>657684232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -61096,7 +61101,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680784</BitOffs>
+            <BitOffs>657684240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -61108,7 +61113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680792</BitOffs>
+            <BitOffs>657684248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -61120,7 +61125,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680800</BitOffs>
+            <BitOffs>657684256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61132,7 +61137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657686976</BitOffs>
+            <BitOffs>657690432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61144,7 +61149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657984896</BitOffs>
+            <BitOffs>657988352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61156,7 +61161,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658282816</BitOffs>
+            <BitOffs>658286272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61168,7 +61173,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658580736</BitOffs>
+            <BitOffs>658584192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61180,7 +61185,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658878656</BitOffs>
+            <BitOffs>658882112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61192,7 +61197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659176576</BitOffs>
+            <BitOffs>659180032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61204,7 +61209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659474496</BitOffs>
+            <BitOffs>659477952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61216,7 +61221,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659772416</BitOffs>
+            <BitOffs>659775872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61228,7 +61233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660070336</BitOffs>
+            <BitOffs>660073792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61240,7 +61245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660368256</BitOffs>
+            <BitOffs>660371712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61252,7 +61257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660666176</BitOffs>
+            <BitOffs>660669632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61264,7 +61269,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660964096</BitOffs>
+            <BitOffs>660967552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61276,7 +61281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661262016</BitOffs>
+            <BitOffs>661265472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61288,7 +61293,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662825216</BitOffs>
+            <BitOffs>662828672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61311,7 +61316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833152</BitOffs>
+            <BitOffs>662836608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61334,7 +61339,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833160</BitOffs>
+            <BitOffs>662836616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -61357,7 +61362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833168</BitOffs>
+            <BitOffs>662836624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61380,7 +61385,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833184</BitOffs>
+            <BitOffs>662836640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61393,7 +61398,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833216</BitOffs>
+            <BitOffs>662836672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61406,7 +61411,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833280</BitOffs>
+            <BitOffs>662836736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61419,7 +61424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833296</BitOffs>
+            <BitOffs>662836752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61431,7 +61436,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662850432</BitOffs>
+            <BitOffs>662853888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61454,7 +61459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858368</BitOffs>
+            <BitOffs>662861824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61477,7 +61482,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858376</BitOffs>
+            <BitOffs>662861832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -61500,7 +61505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858384</BitOffs>
+            <BitOffs>662861840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61523,7 +61528,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858400</BitOffs>
+            <BitOffs>662861856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61536,7 +61541,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858432</BitOffs>
+            <BitOffs>662861888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61549,7 +61554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858496</BitOffs>
+            <BitOffs>662861952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61562,7 +61567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858512</BitOffs>
+            <BitOffs>662861968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61574,7 +61579,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662875648</BitOffs>
+            <BitOffs>662879104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61597,7 +61602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883584</BitOffs>
+            <BitOffs>662887040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61620,7 +61625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883592</BitOffs>
+            <BitOffs>662887048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -61643,7 +61648,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883600</BitOffs>
+            <BitOffs>662887056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61666,7 +61671,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883616</BitOffs>
+            <BitOffs>662887072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61679,7 +61684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883648</BitOffs>
+            <BitOffs>662887104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61692,7 +61697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883712</BitOffs>
+            <BitOffs>662887168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -61705,7 +61710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883728</BitOffs>
+            <BitOffs>662887184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61717,7 +61722,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664587264</BitOffs>
+            <BitOffs>664590720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61740,7 +61745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595200</BitOffs>
+            <BitOffs>664598656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61763,7 +61768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595208</BitOffs>
+            <BitOffs>664598664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -61786,7 +61791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595216</BitOffs>
+            <BitOffs>664598672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61809,7 +61814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595232</BitOffs>
+            <BitOffs>664598688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61822,7 +61827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595264</BitOffs>
+            <BitOffs>664598720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61835,7 +61840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595328</BitOffs>
+            <BitOffs>664598784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61848,7 +61853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595344</BitOffs>
+            <BitOffs>664598800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61860,7 +61865,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664612480</BitOffs>
+            <BitOffs>664615936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61883,7 +61888,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620416</BitOffs>
+            <BitOffs>664623872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61906,7 +61911,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620424</BitOffs>
+            <BitOffs>664623880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -61929,7 +61934,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620432</BitOffs>
+            <BitOffs>664623888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61952,7 +61957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620448</BitOffs>
+            <BitOffs>664623904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61965,7 +61970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620480</BitOffs>
+            <BitOffs>664623936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61978,7 +61983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620544</BitOffs>
+            <BitOffs>664624000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61991,7 +61996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620560</BitOffs>
+            <BitOffs>664624016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62003,7 +62008,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664637696</BitOffs>
+            <BitOffs>664641152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62026,7 +62031,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645632</BitOffs>
+            <BitOffs>664649088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62049,7 +62054,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645640</BitOffs>
+            <BitOffs>664649096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -62072,7 +62077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645648</BitOffs>
+            <BitOffs>664649104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62095,7 +62100,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645664</BitOffs>
+            <BitOffs>664649120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -62108,7 +62113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645696</BitOffs>
+            <BitOffs>664649152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -62121,7 +62126,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645760</BitOffs>
+            <BitOffs>664649216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62134,7 +62139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645776</BitOffs>
+            <BitOffs>664649232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -62150,7 +62155,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665028320</BitOffs>
+            <BitOffs>665031776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -62171,7 +62176,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665031840</BitOffs>
+            <BitOffs>665035296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -62192,7 +62197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665031841</BitOffs>
+            <BitOffs>665035297</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -62204,7 +62209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675230272</BitOffs>
+            <BitOffs>675233728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -62227,7 +62232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238208</BitOffs>
+            <BitOffs>675241664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -62250,7 +62255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238216</BitOffs>
+            <BitOffs>675241672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -62273,7 +62278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238224</BitOffs>
+            <BitOffs>675241680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -62296,7 +62301,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238240</BitOffs>
+            <BitOffs>675241696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -62309,7 +62314,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238272</BitOffs>
+            <BitOffs>675241728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -62322,7 +62327,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238336</BitOffs>
+            <BitOffs>675241792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -62335,7 +62340,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238352</BitOffs>
+            <BitOffs>675241808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -62347,7 +62352,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675255488</BitOffs>
+            <BitOffs>675258944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -62370,7 +62375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263424</BitOffs>
+            <BitOffs>675266880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -62393,7 +62398,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263432</BitOffs>
+            <BitOffs>675266888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -62416,7 +62421,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263440</BitOffs>
+            <BitOffs>675266896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -62439,7 +62444,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263456</BitOffs>
+            <BitOffs>675266912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -62452,7 +62457,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263488</BitOffs>
+            <BitOffs>675266944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -62465,7 +62470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263552</BitOffs>
+            <BitOffs>675267008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -62478,7 +62483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263568</BitOffs>
+            <BitOffs>675267024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -62490,7 +62495,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675280704</BitOffs>
+            <BitOffs>675284160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -62513,7 +62518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288640</BitOffs>
+            <BitOffs>675292096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -62536,7 +62541,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288648</BitOffs>
+            <BitOffs>675292104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -62559,7 +62564,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288656</BitOffs>
+            <BitOffs>675292112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -62582,7 +62587,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288672</BitOffs>
+            <BitOffs>675292128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -62595,7 +62600,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288704</BitOffs>
+            <BitOffs>675292160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -62608,7 +62613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288768</BitOffs>
+            <BitOffs>675292224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -62621,7 +62626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288784</BitOffs>
+            <BitOffs>675292240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -62633,7 +62638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675305920</BitOffs>
+            <BitOffs>675309376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -62656,7 +62661,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313856</BitOffs>
+            <BitOffs>675317312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -62679,7 +62684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313864</BitOffs>
+            <BitOffs>675317320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -62702,7 +62707,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313872</BitOffs>
+            <BitOffs>675317328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -62725,7 +62730,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313888</BitOffs>
+            <BitOffs>675317344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -62738,7 +62743,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313920</BitOffs>
+            <BitOffs>675317376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -62751,7 +62756,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313984</BitOffs>
+            <BitOffs>675317440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -62764,7 +62769,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675314000</BitOffs>
+            <BitOffs>675317456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -62776,7 +62781,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675331136</BitOffs>
+            <BitOffs>675334592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -62799,7 +62804,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339072</BitOffs>
+            <BitOffs>675342528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -62822,7 +62827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339080</BitOffs>
+            <BitOffs>675342536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -62845,7 +62850,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339088</BitOffs>
+            <BitOffs>675342544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -62868,7 +62873,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339104</BitOffs>
+            <BitOffs>675342560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -62881,7 +62886,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339136</BitOffs>
+            <BitOffs>675342592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -62894,7 +62899,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339200</BitOffs>
+            <BitOffs>675342656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -62907,7 +62912,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339216</BitOffs>
+            <BitOffs>675342672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -62919,7 +62924,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675356352</BitOffs>
+            <BitOffs>675359808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -62942,7 +62947,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364288</BitOffs>
+            <BitOffs>675367744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -62965,7 +62970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364296</BitOffs>
+            <BitOffs>675367752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -62988,7 +62993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364304</BitOffs>
+            <BitOffs>675367760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -63011,7 +63016,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364320</BitOffs>
+            <BitOffs>675367776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -63024,7 +63029,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364352</BitOffs>
+            <BitOffs>675367808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -63037,7 +63042,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364416</BitOffs>
+            <BitOffs>675367872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -63050,7 +63055,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364432</BitOffs>
+            <BitOffs>675367888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -63062,7 +63067,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675381568</BitOffs>
+            <BitOffs>675385024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -63085,7 +63090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389504</BitOffs>
+            <BitOffs>675392960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -63108,7 +63113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389512</BitOffs>
+            <BitOffs>675392968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -63131,7 +63136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389520</BitOffs>
+            <BitOffs>675392976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -63154,7 +63159,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389536</BitOffs>
+            <BitOffs>675392992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -63167,7 +63172,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389568</BitOffs>
+            <BitOffs>675393024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -63180,7 +63185,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389632</BitOffs>
+            <BitOffs>675393088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -63193,7 +63198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389648</BitOffs>
+            <BitOffs>675393104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -63205,7 +63210,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675406784</BitOffs>
+            <BitOffs>675410240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -63228,7 +63233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414720</BitOffs>
+            <BitOffs>675418176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -63251,7 +63256,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414728</BitOffs>
+            <BitOffs>675418184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -63274,7 +63279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414736</BitOffs>
+            <BitOffs>675418192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -63297,7 +63302,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414752</BitOffs>
+            <BitOffs>675418208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -63310,7 +63315,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414784</BitOffs>
+            <BitOffs>675418240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -63323,7 +63328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414848</BitOffs>
+            <BitOffs>675418304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -63336,7 +63341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414864</BitOffs>
+            <BitOffs>675418320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -63348,7 +63353,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675432000</BitOffs>
+            <BitOffs>675435456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -63371,7 +63376,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439936</BitOffs>
+            <BitOffs>675443392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -63394,7 +63399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439944</BitOffs>
+            <BitOffs>675443400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -63417,7 +63422,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439952</BitOffs>
+            <BitOffs>675443408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -63440,7 +63445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439968</BitOffs>
+            <BitOffs>675443424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -63453,7 +63458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675440000</BitOffs>
+            <BitOffs>675443456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -63466,7 +63471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675440064</BitOffs>
+            <BitOffs>675443520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -63479,7 +63484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675440080</BitOffs>
+            <BitOffs>675443536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -63491,7 +63496,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675457216</BitOffs>
+            <BitOffs>675460672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -63514,7 +63519,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465152</BitOffs>
+            <BitOffs>675468608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -63537,7 +63542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465160</BitOffs>
+            <BitOffs>675468616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -63560,7 +63565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465168</BitOffs>
+            <BitOffs>675468624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -63583,7 +63588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465184</BitOffs>
+            <BitOffs>675468640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -63596,7 +63601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465216</BitOffs>
+            <BitOffs>675468672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -63609,7 +63614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465280</BitOffs>
+            <BitOffs>675468736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -63622,7 +63627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465296</BitOffs>
+            <BitOffs>675468752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -63634,7 +63639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675482432</BitOffs>
+            <BitOffs>675485888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -63657,7 +63662,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490368</BitOffs>
+            <BitOffs>675493824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -63680,7 +63685,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490376</BitOffs>
+            <BitOffs>675493832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -63703,7 +63708,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490384</BitOffs>
+            <BitOffs>675493840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -63726,7 +63731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490400</BitOffs>
+            <BitOffs>675493856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -63739,7 +63744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490432</BitOffs>
+            <BitOffs>675493888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -63752,7 +63757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490496</BitOffs>
+            <BitOffs>675493952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -63765,7 +63770,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490512</BitOffs>
+            <BitOffs>675493968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -63777,7 +63782,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675507648</BitOffs>
+            <BitOffs>675511104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -63800,7 +63805,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515584</BitOffs>
+            <BitOffs>675519040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -63823,7 +63828,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515592</BitOffs>
+            <BitOffs>675519048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -63846,7 +63851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515600</BitOffs>
+            <BitOffs>675519056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -63869,7 +63874,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515616</BitOffs>
+            <BitOffs>675519072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -63882,7 +63887,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515648</BitOffs>
+            <BitOffs>675519104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -63895,7 +63900,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515712</BitOffs>
+            <BitOffs>675519168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -63908,7 +63913,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515728</BitOffs>
+            <BitOffs>675519184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -63920,7 +63925,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675532864</BitOffs>
+            <BitOffs>675536320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -63943,7 +63948,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540800</BitOffs>
+            <BitOffs>675544256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -63966,7 +63971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540808</BitOffs>
+            <BitOffs>675544264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -63989,7 +63994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540816</BitOffs>
+            <BitOffs>675544272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -64012,7 +64017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540832</BitOffs>
+            <BitOffs>675544288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -64025,7 +64030,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540864</BitOffs>
+            <BitOffs>675544320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -64038,7 +64043,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540928</BitOffs>
+            <BitOffs>675544384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -64051,7 +64056,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540944</BitOffs>
+            <BitOffs>675544400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -64063,7 +64068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675558080</BitOffs>
+            <BitOffs>675561536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -64086,7 +64091,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566016</BitOffs>
+            <BitOffs>675569472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -64109,7 +64114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566024</BitOffs>
+            <BitOffs>675569480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -64132,7 +64137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566032</BitOffs>
+            <BitOffs>675569488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -64155,7 +64160,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566048</BitOffs>
+            <BitOffs>675569504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -64168,7 +64173,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566080</BitOffs>
+            <BitOffs>675569536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -64181,7 +64186,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566144</BitOffs>
+            <BitOffs>675569600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -64194,7 +64199,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566160</BitOffs>
+            <BitOffs>675569616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -64206,7 +64211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675583296</BitOffs>
+            <BitOffs>675586752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -64229,7 +64234,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591232</BitOffs>
+            <BitOffs>675594688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -64252,7 +64257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591240</BitOffs>
+            <BitOffs>675594696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -64275,7 +64280,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591248</BitOffs>
+            <BitOffs>675594704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -64298,7 +64303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591264</BitOffs>
+            <BitOffs>675594720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -64311,7 +64316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591296</BitOffs>
+            <BitOffs>675594752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -64324,7 +64329,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591360</BitOffs>
+            <BitOffs>675594816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -64337,7 +64342,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591376</BitOffs>
+            <BitOffs>675594832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -64349,7 +64354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675608512</BitOffs>
+            <BitOffs>675611968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -64372,7 +64377,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616448</BitOffs>
+            <BitOffs>675619904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -64395,7 +64400,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616456</BitOffs>
+            <BitOffs>675619912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -64418,7 +64423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616464</BitOffs>
+            <BitOffs>675619920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -64441,7 +64446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616480</BitOffs>
+            <BitOffs>675619936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -64454,7 +64459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616512</BitOffs>
+            <BitOffs>675619968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -64467,7 +64472,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616576</BitOffs>
+            <BitOffs>675620032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -64480,7 +64485,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616592</BitOffs>
+            <BitOffs>675620048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -64492,7 +64497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675633728</BitOffs>
+            <BitOffs>675637184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -64515,7 +64520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641664</BitOffs>
+            <BitOffs>675645120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -64538,7 +64543,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641672</BitOffs>
+            <BitOffs>675645128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -64561,7 +64566,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641680</BitOffs>
+            <BitOffs>675645136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -64584,7 +64589,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641696</BitOffs>
+            <BitOffs>675645152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -64597,7 +64602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641728</BitOffs>
+            <BitOffs>675645184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -64610,7 +64615,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641792</BitOffs>
+            <BitOffs>675645248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -64623,7 +64628,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641808</BitOffs>
+            <BitOffs>675645264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -64635,7 +64640,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675658944</BitOffs>
+            <BitOffs>675662400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -64658,7 +64663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666880</BitOffs>
+            <BitOffs>675670336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -64681,7 +64686,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666888</BitOffs>
+            <BitOffs>675670344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -64704,7 +64709,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666896</BitOffs>
+            <BitOffs>675670352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -64727,7 +64732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666912</BitOffs>
+            <BitOffs>675670368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -64740,7 +64745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666944</BitOffs>
+            <BitOffs>675670400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -64753,7 +64758,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675667008</BitOffs>
+            <BitOffs>675670464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -64766,7 +64771,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675667024</BitOffs>
+            <BitOffs>675670480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -64778,7 +64783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675684160</BitOffs>
+            <BitOffs>675687616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -64801,7 +64806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692096</BitOffs>
+            <BitOffs>675695552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -64824,7 +64829,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692104</BitOffs>
+            <BitOffs>675695560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -64847,7 +64852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692112</BitOffs>
+            <BitOffs>675695568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -64870,7 +64875,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692128</BitOffs>
+            <BitOffs>675695584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -64883,7 +64888,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692160</BitOffs>
+            <BitOffs>675695616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -64896,7 +64901,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692224</BitOffs>
+            <BitOffs>675695680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -64909,7 +64914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692240</BitOffs>
+            <BitOffs>675695696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -64921,7 +64926,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675709376</BitOffs>
+            <BitOffs>675712832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -64944,7 +64949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717312</BitOffs>
+            <BitOffs>675720768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -64967,7 +64972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717320</BitOffs>
+            <BitOffs>675720776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -64990,7 +64995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717328</BitOffs>
+            <BitOffs>675720784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -65013,7 +65018,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717344</BitOffs>
+            <BitOffs>675720800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -65026,7 +65031,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717376</BitOffs>
+            <BitOffs>675720832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -65039,7 +65044,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717440</BitOffs>
+            <BitOffs>675720896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -65052,7 +65057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717456</BitOffs>
+            <BitOffs>675720912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -65064,7 +65069,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675734592</BitOffs>
+            <BitOffs>675738048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -65087,7 +65092,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742528</BitOffs>
+            <BitOffs>675745984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -65110,7 +65115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742536</BitOffs>
+            <BitOffs>675745992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -65133,7 +65138,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742544</BitOffs>
+            <BitOffs>675746000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -65156,7 +65161,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742560</BitOffs>
+            <BitOffs>675746016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -65169,7 +65174,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742592</BitOffs>
+            <BitOffs>675746048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -65182,7 +65187,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742656</BitOffs>
+            <BitOffs>675746112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -65195,7 +65200,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742672</BitOffs>
+            <BitOffs>675746128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -65207,7 +65212,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675759808</BitOffs>
+            <BitOffs>675763264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -65230,7 +65235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767744</BitOffs>
+            <BitOffs>675771200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -65253,7 +65258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767752</BitOffs>
+            <BitOffs>675771208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -65276,7 +65281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767760</BitOffs>
+            <BitOffs>675771216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -65299,7 +65304,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767776</BitOffs>
+            <BitOffs>675771232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -65312,7 +65317,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767808</BitOffs>
+            <BitOffs>675771264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -65325,7 +65330,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767872</BitOffs>
+            <BitOffs>675771328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -65338,7 +65343,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767888</BitOffs>
+            <BitOffs>675771344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -65350,7 +65355,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675785024</BitOffs>
+            <BitOffs>675788480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -65373,7 +65378,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792960</BitOffs>
+            <BitOffs>675796416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -65396,7 +65401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792968</BitOffs>
+            <BitOffs>675796424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -65419,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792976</BitOffs>
+            <BitOffs>675796432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -65442,7 +65447,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792992</BitOffs>
+            <BitOffs>675796448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -65455,7 +65460,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675793024</BitOffs>
+            <BitOffs>675796480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -65468,7 +65473,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675793088</BitOffs>
+            <BitOffs>675796544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -65481,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675793104</BitOffs>
+            <BitOffs>675796560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -65493,7 +65498,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675810240</BitOffs>
+            <BitOffs>675813696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -65516,7 +65521,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818176</BitOffs>
+            <BitOffs>675821632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -65539,7 +65544,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818184</BitOffs>
+            <BitOffs>675821640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -65562,7 +65567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818192</BitOffs>
+            <BitOffs>675821648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -65585,7 +65590,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818208</BitOffs>
+            <BitOffs>675821664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -65598,7 +65603,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818240</BitOffs>
+            <BitOffs>675821696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -65611,7 +65616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818304</BitOffs>
+            <BitOffs>675821760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -65624,7 +65629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818320</BitOffs>
+            <BitOffs>675821776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -65636,7 +65641,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675835456</BitOffs>
+            <BitOffs>675838912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -65659,7 +65664,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843392</BitOffs>
+            <BitOffs>675846848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -65682,7 +65687,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843400</BitOffs>
+            <BitOffs>675846856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -65705,7 +65710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843408</BitOffs>
+            <BitOffs>675846864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -65728,7 +65733,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843424</BitOffs>
+            <BitOffs>675846880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -65741,7 +65746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843456</BitOffs>
+            <BitOffs>675846912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -65754,7 +65759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843520</BitOffs>
+            <BitOffs>675846976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -65767,7 +65772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843536</BitOffs>
+            <BitOffs>675846992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -65779,7 +65784,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675860672</BitOffs>
+            <BitOffs>675864128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -65802,7 +65807,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868608</BitOffs>
+            <BitOffs>675872064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -65825,7 +65830,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868616</BitOffs>
+            <BitOffs>675872072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -65848,7 +65853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868624</BitOffs>
+            <BitOffs>675872080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -65871,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868640</BitOffs>
+            <BitOffs>675872096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -65884,7 +65889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868672</BitOffs>
+            <BitOffs>675872128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -65897,7 +65902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868736</BitOffs>
+            <BitOffs>675872192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -65910,7 +65915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868752</BitOffs>
+            <BitOffs>675872208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -65922,7 +65927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675885888</BitOffs>
+            <BitOffs>675889344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -65945,7 +65950,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893824</BitOffs>
+            <BitOffs>675897280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -65968,7 +65973,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893832</BitOffs>
+            <BitOffs>675897288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -65991,7 +65996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893840</BitOffs>
+            <BitOffs>675897296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -66014,7 +66019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893856</BitOffs>
+            <BitOffs>675897312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -66027,7 +66032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893888</BitOffs>
+            <BitOffs>675897344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -66040,7 +66045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893952</BitOffs>
+            <BitOffs>675897408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -66053,7 +66058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893968</BitOffs>
+            <BitOffs>675897424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -66065,7 +66070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675911104</BitOffs>
+            <BitOffs>675914560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -66088,7 +66093,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919040</BitOffs>
+            <BitOffs>675922496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -66111,7 +66116,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919048</BitOffs>
+            <BitOffs>675922504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -66134,7 +66139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919056</BitOffs>
+            <BitOffs>675922512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -66157,7 +66162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919072</BitOffs>
+            <BitOffs>675922528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -66170,7 +66175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919104</BitOffs>
+            <BitOffs>675922560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -66183,7 +66188,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919168</BitOffs>
+            <BitOffs>675922624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -66196,7 +66201,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919184</BitOffs>
+            <BitOffs>675922640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -66208,7 +66213,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675936320</BitOffs>
+            <BitOffs>675939776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -66231,7 +66236,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944256</BitOffs>
+            <BitOffs>675947712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -66254,7 +66259,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944264</BitOffs>
+            <BitOffs>675947720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -66277,7 +66282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944272</BitOffs>
+            <BitOffs>675947728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -66300,7 +66305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944288</BitOffs>
+            <BitOffs>675947744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -66313,7 +66318,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944320</BitOffs>
+            <BitOffs>675947776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -66326,7 +66331,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944384</BitOffs>
+            <BitOffs>675947840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -66339,7 +66344,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944400</BitOffs>
+            <BitOffs>675947856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -66351,7 +66356,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675961536</BitOffs>
+            <BitOffs>675964992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -66374,7 +66379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969472</BitOffs>
+            <BitOffs>675972928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -66397,7 +66402,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969480</BitOffs>
+            <BitOffs>675972936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -66420,7 +66425,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969488</BitOffs>
+            <BitOffs>675972944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -66443,7 +66448,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969504</BitOffs>
+            <BitOffs>675972960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -66456,7 +66461,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969536</BitOffs>
+            <BitOffs>675972992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -66469,7 +66474,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969600</BitOffs>
+            <BitOffs>675973056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -66482,7 +66487,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969616</BitOffs>
+            <BitOffs>675973072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -66494,7 +66499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675986752</BitOffs>
+            <BitOffs>675990208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -66517,7 +66522,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994688</BitOffs>
+            <BitOffs>675998144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -66540,7 +66545,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994696</BitOffs>
+            <BitOffs>675998152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -66563,7 +66568,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994704</BitOffs>
+            <BitOffs>675998160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -66586,7 +66591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994720</BitOffs>
+            <BitOffs>675998176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -66599,7 +66604,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994752</BitOffs>
+            <BitOffs>675998208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -66612,7 +66617,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994816</BitOffs>
+            <BitOffs>675998272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -66625,7 +66630,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994832</BitOffs>
+            <BitOffs>675998288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -66637,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676011968</BitOffs>
+            <BitOffs>676015424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -66660,7 +66665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019904</BitOffs>
+            <BitOffs>676023360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -66683,7 +66688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019912</BitOffs>
+            <BitOffs>676023368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -66706,7 +66711,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019920</BitOffs>
+            <BitOffs>676023376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -66729,7 +66734,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019936</BitOffs>
+            <BitOffs>676023392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -66742,7 +66747,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019968</BitOffs>
+            <BitOffs>676023424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -66755,7 +66760,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676020032</BitOffs>
+            <BitOffs>676023488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -66768,7 +66773,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676020048</BitOffs>
+            <BitOffs>676023504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -66780,7 +66785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676037184</BitOffs>
+            <BitOffs>676040640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -66803,7 +66808,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045120</BitOffs>
+            <BitOffs>676048576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -66826,7 +66831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045128</BitOffs>
+            <BitOffs>676048584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -66849,7 +66854,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045136</BitOffs>
+            <BitOffs>676048592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -66872,7 +66877,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045152</BitOffs>
+            <BitOffs>676048608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -66885,7 +66890,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045184</BitOffs>
+            <BitOffs>676048640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -66898,7 +66903,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045248</BitOffs>
+            <BitOffs>676048704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -66911,7 +66916,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045264</BitOffs>
+            <BitOffs>676048720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -66923,7 +66928,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676062400</BitOffs>
+            <BitOffs>676065856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -66946,7 +66951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070336</BitOffs>
+            <BitOffs>676073792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -66969,7 +66974,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070344</BitOffs>
+            <BitOffs>676073800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -66992,7 +66997,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070352</BitOffs>
+            <BitOffs>676073808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -67015,7 +67020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070368</BitOffs>
+            <BitOffs>676073824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -67028,7 +67033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070400</BitOffs>
+            <BitOffs>676073856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -67041,7 +67046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070464</BitOffs>
+            <BitOffs>676073920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -67054,7 +67059,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070480</BitOffs>
+            <BitOffs>676073936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -67066,7 +67071,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676087616</BitOffs>
+            <BitOffs>676091072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -67089,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095552</BitOffs>
+            <BitOffs>676099008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -67112,7 +67117,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095560</BitOffs>
+            <BitOffs>676099016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -67135,7 +67140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095568</BitOffs>
+            <BitOffs>676099024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -67158,7 +67163,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095584</BitOffs>
+            <BitOffs>676099040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -67171,7 +67176,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095616</BitOffs>
+            <BitOffs>676099072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -67184,7 +67189,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095680</BitOffs>
+            <BitOffs>676099136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -67197,7 +67202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095696</BitOffs>
+            <BitOffs>676099152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -67209,7 +67214,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676112832</BitOffs>
+            <BitOffs>676116288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -67232,7 +67237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120768</BitOffs>
+            <BitOffs>676124224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -67255,7 +67260,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120776</BitOffs>
+            <BitOffs>676124232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -67278,7 +67283,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120784</BitOffs>
+            <BitOffs>676124240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -67301,7 +67306,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120800</BitOffs>
+            <BitOffs>676124256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -67314,7 +67319,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120832</BitOffs>
+            <BitOffs>676124288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -67327,7 +67332,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120896</BitOffs>
+            <BitOffs>676124352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -67340,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120912</BitOffs>
+            <BitOffs>676124368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -67352,7 +67357,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676138048</BitOffs>
+            <BitOffs>676141504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -67375,7 +67380,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676145984</BitOffs>
+            <BitOffs>676149440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -67398,7 +67403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676145992</BitOffs>
+            <BitOffs>676149448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -67421,7 +67426,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146000</BitOffs>
+            <BitOffs>676149456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -67444,7 +67449,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146016</BitOffs>
+            <BitOffs>676149472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -67457,7 +67462,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146048</BitOffs>
+            <BitOffs>676149504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -67470,7 +67475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146112</BitOffs>
+            <BitOffs>676149568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -67483,7 +67488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146128</BitOffs>
+            <BitOffs>676149584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -67495,7 +67500,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676163264</BitOffs>
+            <BitOffs>676166720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -67518,7 +67523,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171200</BitOffs>
+            <BitOffs>676174656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -67541,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171208</BitOffs>
+            <BitOffs>676174664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -67564,7 +67569,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171216</BitOffs>
+            <BitOffs>676174672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -67587,7 +67592,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171232</BitOffs>
+            <BitOffs>676174688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -67600,7 +67605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171264</BitOffs>
+            <BitOffs>676174720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -67613,7 +67618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171328</BitOffs>
+            <BitOffs>676174784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -67626,7 +67631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171344</BitOffs>
+            <BitOffs>676174800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -67638,7 +67643,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676188480</BitOffs>
+            <BitOffs>676191936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -67661,7 +67666,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196416</BitOffs>
+            <BitOffs>676199872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -67684,7 +67689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196424</BitOffs>
+            <BitOffs>676199880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -67707,7 +67712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196432</BitOffs>
+            <BitOffs>676199888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -67730,7 +67735,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196448</BitOffs>
+            <BitOffs>676199904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -67743,7 +67748,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196480</BitOffs>
+            <BitOffs>676199936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -67756,7 +67761,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196544</BitOffs>
+            <BitOffs>676200000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -67769,7 +67774,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196560</BitOffs>
+            <BitOffs>676200016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -67781,7 +67786,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676213696</BitOffs>
+            <BitOffs>676217152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -67804,7 +67809,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221632</BitOffs>
+            <BitOffs>676225088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -67827,7 +67832,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221640</BitOffs>
+            <BitOffs>676225096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -67850,7 +67855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221648</BitOffs>
+            <BitOffs>676225104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -67873,7 +67878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221664</BitOffs>
+            <BitOffs>676225120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -67886,7 +67891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221696</BitOffs>
+            <BitOffs>676225152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -67899,7 +67904,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221760</BitOffs>
+            <BitOffs>676225216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -67912,7 +67917,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221776</BitOffs>
+            <BitOffs>676225232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -67924,7 +67929,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676238912</BitOffs>
+            <BitOffs>676242368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -67947,7 +67952,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246848</BitOffs>
+            <BitOffs>676250304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -67970,7 +67975,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246856</BitOffs>
+            <BitOffs>676250312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -67993,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246864</BitOffs>
+            <BitOffs>676250320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -68016,7 +68021,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246880</BitOffs>
+            <BitOffs>676250336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -68029,7 +68034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246912</BitOffs>
+            <BitOffs>676250368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -68042,7 +68047,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246976</BitOffs>
+            <BitOffs>676250432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -68055,7 +68060,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246992</BitOffs>
+            <BitOffs>676250448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -68067,7 +68072,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676264128</BitOffs>
+            <BitOffs>676267584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -68090,7 +68095,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272064</BitOffs>
+            <BitOffs>676275520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -68113,7 +68118,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272072</BitOffs>
+            <BitOffs>676275528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -68136,7 +68141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272080</BitOffs>
+            <BitOffs>676275536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -68159,7 +68164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272096</BitOffs>
+            <BitOffs>676275552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -68172,7 +68177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272128</BitOffs>
+            <BitOffs>676275584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -68185,7 +68190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272192</BitOffs>
+            <BitOffs>676275648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -68198,7 +68203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272208</BitOffs>
+            <BitOffs>676275664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -68210,7 +68215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676289344</BitOffs>
+            <BitOffs>676292800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -68233,7 +68238,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297280</BitOffs>
+            <BitOffs>676300736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -68256,7 +68261,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297288</BitOffs>
+            <BitOffs>676300744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -68279,7 +68284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297296</BitOffs>
+            <BitOffs>676300752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -68302,7 +68307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297312</BitOffs>
+            <BitOffs>676300768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -68315,7 +68320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297344</BitOffs>
+            <BitOffs>676300800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -68328,7 +68333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297408</BitOffs>
+            <BitOffs>676300864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -68341,7 +68346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297424</BitOffs>
+            <BitOffs>676300880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -68353,7 +68358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676314560</BitOffs>
+            <BitOffs>676318016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -68376,7 +68381,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322496</BitOffs>
+            <BitOffs>676325952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -68399,7 +68404,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322504</BitOffs>
+            <BitOffs>676325960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -68422,7 +68427,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322512</BitOffs>
+            <BitOffs>676325968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -68445,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322528</BitOffs>
+            <BitOffs>676325984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -68458,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322560</BitOffs>
+            <BitOffs>676326016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -68471,7 +68476,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322624</BitOffs>
+            <BitOffs>676326080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -68484,7 +68489,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322640</BitOffs>
+            <BitOffs>676326096</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -68502,7 +68507,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639776192</BitOffs>
+            <BitOffs>639776512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -68514,7 +68519,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640746304</BitOffs>
+            <BitOffs>640746624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -68526,7 +68531,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640746320</BitOffs>
+            <BitOffs>640746640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -68539,7 +68544,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640747136</BitOffs>
+            <BitOffs>640747584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68551,7 +68556,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640766656</BitOffs>
+            <BitOffs>640767040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -68563,7 +68568,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642323232</BitOffs>
+            <BitOffs>642323744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -68583,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642323248</BitOffs>
+            <BitOffs>642323760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68596,7 +68601,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642324096</BitOffs>
+            <BitOffs>642324736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68608,7 +68613,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642342208</BitOffs>
+            <BitOffs>642343232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -68620,7 +68625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643898784</BitOffs>
+            <BitOffs>643899936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -68640,7 +68645,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643898800</BitOffs>
+            <BitOffs>643899952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68653,7 +68658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643899648</BitOffs>
+            <BitOffs>643900928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68665,7 +68670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643917760</BitOffs>
+            <BitOffs>643919424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -68677,7 +68682,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645474336</BitOffs>
+            <BitOffs>645476128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -68697,7 +68702,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645474352</BitOffs>
+            <BitOffs>645476144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68710,7 +68715,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645475200</BitOffs>
+            <BitOffs>645477120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68722,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645493312</BitOffs>
+            <BitOffs>645495616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -68734,7 +68739,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647049888</BitOffs>
+            <BitOffs>647052320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -68754,7 +68759,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647049904</BitOffs>
+            <BitOffs>647052336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68767,7 +68772,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647050752</BitOffs>
+            <BitOffs>647053312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68779,7 +68784,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647068864</BitOffs>
+            <BitOffs>647071808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -68791,7 +68796,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648625440</BitOffs>
+            <BitOffs>648628512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -68811,7 +68816,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648625456</BitOffs>
+            <BitOffs>648628528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68824,7 +68829,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648626304</BitOffs>
+            <BitOffs>648629504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68836,7 +68841,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648644928</BitOffs>
+            <BitOffs>648648448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68848,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649650304</BitOffs>
+            <BitOffs>649653824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68860,7 +68865,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649948224</BitOffs>
+            <BitOffs>649951744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68872,7 +68877,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>650960768</BitOffs>
+            <BitOffs>650964288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68884,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651258688</BitOffs>
+            <BitOffs>651262208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68896,7 +68901,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652249536</BitOffs>
+            <BitOffs>652253056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68908,7 +68913,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652547456</BitOffs>
+            <BitOffs>652550976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68920,7 +68925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652845376</BitOffs>
+            <BitOffs>652848896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68932,7 +68937,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653143296</BitOffs>
+            <BitOffs>653146816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -68944,7 +68949,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653589920</BitOffs>
+            <BitOffs>653593440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68956,7 +68961,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653596160</BitOffs>
+            <BitOffs>653599616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68968,7 +68973,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653894080</BitOffs>
+            <BitOffs>653897536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68980,7 +68985,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654192000</BitOffs>
+            <BitOffs>654195456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68992,7 +68997,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654489920</BitOffs>
+            <BitOffs>654493376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -69004,7 +69009,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654936544</BitOffs>
+            <BitOffs>654940000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -69016,7 +69021,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655049136</BitOffs>
+            <BitOffs>655052592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -69028,7 +69033,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655049144</BitOffs>
+            <BitOffs>655052600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69040,7 +69045,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655081856</BitOffs>
+            <BitOffs>655085312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69052,7 +69057,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655379776</BitOffs>
+            <BitOffs>655383232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69064,7 +69069,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656397696</BitOffs>
+            <BitOffs>656401152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69076,7 +69081,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656695616</BitOffs>
+            <BitOffs>656699072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69088,7 +69093,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657685952</BitOffs>
+            <BitOffs>657689408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69100,7 +69105,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657983872</BitOffs>
+            <BitOffs>657987328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69112,7 +69117,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658281792</BitOffs>
+            <BitOffs>658285248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69124,7 +69129,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658579712</BitOffs>
+            <BitOffs>658583168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69136,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658877632</BitOffs>
+            <BitOffs>658881088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69148,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659175552</BitOffs>
+            <BitOffs>659179008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69160,7 +69165,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659473472</BitOffs>
+            <BitOffs>659476928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69172,7 +69177,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659771392</BitOffs>
+            <BitOffs>659774848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69184,7 +69189,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660069312</BitOffs>
+            <BitOffs>660072768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69196,7 +69201,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660367232</BitOffs>
+            <BitOffs>660370688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69208,7 +69213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660665152</BitOffs>
+            <BitOffs>660668608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69220,7 +69225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660963072</BitOffs>
+            <BitOffs>660966528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69232,7 +69237,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661260992</BitOffs>
+            <BitOffs>661264448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -69244,7 +69249,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662824192</BitOffs>
+            <BitOffs>662827648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -69267,7 +69272,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662833176</BitOffs>
+            <BitOffs>662836632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -69279,7 +69284,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662849408</BitOffs>
+            <BitOffs>662852864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -69302,7 +69307,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662858392</BitOffs>
+            <BitOffs>662861848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -69314,7 +69319,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662874624</BitOffs>
+            <BitOffs>662878080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -69337,7 +69342,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662883608</BitOffs>
+            <BitOffs>662887064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -69349,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664586240</BitOffs>
+            <BitOffs>664589696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -69372,7 +69377,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664595224</BitOffs>
+            <BitOffs>664598680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -69384,7 +69389,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664611456</BitOffs>
+            <BitOffs>664614912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -69407,7 +69412,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664620440</BitOffs>
+            <BitOffs>664623896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -69419,7 +69424,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664636672</BitOffs>
+            <BitOffs>664640128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -69442,7 +69447,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664645656</BitOffs>
+            <BitOffs>664649112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -69461,7 +69466,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665027512</BitOffs>
+            <BitOffs>665030968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -69477,7 +69482,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665030080</BitOffs>
+            <BitOffs>665033536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -69497,7 +69502,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671935560</BitOffs>
+            <BitOffs>671939016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -69517,7 +69522,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673582472</BitOffs>
+            <BitOffs>673585928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -69536,7 +69541,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229120</BitOffs>
+            <BitOffs>675232576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -69548,7 +69553,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675229248</BitOffs>
+            <BitOffs>675232704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -69571,7 +69576,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675238232</BitOffs>
+            <BitOffs>675241688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -69583,7 +69588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675254464</BitOffs>
+            <BitOffs>675257920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -69606,7 +69611,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675263448</BitOffs>
+            <BitOffs>675266904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -69618,7 +69623,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675279680</BitOffs>
+            <BitOffs>675283136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -69641,7 +69646,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675288664</BitOffs>
+            <BitOffs>675292120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -69653,7 +69658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675304896</BitOffs>
+            <BitOffs>675308352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -69676,7 +69681,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675313880</BitOffs>
+            <BitOffs>675317336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -69688,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675330112</BitOffs>
+            <BitOffs>675333568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -69711,7 +69716,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675339096</BitOffs>
+            <BitOffs>675342552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -69723,7 +69728,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675355328</BitOffs>
+            <BitOffs>675358784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -69746,7 +69751,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675364312</BitOffs>
+            <BitOffs>675367768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -69758,7 +69763,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675380544</BitOffs>
+            <BitOffs>675384000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -69781,7 +69786,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675389528</BitOffs>
+            <BitOffs>675392984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -69793,7 +69798,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675405760</BitOffs>
+            <BitOffs>675409216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -69816,7 +69821,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675414744</BitOffs>
+            <BitOffs>675418200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -69828,7 +69833,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675430976</BitOffs>
+            <BitOffs>675434432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -69851,7 +69856,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675439960</BitOffs>
+            <BitOffs>675443416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -69863,7 +69868,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675456192</BitOffs>
+            <BitOffs>675459648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -69886,7 +69891,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675465176</BitOffs>
+            <BitOffs>675468632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -69898,7 +69903,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675481408</BitOffs>
+            <BitOffs>675484864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -69921,7 +69926,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675490392</BitOffs>
+            <BitOffs>675493848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -69933,7 +69938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675506624</BitOffs>
+            <BitOffs>675510080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -69956,7 +69961,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675515608</BitOffs>
+            <BitOffs>675519064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -69968,7 +69973,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675531840</BitOffs>
+            <BitOffs>675535296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -69991,7 +69996,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675540824</BitOffs>
+            <BitOffs>675544280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -70003,7 +70008,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675557056</BitOffs>
+            <BitOffs>675560512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -70026,7 +70031,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675566040</BitOffs>
+            <BitOffs>675569496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -70038,7 +70043,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675582272</BitOffs>
+            <BitOffs>675585728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -70061,7 +70066,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675591256</BitOffs>
+            <BitOffs>675594712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -70073,7 +70078,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675607488</BitOffs>
+            <BitOffs>675610944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -70096,7 +70101,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675616472</BitOffs>
+            <BitOffs>675619928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -70108,7 +70113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675632704</BitOffs>
+            <BitOffs>675636160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -70131,7 +70136,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675641688</BitOffs>
+            <BitOffs>675645144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -70143,7 +70148,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675657920</BitOffs>
+            <BitOffs>675661376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -70166,7 +70171,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675666904</BitOffs>
+            <BitOffs>675670360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -70178,7 +70183,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675683136</BitOffs>
+            <BitOffs>675686592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -70201,7 +70206,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675692120</BitOffs>
+            <BitOffs>675695576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -70213,7 +70218,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675708352</BitOffs>
+            <BitOffs>675711808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -70236,7 +70241,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675717336</BitOffs>
+            <BitOffs>675720792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -70248,7 +70253,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675733568</BitOffs>
+            <BitOffs>675737024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -70271,7 +70276,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675742552</BitOffs>
+            <BitOffs>675746008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -70283,7 +70288,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675758784</BitOffs>
+            <BitOffs>675762240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -70306,7 +70311,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675767768</BitOffs>
+            <BitOffs>675771224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -70318,7 +70323,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675784000</BitOffs>
+            <BitOffs>675787456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -70341,7 +70346,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675792984</BitOffs>
+            <BitOffs>675796440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -70353,7 +70358,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675809216</BitOffs>
+            <BitOffs>675812672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -70376,7 +70381,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675818200</BitOffs>
+            <BitOffs>675821656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -70388,7 +70393,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675834432</BitOffs>
+            <BitOffs>675837888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -70411,7 +70416,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675843416</BitOffs>
+            <BitOffs>675846872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -70423,7 +70428,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675859648</BitOffs>
+            <BitOffs>675863104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -70446,7 +70451,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675868632</BitOffs>
+            <BitOffs>675872088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -70458,7 +70463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675884864</BitOffs>
+            <BitOffs>675888320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -70481,7 +70486,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675893848</BitOffs>
+            <BitOffs>675897304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -70493,7 +70498,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675910080</BitOffs>
+            <BitOffs>675913536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -70516,7 +70521,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675919064</BitOffs>
+            <BitOffs>675922520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -70528,7 +70533,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675935296</BitOffs>
+            <BitOffs>675938752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -70551,7 +70556,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675944280</BitOffs>
+            <BitOffs>675947736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -70563,7 +70568,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675960512</BitOffs>
+            <BitOffs>675963968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -70586,7 +70591,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675969496</BitOffs>
+            <BitOffs>675972952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -70598,7 +70603,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675985728</BitOffs>
+            <BitOffs>675989184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -70621,7 +70626,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675994712</BitOffs>
+            <BitOffs>675998168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -70633,7 +70638,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676010944</BitOffs>
+            <BitOffs>676014400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -70656,7 +70661,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676019928</BitOffs>
+            <BitOffs>676023384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -70668,7 +70673,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676036160</BitOffs>
+            <BitOffs>676039616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -70691,7 +70696,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676045144</BitOffs>
+            <BitOffs>676048600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -70703,7 +70708,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676061376</BitOffs>
+            <BitOffs>676064832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -70726,7 +70731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676070360</BitOffs>
+            <BitOffs>676073816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -70738,7 +70743,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676086592</BitOffs>
+            <BitOffs>676090048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -70761,7 +70766,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676095576</BitOffs>
+            <BitOffs>676099032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -70773,7 +70778,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676111808</BitOffs>
+            <BitOffs>676115264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -70796,7 +70801,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676120792</BitOffs>
+            <BitOffs>676124248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -70808,7 +70813,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676137024</BitOffs>
+            <BitOffs>676140480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -70831,7 +70836,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676146008</BitOffs>
+            <BitOffs>676149464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -70843,7 +70848,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676162240</BitOffs>
+            <BitOffs>676165696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -70866,7 +70871,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676171224</BitOffs>
+            <BitOffs>676174680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -70878,7 +70883,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676187456</BitOffs>
+            <BitOffs>676190912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -70901,7 +70906,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676196440</BitOffs>
+            <BitOffs>676199896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -70913,7 +70918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676212672</BitOffs>
+            <BitOffs>676216128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -70936,7 +70941,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676221656</BitOffs>
+            <BitOffs>676225112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -70948,7 +70953,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676237888</BitOffs>
+            <BitOffs>676241344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -70971,7 +70976,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676246872</BitOffs>
+            <BitOffs>676250328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -70983,7 +70988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676263104</BitOffs>
+            <BitOffs>676266560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -71006,7 +71011,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676272088</BitOffs>
+            <BitOffs>676275544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -71018,7 +71023,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676288320</BitOffs>
+            <BitOffs>676291776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -71041,7 +71046,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676297304</BitOffs>
+            <BitOffs>676300760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -71053,7 +71058,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676313536</BitOffs>
+            <BitOffs>676316992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -71076,7 +71081,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676322520</BitOffs>
+            <BitOffs>676325976</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -76393,35 +76398,40 @@ Digital outputs</Comment>
             <BitOffs>8538368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>MOTION_GVL.nMaxStates</Name>
-            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <Name>Global_Version.stLibVersion_lcls2_cc_lib_nrw</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>0.0.0</String>
+              </SubItem>
+            </Default>
             <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
             <BitOffs>8538656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
-            <Comment>
-    Arbitary cap on multidimensional states to simplify statements for the compiler.
-    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
-    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
-    </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>3</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8538672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbPmpsFileReader</Name>
@@ -76433,7 +76443,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8538688</BitOffs>
+            <BitOffs>8538944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbStandardPMPSDB</Name>
@@ -76452,7 +76462,38 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9466816</BitOffs>
+            <BitOffs>9467072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.nMaxStates</Name>
+            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9494816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
+            <Comment>
+    Arbitary cap on multidimensional states to simplify statements for the compiler.
+    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
+    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
+    </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9494832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -76472,7 +76513,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494560</BitOffs>
+            <BitOffs>9494848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -76492,7 +76533,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9496320</BitOffs>
+            <BitOffs>9496608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -76517,7 +76558,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9498080</BitOffs>
+            <BitOffs>9498368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -76529,7 +76570,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499104</BitOffs>
+            <BitOffs>9499392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -76544,21 +76585,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9499168</BitOffs>
+            <BitOffs>9499424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -76572,7 +76599,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499200</BitOffs>
+            <BitOffs>9499456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -76586,7 +76613,21 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499264</BitOffs>
+            <BitOffs>9499520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9499584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -76601,7 +76642,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499328</BitOffs>
+            <BitOffs>9499616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
@@ -76616,7 +76657,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499360</BitOffs>
+            <BitOffs>9499648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -76630,7 +76671,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499376</BitOffs>
+            <BitOffs>9499664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stAttenuators</Name>
@@ -76651,7 +76692,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499392</BitOffs>
+            <BitOffs>9499680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cstFullBeam</Name>
@@ -76671,7 +76712,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499456</BitOffs>
+            <BitOffs>9499744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cst0RateBeam</Name>
@@ -76691,7 +76732,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9501216</BitOffs>
+            <BitOffs>9501504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -76716,7 +76757,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9502976</BitOffs>
+            <BitOffs>9503264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -76731,7 +76772,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9502992</BitOffs>
+            <BitOffs>9503280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -76750,7 +76791,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503008</BitOffs>
+            <BitOffs>9503296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
@@ -76764,7 +76805,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504032</BitOffs>
+            <BitOffs>9504320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
@@ -76779,7 +76820,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504048</BitOffs>
+            <BitOffs>9504336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -76806,7 +76847,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504064</BitOffs>
+            <BitOffs>9504352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -76961,7 +77002,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504096</BitOffs>
+            <BitOffs>9504384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -77116,7 +77157,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9505120</BitOffs>
+            <BitOffs>9505408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -77131,7 +77172,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506144</BitOffs>
+            <BitOffs>9506432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -77146,7 +77187,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506176</BitOffs>
+            <BitOffs>9506464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -77157,7 +77198,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506208</BitOffs>
+            <BitOffs>9506496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
@@ -77171,7 +77212,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506464</BitOffs>
+            <BitOffs>9506752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -77185,7 +77226,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506480</BitOffs>
+            <BitOffs>9506768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -77199,7 +77240,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506496</BitOffs>
+            <BitOffs>9506784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -77226,7 +77267,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506512</BitOffs>
+            <BitOffs>9506800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -77241,7 +77282,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506520</BitOffs>
+            <BitOffs>9506808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -77256,7 +77297,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506528</BitOffs>
+            <BitOffs>9506816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -77271,7 +77312,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506560</BitOffs>
+            <BitOffs>9506848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -77289,7 +77330,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508608</BitOffs>
+            <BitOffs>9508896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -77301,7 +77342,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508624</BitOffs>
+            <BitOffs>9508912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -77313,7 +77354,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508632</BitOffs>
+            <BitOffs>9508920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -77329,7 +77370,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508640</BitOffs>
+            <BitOffs>9508928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
@@ -77340,7 +77381,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508672</BitOffs>
+            <BitOffs>9508960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -77352,7 +77393,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631335872</BitOffs>
+            <BitOffs>631336160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -77364,7 +77405,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631335904</BitOffs>
+            <BitOffs>631336192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -77378,7 +77419,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631337952</BitOffs>
+            <BitOffs>631338240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
@@ -77389,7 +77430,7 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>631337960</BitOffs>
+            <BitOffs>631338248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -77405,7 +77446,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631337968</BitOffs>
+            <BitOffs>631338256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -77420,7 +77461,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631337984</BitOffs>
+            <BitOffs>631338272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -77446,7 +77487,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631369984</BitOffs>
+            <BitOffs>631370272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -77458,7 +77499,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631385984</BitOffs>
+            <BitOffs>631386272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -77494,7 +77535,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639706848</BitOffs>
+            <BitOffs>639707136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -77530,7 +77571,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707136</BitOffs>
+            <BitOffs>639707424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -77541,7 +77582,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707424</BitOffs>
+            <BitOffs>639707712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -77555,7 +77596,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714432</BitOffs>
+            <BitOffs>639714688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -77569,7 +77610,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714496</BitOffs>
+            <BitOffs>639714752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -77605,11 +77646,71 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714560</BitOffs>
+            <BitOffs>639714816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>639766240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>639766248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <BitOffs>639766256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL2K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>639766264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
-            <BitSize>981568</BitSize>
+            <BitSize>981696</BitSize>
             <BaseType Namespace="lcls2_cc_lib">FB_REF</BaseType>
             <Properties>
               <Property>
@@ -77625,11 +77726,21 @@ Digital outputs</Comment>
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
               </Property>
             </Properties>
-            <BitOffs>639765952</BitOffs>
+            <BitOffs>639766272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>640749408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
-            <BitSize>1575488</BitSize>
+            <BitSize>1576128</BitSize>
             <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -77654,7 +77765,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw := TIIB[IM2K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>640749120</BitOffs>
+            <BitOffs>640749440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fStartupVelo</Name>
@@ -77663,11 +77774,11 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>642324608</BitOffs>
+            <BitOffs>642325568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
-            <BitSize>1575488</BitSize>
+            <BitSize>1576128</BitSize>
             <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -77692,7 +77803,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>642324672</BitOffs>
+            <BitOffs>642325632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fStartupVelo</Name>
@@ -77701,11 +77812,11 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>643900160</BitOffs>
+            <BitOffs>643901760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
-            <BitSize>1575488</BitSize>
+            <BitSize>1576128</BitSize>
             <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -77727,10 +77838,11 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>643900224</BitOffs>
+            <BitOffs>643901824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fStartupVelo</Name>
@@ -77739,11 +77851,11 @@ Digital outputs</Comment>
             <Default>
               <Value>15</Value>
             </Default>
-            <BitOffs>645475712</BitOffs>
+            <BitOffs>645477952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
-            <BitSize>1575488</BitSize>
+            <BitSize>1576128</BitSize>
             <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -77768,7 +77880,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>645475776</BitOffs>
+            <BitOffs>645478016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fStartupVelo</Name>
@@ -77777,11 +77889,11 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>647051264</BitOffs>
+            <BitOffs>647054144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
-            <BitSize>1575488</BitSize>
+            <BitSize>1576128</BitSize>
             <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -77806,7 +77918,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>647051328</BitOffs>
+            <BitOffs>647054208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fStartupVelo</Name>
@@ -77815,67 +77927,17 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>648626816</BitOffs>
+            <BitOffs>648630336</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
             <Default>
-              <Value>0</Value>
+              <Value>-15</Value>
             </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>648627360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>648627368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <BitOffs>648627376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL2K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>648627384</BitOffs>
+            <BitOffs>648630880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
@@ -77890,23 +77952,23 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>648627392</BitOffs>
+            <BitOffs>648630912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>649622976</BitOffs>
+            <BitOffs>649626496</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>649625376</BitOffs>
+            <BitOffs>649628896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
@@ -77932,23 +77994,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649625408</BitOffs>
+            <BitOffs>649628928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>650934080</BitOffs>
+            <BitOffs>650937600</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>650935840</BitOffs>
+            <BitOffs>650939360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -77974,23 +78036,28 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>650935872</BitOffs>
+            <BitOffs>650939392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>652244544</BitOffs>
+            <BitOffs>652248064</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>-15</Value>
+              <Value>0</Value>
             </Default>
-            <BitOffs>652246944</BitOffs>
+            <BitOffs>652250464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>652250472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -78005,7 +78072,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>652246976</BitOffs>
+            <BitOffs>652250496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -78016,32 +78083,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>653590144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>653593216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>653593568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>653593576</BitOffs>
+            <BitOffs>653593664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -78056,7 +78098,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653593600</BitOffs>
+            <BitOffs>653597056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -78067,7 +78109,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>654936768</BitOffs>
+            <BitOffs>654940224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
@@ -78077,7 +78119,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939840</BitOffs>
+            <BitOffs>654943296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -78087,7 +78129,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939872</BitOffs>
+            <BitOffs>654943328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -78097,7 +78139,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939904</BitOffs>
+            <BitOffs>654943360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -78107,7 +78149,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939936</BitOffs>
+            <BitOffs>654943392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -78126,13 +78168,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654940224</BitOffs>
+            <BitOffs>654943680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>655049648</BitOffs>
+            <BitOffs>655053104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -78154,13 +78196,13 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>655049664</BitOffs>
+            <BitOffs>655053120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>656372768</BitOffs>
+            <BitOffs>656376224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -78182,97 +78224,97 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>656372800</BitOffs>
+            <BitOffs>656376256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657684480</BitOffs>
+            <BitOffs>657687936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657982400</BitOffs>
+            <BitOffs>657985856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658280320</BitOffs>
+            <BitOffs>658283776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658578240</BitOffs>
+            <BitOffs>658581696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658876160</BitOffs>
+            <BitOffs>658879616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659174080</BitOffs>
+            <BitOffs>659177536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659472000</BitOffs>
+            <BitOffs>659475456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659769920</BitOffs>
+            <BitOffs>659773376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660067840</BitOffs>
+            <BitOffs>660071296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660365760</BitOffs>
+            <BitOffs>660369216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660663680</BitOffs>
+            <BitOffs>660667136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660961600</BitOffs>
+            <BitOffs>660965056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>661259520</BitOffs>
+            <BitOffs>661262976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>661557440</BitOffs>
+            <BitOffs>661560896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>661557456</BitOffs>
+            <BitOffs>661560912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -78281,7 +78323,7 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>661557472</BitOffs>
+            <BitOffs>661560928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -78290,14 +78332,14 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>661557488</BitOffs>
+            <BitOffs>661560944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>661557496</BitOffs>
+            <BitOffs>661560952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates</Name>
@@ -78312,7 +78354,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>661557504</BitOffs>
+            <BitOffs>661560960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -78327,7 +78369,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063936</BitOffs>
+            <BitOffs>663067392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -78342,7 +78384,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063952</BitOffs>
+            <BitOffs>663067408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumSet</Name>
@@ -78357,7 +78399,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063968</BitOffs>
+            <BitOffs>663067424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumGet</Name>
@@ -78372,13 +78414,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063984</BitOffs>
+            <BitOffs>663067440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>663064000</BitOffs>
+            <BitOffs>663067456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -78402,7 +78444,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>663151808</BitOffs>
+            <BitOffs>663155264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -78412,7 +78454,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663155456</BitOffs>
+            <BitOffs>663158912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -78422,7 +78464,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663210176</BitOffs>
+            <BitOffs>663213632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -78432,7 +78474,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663264896</BitOffs>
+            <BitOffs>663268352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -78447,13 +78489,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663319616</BitOffs>
+            <BitOffs>663323072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>664825984</BitOffs>
+            <BitOffs>664829440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -78477,7 +78519,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>664913792</BitOffs>
+            <BitOffs>664917248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -78487,7 +78529,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>664917440</BitOffs>
+            <BitOffs>664920896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -78497,43 +78539,43 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>664972160</BitOffs>
+            <BitOffs>664975616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>665027488</BitOffs>
+            <BitOffs>665030944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>665027496</BitOffs>
+            <BitOffs>665030952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>665027504</BitOffs>
+            <BitOffs>665030960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>665027520</BitOffs>
+            <BitOffs>665030976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>665165888</BitOffs>
+            <BitOffs>665169344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>665196736</BitOffs>
+            <BitOffs>665200192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -78552,7 +78594,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>670988352</BitOffs>
+            <BitOffs>670991808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -78571,7 +78613,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671461824</BitOffs>
+            <BitOffs>671465280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -78601,7 +78643,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671935296</BitOffs>
+            <BitOffs>671938752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -78631,7 +78673,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673582208</BitOffs>
+            <BitOffs>673585664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -78646,7 +78688,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229136</BitOffs>
+            <BitOffs>675232592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -78661,7 +78703,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229144</BitOffs>
+            <BitOffs>675232600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -78676,7 +78718,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229152</BitOffs>
+            <BitOffs>675232608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -78691,7 +78733,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229168</BitOffs>
+            <BitOffs>675232624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -78720,7 +78762,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229184</BitOffs>
+            <BitOffs>675232640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -78732,7 +78774,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675254400</BitOffs>
+            <BitOffs>675257856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -78743,7 +78785,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675279616</BitOffs>
+            <BitOffs>675283072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -78754,7 +78796,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675304832</BitOffs>
+            <BitOffs>675308288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -78765,7 +78807,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675330048</BitOffs>
+            <BitOffs>675333504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -78776,7 +78818,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675355264</BitOffs>
+            <BitOffs>675358720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -78787,7 +78829,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675380480</BitOffs>
+            <BitOffs>675383936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -78798,7 +78840,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675405696</BitOffs>
+            <BitOffs>675409152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -78827,7 +78869,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675430912</BitOffs>
+            <BitOffs>675434368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -78855,7 +78897,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675456128</BitOffs>
+            <BitOffs>675459584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -78882,7 +78924,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675481344</BitOffs>
+            <BitOffs>675484800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -78909,7 +78951,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675506560</BitOffs>
+            <BitOffs>675510016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -78936,7 +78978,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675531776</BitOffs>
+            <BitOffs>675535232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -78948,7 +78990,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675556992</BitOffs>
+            <BitOffs>675560448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -78977,7 +79019,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675582208</BitOffs>
+            <BitOffs>675585664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -79006,7 +79048,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675607424</BitOffs>
+            <BitOffs>675610880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -79035,7 +79077,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675632640</BitOffs>
+            <BitOffs>675636096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -79064,7 +79106,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675657856</BitOffs>
+            <BitOffs>675661312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -79089,7 +79131,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675683072</BitOffs>
+            <BitOffs>675686528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -79118,7 +79160,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675708288</BitOffs>
+            <BitOffs>675711744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -79147,7 +79189,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675733504</BitOffs>
+            <BitOffs>675736960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -79172,7 +79214,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675758720</BitOffs>
+            <BitOffs>675762176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -79200,7 +79242,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675783936</BitOffs>
+            <BitOffs>675787392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -79227,7 +79269,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675809152</BitOffs>
+            <BitOffs>675812608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -79254,7 +79296,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675834368</BitOffs>
+            <BitOffs>675837824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -79281,7 +79323,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675859584</BitOffs>
+            <BitOffs>675863040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -79310,7 +79352,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675884800</BitOffs>
+            <BitOffs>675888256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -79339,7 +79381,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675910016</BitOffs>
+            <BitOffs>675913472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -79364,7 +79406,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675935232</BitOffs>
+            <BitOffs>675938688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -79393,7 +79435,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675960448</BitOffs>
+            <BitOffs>675963904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -79418,7 +79460,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675985664</BitOffs>
+            <BitOffs>675989120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -79455,7 +79497,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676010880</BitOffs>
+            <BitOffs>676014336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -79500,7 +79542,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676036096</BitOffs>
+            <BitOffs>676039552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -79541,7 +79583,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676061312</BitOffs>
+            <BitOffs>676064768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -79582,7 +79624,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676086528</BitOffs>
+            <BitOffs>676089984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -79623,7 +79665,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676111744</BitOffs>
+            <BitOffs>676115200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -79664,7 +79706,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676136960</BitOffs>
+            <BitOffs>676140416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -79705,7 +79747,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676162176</BitOffs>
+            <BitOffs>676165632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -79746,7 +79788,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676187392</BitOffs>
+            <BitOffs>676190848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -79787,7 +79829,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676212608</BitOffs>
+            <BitOffs>676216064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -79823,7 +79865,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676237824</BitOffs>
+            <BitOffs>676241280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -79859,7 +79901,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676263040</BitOffs>
+            <BitOffs>676266496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -79895,7 +79937,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676288256</BitOffs>
+            <BitOffs>676291712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -79940,7 +79982,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676313472</BitOffs>
+            <BitOffs>676316928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -79970,7 +80012,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338688</BitOffs>
+            <BitOffs>676342144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -80000,7 +80042,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338752</BitOffs>
+            <BitOffs>676342208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -80014,7 +80056,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338816</BitOffs>
+            <BitOffs>676342272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -80028,7 +80070,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338848</BitOffs>
+            <BitOffs>676342304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -80042,7 +80084,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338880</BitOffs>
+            <BitOffs>676342336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -80056,7 +80098,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338912</BitOffs>
+            <BitOffs>676342368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -80070,7 +80112,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676340960</BitOffs>
+            <BitOffs>676344416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -80088,7 +80130,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676340992</BitOffs>
+            <BitOffs>676344448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -80102,7 +80144,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342016</BitOffs>
+            <BitOffs>676345472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -80123,7 +80165,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342048</BitOffs>
+            <BitOffs>676345504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -80192,7 +80234,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355424</BitOffs>
+            <BitOffs>676358880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -80261,7 +80303,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355552</BitOffs>
+            <BitOffs>676359008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -80330,7 +80372,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355680</BitOffs>
+            <BitOffs>676359136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -80399,7 +80441,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355808</BitOffs>
+            <BitOffs>676359264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -80468,7 +80510,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355936</BitOffs>
+            <BitOffs>676359392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -80537,7 +80579,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676356064</BitOffs>
+            <BitOffs>676359520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -80560,7 +80602,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676386400</BitOffs>
+            <BitOffs>676389856</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -80647,7 +80689,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-18T12:08:19</Value>
+          <Value>2023-08-21T16:31:22</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- `LCLS-General 2.9.0`
- `lcls2-cc-lib 2.1.0`
- implement flow meters for im3/4/5/6k4

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New hardware installed FD-Q20C Keyence flow meters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- running branch on lcls-plc-tmo-motion
- IOC rebuilt and test:
- nrw@tmo-control:~$ camonitor IM4K4:PPM:FWM:VAL_RBV
IM4K4:PPM:FWM:VAL_RBV          2023-08-22 10:21:48.375937 1.80366  
IM4K4:PPM:FWM:VAL_RBV          2023-08-22 10:21:49.375949 1.87692  
IM4K4:PPM:FWM:VAL_RBV          2023-08-22 10:21:50.375985 1.74212  


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-1248
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
