### PR TITLE
Wfs ppm pmps 

### DIFF
--- a/plc-tmo-motion/_Config/NC/Axes/FoilY.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/FoilY.xti
@@ -1329,7 +1329,7 @@ External Setpoint Generation:
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
-			<EncPara ScaleFactorNumerator="5e-05" MaxCount="#xffffffff">
+			<EncPara ScaleFactorNumerator="5e-05" Offset="-214725.8336" MaxCount="#xffffffff">
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1463,7 +1463,7 @@ Drive Status 4 (manually linked):
 		</Drive>
 		<Controller Name="Ctrl" CtrType="1">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="0.1"/>
+				<PosDiffControl Range="0.005"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>
 		</Controller>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -12518,6 +12518,9 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^Main.M16.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
 			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
@@ -12575,6 +12578,9 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL2004-E3">
 				<Link VarA="PlcTask Outputs^Main.M27.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
@@ -12657,6 +12663,9 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL2004-E3">
 				<Link VarA="PlcTask Outputs^Main.M17.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -12488,6 +12488,9 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^Main.M15.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
 			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM3K4-PPM (EK1100)^IM3K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM3K4-PPM (EK1100)^IM3K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1236,6 +1236,300 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
 					<Comment>
 						<![CDATA[ Connect this input to the terminal]]>
@@ -1292,6 +1586,300 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -1326,7 +1914,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1395,6 +1986,300 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -1429,7 +2314,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1498,6 +2386,300 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -1532,7 +2714,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1601,6 +2786,300 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -1635,7 +3114,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1704,6 +3186,300 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -1738,7 +3514,10 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.fRaw</Name>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1805,6 +3584,300 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -1903,6 +3976,300 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -2033,6 +4400,300 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<SubVar>
+						<Name>AxisState</Name>
+						<Comment>
+							<![CDATA[Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>HomingState</Name>
+						<Comment>
+							<![CDATA[Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+]]>
+						</Comment>
+					</SubVar>
+					<SubVar>
+						<Name>CoupleState</Name>
+						<Comment>
+							<![CDATA[Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+]]>
+						</Comment>
+					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment>
+						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
+					<Comment>
+						<![CDATA[ NO Home Switch: TRUE if at home]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment>
+						<![CDATA[ NC STO Input: TRUE if ok to move]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
+					</Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment>
+						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
+					</Comment>
+					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -2522,14 +5183,6 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL1Low</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -2644,11 +5297,11 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL2High</Name>
+					<Name>PRG_SP1K4.bTL1High</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL2Low</Name>
+					<Name>PRG_SP1K4.bTL1Low</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -3401,6 +6054,14 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL2High</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL2Low</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -8448,6 +11109,39 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -8465,6 +11159,39 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -8486,6 +11213,39 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -8503,6 +11263,39 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -8524,6 +11317,39 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
 					<Type>INT</Type>
 				</Var>
@@ -8541,6 +11367,39 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -8562,6 +11421,39 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
@@ -8570,12 +11462,78 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment>
+						<![CDATA[ NC Brake Output: TRUE to release brake]]>
+					</Comment>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -8800,6 +11758,10 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 					<SubVar>
@@ -8935,10 +11897,6 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -4946,14 +4946,6 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bHallInput1</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -5172,6 +5164,22 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.bHallInput1</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bHallInput2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1High</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1Low</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
 					<Comment>
 						<![CDATA[IO]]>
@@ -5297,11 +5305,11 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
+					<Name>PRG_SP1K4.bTL2High</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1Low</Name>
+					<Name>PRG_SP1K4.bTL2Low</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6054,14 +6062,6 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL2High</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL2Low</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -11758,10 +11758,6 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 					<SubVar>
@@ -11897,6 +11893,10 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -4946,6 +4946,14 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.bHallInput1</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bHallInput2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -5164,22 +5172,6 @@ External Setpoint Generation:
 					</SubVar>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bHallInput1</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL1Low</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
 					<Comment>
 						<![CDATA[IO]]>
@@ -5305,11 +5297,11 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL2High</Name>
+					<Name>PRG_SP1K4.bTL1High</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL2Low</Name>
+					<Name>PRG_SP1K4.bTL1Low</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6062,6 +6054,14 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL2High</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL2Low</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -11758,6 +11758,10 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 					<SubVar>
@@ -11893,10 +11897,6 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -12696,8 +12696,8 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO" VarB="Channel 9^Output" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Bottom Rail (EK1100)^FoilX-EL7041">
-				<Link VarA="PlcTask Inputs^Main.M33.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^Main.M33.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M33.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M33.bLimitForwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Bottom Rail (EK1100)^LensX_EL1004">
 				<Link VarA="PlcTask Inputs^PRG_SP1K4.bHallInput1" VarB="Channel 1^Input" AutoLink="true"/>

--- a/plc-tmo-motion/tmo_motion/GVLs/GVL_TcGVL.TcGVL
+++ b/plc-tmo-motion/tmo_motion/GVLs/GVL_TcGVL.TcGVL
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <GVL Name="GVL_TcGVL" Id="{e55d56fd-1b98-4fb3-b5c9-b090cee52dfb}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+VAR_GLOBAL
+    ePF1K4State: E_WFS_States;
+    ePF2K4State:E_WFS_States;
+END_VAR]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/plc-tmo-motion/tmo_motion/GVLs/Main.TcGVL
+++ b/plc-tmo-motion/tmo_motion/GVLs/Main.TcGVL
@@ -168,8 +168,8 @@ VAR_GLOBAL
         bPowerSelf:=TRUE,
         nEnableMode:=ENUM_StageEnableMode.DURING_MOTION,
         nHomingMode := ENUM_EpicsHomeCmd.ABSOLUTE_SET);
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 2'
+    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 1'
                               .nRawEncoderULINT:=TIIB[SP1K4-EL5042-E2]^FB Inputs Channel 2^Position'}
     {attribute 'pytmc' := '
         pv: TMO:SPEC:MMS:02

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
@@ -29,8 +29,11 @@ fbAL1K4(
     stYStage := Main.M1,
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
-    sPmpsDeviceName := 'AL1K4:L2SI',
+    sDeviceName := 'AL1K4:L2SI',
     sTransitionKey := 'AL1K4:L2SI-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
@@ -18,11 +18,13 @@ END_VAR
 fbAL1K4.stOut.fPosition := -33.5; // Upper limit
 fbAL1K4.stOut.bUseRawCounts := FALSE;
 fbAL1K4.stOut.bValid := TRUE;
+fbAL1K4.stOut.bMoveOk := TRUE;
 fbAL1K4.stOut.stPMPS.sPmpsState := 'AL1K4:L2SI-OUT';
 
 fbAL1K4.stIn.fPosition := -75; // Current position at time of edit
 fbAL1K4.stIn.bUseRawCounts := FALSE;
 fbAL1K4.stIn.bValid := TRUE;
+fbAL1K4.stIn.bMoveOk := TRUE;
 fbAL1K4.stIn.stPMPS.sPmpsState := 'AL1K4:L2SI-IN';
 
 fbAL1K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM2K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM2K4_PPM.TcPOU
@@ -53,8 +53,11 @@ fbIM2K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M9,
-    sPmpsDeviceName := 'IM2K4:PPM',
+    sDeviceName := 'IM2K4:PPM',
     sTransitionKey := 'IM2K4:PPM-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM2K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM2K4_PPM.TcPOU
@@ -29,24 +29,28 @@ fbIM2K4.stOut.fPosition := -8.59;
 fbIM2K4.stOut.fVelocity := fStartupVelo;
 fbIM2K4.stOut.bUseRawCounts := FALSE;
 fbIM2K4.stOut.bValid := TRUE;
+fbIM2K4.stOut.bMoveOk := TRUE;
 fbIM2K4.stOut.stPMPS.sPmpsState := 'IM2K4:PPM-OUT';
 
 fbIM2K4.stPower.fPosition := -47.69;
 fbIM2K4.stPower.fVelocity := fStartupVelo;
 fbIM2K4.stPower.bUseRawCounts := FALSE;
 fbIM2K4.stPower.bValid := TRUE;
+fbIM2K4.stPower.bMoveOk := TRUE;
 fbIM2K4.stPower.stPMPS.sPmpsState := 'IM2K4:PPM-POWERMETER';
 
 fbIM2K4.stYag1.fPosition := -71.69;
 fbIM2K4.stYag1.fVelocity := fStartupVelo;
 fbIM2K4.stYag1.bUseRawCounts := FALSE;
 fbIM2K4.stYag1.bValid := TRUE;
+fbIM2K4.stYag1.bMoveOk := TRUE;
 fbIM2K4.stYag1.stPMPS.sPmpsState := 'IM2K4:PPM-YAG1';
 
 fbIM2K4.stYag2.fPosition := -97.70;
 fbIM2K4.stYag2.fVelocity := fStartupVelo;
 fbIM2K4.stYag2.bUseRawCounts := FALSE;
 fbIM2K4.stYag2.bValid := TRUE;
+fbIM2K4.stYag2.bMoveOk := TRUE;
 fbIM2K4.stYag2.stPMPS.sPmpsState := 'IM2K4:PPM-YAG2';
 
 fbIM2K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
@@ -53,8 +53,11 @@ fbIM3K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M15,
-    sPmpsDeviceName := 'IM3K4:PPM',
+    sDeviceName := 'IM3K4:PPM',
     sTransitionKey := 'IM3K4:PPM-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
@@ -30,24 +30,28 @@ fbIM3K4.stOut.fPosition := -5.82;
 fbIM3K4.stOut.fVelocity := fStartupVelo;
 fbIM3K4.stOut.bUseRawCounts := FALSE;
 fbIM3K4.stOut.bValid := TRUE;
+fbIM3K4.stOut.bMoveOk := TRUE;
 fbIM3K4.stOut.stPMPS.sPmpsState := 'IM3K4:PPM-OUT';
 
 fbIM3K4.stPower.fPosition := -44.92;
 fbIM3K4.stPower.fVelocity := fStartupVelo;
 fbIM3K4.stPower.bUseRawCounts := FALSE;
 fbIM3K4.stPower.bValid := TRUE;
+fbIM3K4.stPower.bMoveOk := TRUE;
 fbIM3K4.stPower.stPMPS.sPmpsState := 'IM3K4:PPM-POWERMETER';
 
 fbIM3K4.stYag1.fPosition := -68.92;
 fbIM3K4.stYag1.fVelocity := fStartupVelo;
 fbIM3K4.stYag1.bUseRawCounts := FALSE;
 fbIM3K4.stYag1.bValid := TRUE;
+fbIM3K4.stYag1.bMoveOk := TRUE;
 fbIM3K4.stYag1.stPMPS.sPmpsState := 'IM3K4:PPM-YAG1';
 
 fbIM3K4.stYag2.fPosition := -94.93;
 fbIM3K4.stYag2.fVelocity := fStartupVelo;
 fbIM3K4.stYag2.bUseRawCounts := FALSE;
 fbIM3K4.stYag2.bValid := TRUE;
+fbIM3K4.stYag2.bMoveOk := TRUE;
 fbIM3K4.stYag2.stPMPS.sPmpsState := 'IM3K4:PPM-YAG2';
 
 fbIM3K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value';
+                              .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM4K4: FB_PPM;
     fStartupVelo: LREAL := 15;
 END_VAR
@@ -63,6 +64,7 @@ fbIM4K4(
     bEnableMotion := TRUE,
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
+    fFlowOffset := 0.4,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -29,24 +29,28 @@ fbIM4K4.stOut.fPosition := -9.29;
 fbIM4K4.stOut.fVelocity := fStartupVelo;
 fbIM4K4.stOut.bUseRawCounts := FALSE;
 fbIM4K4.stOut.bValid := TRUE;
+fbIM4K4.stOut.bMoveOk := TRUE;
 fbIM4K4.stOut.stPMPS.sPmpsState := 'IM4K4:PPM-OUT';
 
 fbIM4K4.stPower.fPosition := -48.39;
 fbIM4K4.stPower.fVelocity := fStartupVelo;
 fbIM4K4.stPower.bUseRawCounts := FALSE;
 fbIM4K4.stPower.bValid := TRUE;
+fbIM4K4.stPower.bMoveOk := TRUE;
 fbIM4K4.stPower.stPMPS.sPmpsState := 'IM4K4:PPM-POWERMETER';
 
 fbIM4K4.stYag1.fPosition := -72.39;
 fbIM4K4.stYag1.fVelocity := fStartupVelo;
 fbIM4K4.stYag1.bUseRawCounts := FALSE;
 fbIM4K4.stYag1.bValid := TRUE;
+fbIM4K4.stYag1.bMoveOk := TRUE;
 fbIM4K4.stYag1.stPMPS.sPmpsState := 'IM4K4:PPM-YAG1';
 
 fbIM4K4.stYag2.fPosition := -98.4;
 fbIM4K4.stYag2.fVelocity := fStartupVelo;
 fbIM4K4.stYag2.bUseRawCounts := FALSE;
 fbIM4K4.stYag2.bValid := TRUE;
+fbIM4K4.stYag2.bMoveOk := TRUE;
 fbIM4K4.stYag2.stPMPS.sPmpsState := 'IM4K4:PPM-YAG2';
 
 IF Main.M16.fVelocity > 1 AND Main.M16.fVelocity <> 15 AND Main.M16.bExecute THEN

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -17,7 +17,7 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value';
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value;
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM4K4: FB_PPM;
     fStartupVelo: LREAL := 15;

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -58,8 +58,11 @@ fbIM4K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M16,
-    sPmpsDeviceName := 'IM4K4:PPM',
+    sDeviceName := 'IM4K4:PPM',
     sTransitionKey := 'IM4K4:PPM-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -31,23 +31,27 @@ fbIM5K4.stOut.fPosition := -5.13;
 fbIM5K4.stOut.fVelocity := fStartupVelo;
 fbIM5K4.stOut.bUseRawCounts := FALSE;
 fbIM5K4.stOut.bValid := TRUE;
+fbIM5K4.stOut.bMoveOk := TRUE;
 fbIM5K4.stOut.stPMPS.sPmpsState := 'IM5K4:PPM-OUT';
 
 fbIM5K4.stPower.fPosition := -44.23;
 fbIM5K4.stPower.fVelocity := fStartupVelo;
 fbIM5K4.stPower.bUseRawCounts := FALSE;
 fbIM5K4.stPower.bValid := TRUE;
+fbIM5K4.stPower.bMoveOk := TRUE;
 fbIM5K4.stPower.stPMPS.sPmpsState := 'IM5K4:PPM-POWERMETER';
 
 fbIM5K4.stYag1.fPosition := -68.23;
 fbIM5K4.stYag1.fVelocity := fStartupVelo;
 fbIM5K4.stYag1.bUseRawCounts := FALSE;
+fbIM5K4.stYag1.bMoveOk := TRUE;
 fbIM5K4.stYag1.bValid := TRUE;
 
 
 fbIM5K4.stYag2.fPosition := -94.24;
 fbIM5K4.stYag2.fVelocity := fStartupVelo;
 fbIM5K4.stYag2.bUseRawCounts := FALSE;
+fbIM5K4.stYag2.bMoveOk := TRUE;
 fbIM5K4.stYag2.bValid := TRUE;
 
 

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value';
+                              .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM5K4: FB_PPM;
     fStartupVelo: LREAL := 12;
 
@@ -70,6 +71,7 @@ fbIM5K4(
     bEnableMotion := TRUE,
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
+    fFlowOffset := 0.8,
 
 );]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -17,7 +17,7 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value';
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value;
                               .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM5K4: FB_PPM;
     fStartupVelo: LREAL := 12;

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -20,6 +20,7 @@ VAR
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value'}
     fbIM5K4: FB_PPM;
     fStartupVelo: LREAL := 12;
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -41,20 +42,34 @@ fbIM5K4.stYag1.fPosition := -68.23;
 fbIM5K4.stYag1.fVelocity := fStartupVelo;
 fbIM5K4.stYag1.bUseRawCounts := FALSE;
 fbIM5K4.stYag1.bValid := TRUE;
-fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1';
+
 
 fbIM5K4.stYag2.fPosition := -94.24;
 fbIM5K4.stYag2.fVelocity := fStartupVelo;
 fbIM5K4.stYag2.bUseRawCounts := FALSE;
 fbIM5K4.stYag2.bValid := TRUE;
-fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2';
+
+
+CASE GVL_TcGVL.ePF1K4State OF
+    E_WFS_STATES.TARGET1, E_WFS_STATES.TARGET2, E_WFS_STATES.TARGET3, E_WFS_STATES.TARGET4, E_WFS_STATES.TARGET5 :
+        // Known state targets: allow less strict pmps
+        fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1_WFS_IN';
+        fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2_WFS_IN';
+ELSE
+    // Out, Unknown, or an unexpected state: full pmps
+    fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1';
+    fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2';
+END_CASE
 
 fbIM5K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M17,
-    sPmpsDeviceName := 'IM5K4:PPM',
+    sDeviceName := 'IM5K4:PPM',
     sTransitionKey := 'IM5K4:PPM-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 
 );]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -17,7 +17,8 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value'}
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value';
+                              .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM6K4: FB_PPM;
     fStartupVelo: LREAL := 13;
 END_VAR
@@ -70,6 +71,7 @@ fbIM6K4(
     bEnableMotion := TRUE,
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
+    fFlowOffset := 0.6,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -29,23 +29,29 @@ fbIM6K4.stOut.fPosition := -7.4;
 fbIM6K4.stOut.fVelocity := fStartupVelo;
 fbIM6K4.stOut.bUseRawCounts := FALSE;
 fbIM6K4.stOut.bValid := TRUE;
+fbIM6K4.stOut.bMoveOk := TRUE;
 fbIM6K4.stOut.stPMPS.sPmpsState := 'IM6K4:PPM-OUT';
 
 fbIM6K4.stPower.fPosition := -46.5;
 fbIM6K4.stPower.fVelocity := fStartupVelo;
 fbIM6K4.stPower.bUseRawCounts := FALSE;
 fbIM6K4.stPower.bValid := TRUE;
+fbIM6K4.stPower.bMoveOk := TRUE;
+fbIM6K4.stPower.stPMPS.sPmpsState := 'IM6K4:PPM-POWERMETER';
 
 fbIM6K4.stYag1.fPosition := -70.5;
 fbIM6K4.stYag1.fVelocity := fStartupVelo;
 fbIM6K4.stYag1.bUseRawCounts := FALSE;
 fbIM6K4.stYag1.bValid := TRUE;
-fbIM6K4.stYag1.stPMPS.sPmpsState := 'IM6K4:PPM-YAG1';
+fbIM6K4.stYag1.bMoveOk := TRUE;
+
 
 fbIM6K4.stYag2.fPosition := -96.51;
 fbIM6K4.stYag2.fVelocity := fStartupVelo;
 fbIM6K4.stYag2.bUseRawCounts := FALSE;
 fbIM6K4.stYag2.bValid := TRUE;
+fbIM6K4.stYag2.bMoveOk := TRUE;
+
 
 CASE GVL_TcGVL.ePF2K4State OF
     E_WFS_STATES.TARGET1, E_WFS_STATES.TARGET2, E_WFS_STATES.TARGET3, E_WFS_STATES.TARGET4, E_WFS_STATES.TARGET5 :

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -17,7 +17,7 @@ VAR
                               .fbYagThermoCouple.bError 				:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value';
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value;
                               .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM6K4: FB_PPM;
     fStartupVelo: LREAL := 13;

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -34,7 +34,6 @@ fbIM6K4.stPower.fPosition := -46.5;
 fbIM6K4.stPower.fVelocity := fStartupVelo;
 fbIM6K4.stPower.bUseRawCounts := FALSE;
 fbIM6K4.stPower.bValid := TRUE;
-fbIM6K4.stPower.stPMPS.sPmpsState := 'IM6K4:PPM-POWERMETER';
 
 fbIM6K4.stYag1.fPosition := -70.5;
 fbIM6K4.stYag1.fVelocity := fStartupVelo;
@@ -46,14 +45,31 @@ fbIM6K4.stYag2.fPosition := -96.51;
 fbIM6K4.stYag2.fVelocity := fStartupVelo;
 fbIM6K4.stYag2.bUseRawCounts := FALSE;
 fbIM6K4.stYag2.bValid := TRUE;
-fbIM6K4.stYag2.stPMPS.sPmpsState := 'IM6K4:PPM-YAG2';
+
+CASE GVL_TcGVL.ePF2K4State OF
+    E_WFS_STATES.TARGET1, E_WFS_STATES.TARGET2, E_WFS_STATES.TARGET3, E_WFS_STATES.TARGET4, E_WFS_STATES.TARGET5 :
+        // Known state targets: allow less strict pmps
+        fbIM6K4.stYag1.stPMPS.sPmpsState := 'IM6K4:PPM-YAG1_WFS_IN';
+        fbIM6K4.stYag2.stPMPS.sPmpsState := 'IM6K4:PPM-YAG2_WFS_IN';
+ELSE
+    // Out, Unknown, or an unexpected state: full pmps
+    fbIM6K4.stYag1.stPMPS.sPmpsState := 'IM6K4:PPM-YAG1';
+    fbIM6K4.stYag2.stPMPS.sPmpsState := 'IM6K4:PPM-YAG2';
+END_CASE
+
+
+
+
 
 fbIM6K4(
     fbArbiter := fbArbiter2,
     fbFFHWO := fbFastFaultOutput2,
     stYStage := Main.M27,
-    sPmpsDeviceName := 'IM6K4:PPM',
+    sDeviceName := 'IM6K4:PPM',
     sTransitionKey := 'IM6K4:PPM-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
@@ -24,21 +24,25 @@ END_VAR
 fbLI1K4.stOut.fPosition := 0.118;
 fbLI1K4.stOut.bUseRawCounts := FALSE;
 fbLI1K4.stOut.bValid := TRUE;
+fbLI1K4.stOut.bMoveOk := TRUE;
 fbLI1K4.stOut.stPMPS.sPmpsState := 'LI1K4:IP1-OUT';
 
 fbLI1K4.stMirror1.fPosition := -36.38;
 fbLI1K4.stMirror1.bUseRawCounts := FALSE;
 fbLI1K4.stMirror1.bValid := TRUE;
+fbLI1K4.stMirror1.bMoveOk := TRUE;
 fbLI1K4.stMirror1.stPMPS.sPmpsState := 'LI1K4:IP1-MIRROR1';
 
 fbLI1K4.stMirror2.fPosition := -70.38;
 fbLI1K4.stMirror2.bUseRawCounts := FALSE;
 fbLI1K4.stMirror2.bValid := TRUE;
+fbLI1K4.stMirror2.bMoveOk := TRUE;
 fbLI1K4.stMirror2.stPMPS.sPmpsState := 'LI1K4:IP1-MIRROR2';
 
 fbLI1K4.stTarget1.fPosition := -102.38;
 fbLI1K4.stTarget1.bUseRawCounts := FALSE;
 fbLI1K4.stTarget1.bValid := TRUE;
+fbLI1K4.stTarget1.bMoveOk := TRUE;
 fbLI1K4.stTarget1.stPMPS.sPmpsState := 'LI1K4:IP1-TARGET1';
 
 fbLI1K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
@@ -45,8 +45,11 @@ fbLI1K4(
     fbArbiter := fbArbiter,
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M20,
-    sPmpsDeviceName := 'LI1K4:IP1',
+    sDeviceName := 'LI1K4:IP1',
     sTransitionKey := 'LI1K4:IP1-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
@@ -62,8 +62,12 @@ fbPF1K4(
     fbFFHWO := fbFastFaultOutput1,
     stYStage := Main.M18,
     stZStage := Main.M19,
-    sPmpsDeviceName := 'PF1K4:WFS',
+    sDeviceName := 'PF1K4:WFS',
     sTransitionKey := 'PF1K4:WFS-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
+    eEnumGet => GVL_TcGVL.ePF1K4State,
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
@@ -30,31 +30,37 @@ END_VAR
 fbPF1K4.stOut.fPosition := -10.5;
 fbPF1K4.stOut.bUseRawCounts := FALSE;
 fbPF1K4.stOut.bValid := TRUE;
+fbPF1K4.stOut.bMoveOk := TRUE;
 fbPF1K4.stOut.stPMPS.sPmpsState := 'PF1K4:WFS-OUT';
 
 fbPF1K4.stTarget1.fPosition := -93.033;
 fbPF1K4.stTarget1.bUseRawCounts := FALSE;
 fbPF1K4.stTarget1.bValid := TRUE;
+fbPF1K4.stTarget1.bMoveOk := TRUE;
 fbPF1K4.stTarget1.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET1';
 
 fbPF1K4.stTarget2.fPosition := -78.658;
 fbPF1K4.stTarget2.bUseRawCounts := FALSE;
 fbPF1K4.stTarget2.bValid := TRUE;
+fbPF1K4.stTarget2.bMoveOk := TRUE;
 fbPF1K4.stTarget2.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET2';
 
 fbPF1K4.stTarget3.fPosition := -64.282;
 fbPF1K4.stTarget3.bUseRawCounts := FALSE;
 fbPF1K4.stTarget3.bValid := TRUE;
+fbPF1K4.stTarget3.bMoveOk := TRUE;
 fbPF1K4.stTarget3.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET3';
 
 fbPF1K4.stTarget4.fPosition := -49.907;
 fbPF1K4.stTarget4.bUseRawCounts := FALSE;
 fbPF1K4.stTarget4.bValid := TRUE;
+fbPF1K4.stTarget4.bMoveOk := TRUE;
 fbPF1K4.stTarget4.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET4';
 
 fbPF1K4.stTarget5.fPosition := -35.533;
 fbPF1K4.stTarget5.bUseRawCounts := FALSE;
 fbPF1K4.stTarget5.bValid := TRUE;
+fbPF1K4.stTarget5.bMoveOk := TRUE;
 fbPF1K4.stTarget5.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET5';
 
 fbPF1K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
@@ -29,31 +29,37 @@ END_VAR
 fbPF2K4.stOut.fPosition := -13.5;
 fbPF2K4.stOut.bUseRawCounts := FALSE;
 fbPF2K4.stOut.bValid := TRUE;
+fbPF2K4.stOut.bMoveOk := TRUE;
 fbPF2K4.stOut.stPMPS.sPmpsState := 'PF2K4:WFS-OUT';
 
 fbPF2K4.stTarget1.fPosition := -96.127;
 fbPF2K4.stTarget1.bUseRawCounts := FALSE;
 fbPF2K4.stTarget1.bValid := TRUE;
+fbPF2K4.stTarget1.bMoveOk := TRUE;
 fbPF2K4.stTarget1.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET1';
 
 fbPF2K4.stTarget2.fPosition := -81.753;
 fbPF2K4.stTarget2.bUseRawCounts := FALSE;
 fbPF2K4.stTarget2.bValid := TRUE;
+fbPF2K4.stTarget2.bMoveOk := TRUE;
 fbPF2K4.stTarget2.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET2';
 
 fbPF2K4.stTarget3.fPosition := -67.378;
 fbPF2K4.stTarget3.bUseRawCounts := FALSE;
 fbPF2K4.stTarget3.bValid := TRUE;
+fbPF2K4.stTarget3.bMoveOk := TRUE;
 fbPF2K4.stTarget3.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET3';
 
 fbPF2K4.stTarget4.fPosition := -53.002;
 fbPF2K4.stTarget4.bUseRawCounts := FALSE;
 fbPF2K4.stTarget4.bValid := TRUE;
+fbPF2K4.stTarget4.bMoveOk := TRUE;
 fbPF2K4.stTarget4.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET4';
 
 fbPF2K4.stTarget5.fPosition := -38.627;
 fbPF2K4.stTarget5.bUseRawCounts := FALSE;
 fbPF2K4.stTarget5.bValid := TRUE;
+fbPF2K4.stTarget5.bMoveOk := TRUE;
 fbPF2K4.stTarget5.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET5';
 
 fbPF2K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
@@ -61,8 +61,12 @@ fbPF2K4(
     fbFFHWO := fbFastFaultOutput2,
     stYStage := Main.M28,
     stZStage := Main.M29,
-    sPmpsDeviceName := 'PF2K4:WFS',
+    sDeviceName := 'PF2K4:WFS',
     sTransitionKey := 'PF2K4:WFS-TRANSITION',
+    bEnableMotion := TRUE,
+    bEnableBeamParams := TRUE,
+    bEnablePositionLimits := TRUE,
+    eEnumGet => GVL_TcGVL.ePF2K4State,
 );
 ]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -34,6 +34,10 @@
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
     </Compile>
+    <Compile Include="GVLs\GVL_TcGVL.TcGVL">
+      <SubType>Code</SubType>
+      <LinkAlways>true</LinkAlways>
+    </Compile>
     <Compile Include="GVLs\Main.TcGVL">
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
@@ -149,13 +153,13 @@
       <DefaultResolution>LCLS General, * (SLAC)</DefaultResolution>
       <Namespace>LCLS_General</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="lcls-twincat-common-components">
+      <DefaultResolution>lcls-twincat-common-components, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_common_components</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="lcls-twincat-motion">
       <DefaultResolution>lcls-twincat-motion, * (SLAC)</DefaultResolution>
       <Namespace>lcls_twincat_motion</Namespace>
-    </PlaceholderReference>
-    <PlaceholderReference Include="lcls2-cc-lib">
-      <DefaultResolution>lcls2-cc-lib, * (SLAC)</DefaultResolution>
-      <Namespace>lcls2_cc_lib</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="PMPS">
       <DefaultResolution>PMPS, * (SLAC - LCLS)</DefaultResolution>
@@ -190,13 +194,13 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="LCLS General">
-      <Resolution>LCLS General, 2.8.2 (SLAC)</Resolution>
+      <Resolution>LCLS General, 2.9.1 (SLAC)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="lcls-twincat-common-components">
+      <Resolution>lcls-twincat-common-components, 3.0.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 3.0.1 (SLAC)</Resolution>
-    </PlaceholderResolution>
-    <PlaceholderResolution Include="lcls2-cc-lib">
-      <Resolution>lcls2-cc-lib, 2.0.0 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, 4.0.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -197,7 +197,7 @@
       <Resolution>LCLS General, 2.9.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-common-components">
-      <Resolution>lcls-twincat-common-components, 3.0.0 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-common-components, 0.0.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 4.0.0 (SLAC)</Resolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -196,6 +196,12 @@
     <PlaceholderResolution Include="LCLS General">
       <Resolution>LCLS General, 2.9.1 (SLAC)</Resolution>
     </PlaceholderResolution>
+    <PlaceholderResolution Include="lcls-twincat-common-components">
+      <Resolution>lcls-twincat-common-components, 3.0.1 (SLAC)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="lcls-twincat-motion">
+      <Resolution>lcls-twincat-motion, 4.0.1 (SLAC)</Resolution>
+    </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>
     </PlaceholderResolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -196,12 +196,6 @@
     <PlaceholderResolution Include="LCLS General">
       <Resolution>LCLS General, 2.9.1 (SLAC)</Resolution>
     </PlaceholderResolution>
-    <PlaceholderResolution Include="lcls-twincat-common-components">
-      <Resolution>lcls-twincat-common-components, 0.0.0 (SLAC)</Resolution>
-    </PlaceholderResolution>
-    <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 4.0.0 (SLAC)</Resolution>
-    </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.0.14 (SLAC - LCLS)</Resolution>
     </PlaceholderResolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{20F1ABBE-454A-D8D7-FD93-9D844EEFED26}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FFAD9F7F-8F47-E9A2-2B04-1E1315764F5C}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85690500</GetCodeOffs>
+        <GetCodeOffs>85690536</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85690532</GetCodeOffs>
+        <GetCodeOffs>85690568</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690540</GetCodeOffs>
+        <GetCodeOffs>85690576</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690524</GetCodeOffs>
+        <GetCodeOffs>85690560</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690536</GetCodeOffs>
+        <GetCodeOffs>85690572</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690444</GetCodeOffs>
-        <SetCodeOffs>85690468</SetCodeOffs>
+        <GetCodeOffs>85690480</GetCodeOffs>
+        <SetCodeOffs>85690504</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690480</GetCodeOffs>
-        <SetCodeOffs>85690492</SetCodeOffs>
+        <GetCodeOffs>85690516</GetCodeOffs>
+        <SetCodeOffs>85690528</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1435,9 +1435,6 @@
             <Name>property</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
       </Method>
       <Method>
         <Name>ExtendName</Name>
@@ -1495,19 +1492,7 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Name>Clear</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1554,6 +1539,21 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>32</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>85690588</GetCodeOffs>
+        <GetCodeOffs>85690624</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690568</GetCodeOffs>
+        <GetCodeOffs>85690604</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690656</GetCodeOffs>
+        <GetCodeOffs>85690692</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690616</GetCodeOffs>
+        <GetCodeOffs>85690652</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690660</GetCodeOffs>
+        <GetCodeOffs>85690696</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -1773,7 +1773,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1974,9 +1974,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2139,6 +2136,9 @@
         </Local>
       </Method>
       <Method>
+        <Name>UpdateLangId</Name>
+      </Method>
+      <Method>
         <Name>EqualsToEventEntryEx</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85690684</GetCodeOffs>
+        <GetCodeOffs>85690720</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -4066,6 +4066,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -4547,69 +4610,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4640,15 +4640,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -4933,12 +4933,91 @@
         <BitOffs>8224288</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -4987,53 +5066,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5221,44 +5253,12 @@
         </Properties>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -5569,6 +5569,14 @@
         <BitOffs>4240224</BitOffs>
       </SubItem>
       <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5608,46 +5616,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5814,7 +5782,39 @@
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6158,6 +6158,105 @@
         <BitOffs>12687680</BitOffs>
       </SubItem>
       <Method>
+        <Name>AssertArrayEquals_DINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6403,18 +6502,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6569,115 +6668,6 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6813,21 +6803,6 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7202,11 +7177,26 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>128</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7220,8 +7210,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7285,6 +7275,16 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7299,42 +7299,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7371,6 +7335,210 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>7840</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7577,11 +7745,17 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7590,6 +7764,16 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -7842,37 +8026,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertEquals_REAL</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -7941,34 +8094,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LTIME</Name>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8133,340 +8270,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>7840</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -8566,6 +8369,204 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Parameter>
           <Name>Condition</Name>
@@ -8596,11 +8597,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -8614,8 +8615,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9122,19 +9123,19 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>128</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9182,6 +9183,37 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9294,93 +9326,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -9480,11 +9425,41 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9498,8 +9473,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9510,12 +9485,6 @@
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9582,6 +9551,37 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -12965,6 +12965,14 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13017,6 +13025,20 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13030,25 +13052,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13073,9 +13085,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13095,22 +13104,36 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13137,20 +13160,6 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13194,21 +13203,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13260,35 +13254,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>ResetDocument</Name>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13301,20 +13267,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
+        <Name>AddRawObject</Name>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -13324,11 +13279,21 @@
             </Property>
           </Properties>
         </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13337,6 +13302,21 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13360,7 +13340,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
+        <Name>AddKeyDateTime</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13371,6 +13351,11 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13383,10 +13368,25 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>AddReal</Name>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13705,22 +13705,11 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13779,41 +13768,14 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>7680</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -13851,14 +13813,52 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>7680</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14126,22 +14126,12 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14228,19 +14218,14 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14284,32 +14269,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14332,16 +14291,6 @@
         <Parameter>
           <Name>reserve</Name>
           <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14377,34 +14326,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14444,6 +14382,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14459,7 +14407,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14469,8 +14417,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14535,16 +14483,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14581,7 +14519,59 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14591,8 +14581,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14611,9 +14601,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14626,6 +14616,16 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14636,13 +14636,18 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14714,36 +14719,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14754,24 +14729,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -14822,9 +14792,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14832,7 +14802,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -14930,7 +14900,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14939,15 +14909,9 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14968,21 +14932,6 @@
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15027,6 +14976,38 @@
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15062,39 +15043,44 @@
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15128,34 +15114,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15218,9 +15179,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15228,7 +15189,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15237,26 +15208,9 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15288,9 +15242,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15390,14 +15344,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15480,58 +15426,16 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
@@ -15586,6 +15490,42 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15612,12 +15552,22 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15706,9 +15656,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15726,7 +15676,22 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -15758,17 +15723,28 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15783,9 +15759,134 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -15823,7 +15924,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15833,108 +15934,7 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18237,18 +18237,19 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18264,19 +18265,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18460,88 +18460,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type RpcDirection="in">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -18597,6 +18515,88 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -18795,6 +18795,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Parameter>
           <Name>Name</Name>
@@ -18813,22 +18816,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
         <ReturnType RpcDirection="out">UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -18844,9 +18831,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -18867,10 +18865,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -19230,6 +19230,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -19241,14 +19246,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -19264,9 +19261,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -19303,14 +19300,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -19595,35 +19595,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640288</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19671,9 +19688,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19870,47 +19905,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -20056,37 +20056,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480224</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20094,9 +20064,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -20283,7 +20251,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20843,18 +20843,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -21585,6 +21585,666 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -21889,514 +22549,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -22940,6 +23092,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23429,50 +23596,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -23537,42 +23678,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -23581,22 +23698,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -23604,124 +23706,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -23992,18 +23976,34 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -24376,6 +24376,32 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>WriteLog</Name>
         <Parameter>
           <Name>MsgCtrlMask</Name>
@@ -24409,32 +24435,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -30211,37 +30211,6 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -30286,6 +30255,37 @@ External Setpoint Generation:
 	</Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -30901,28 +30901,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -31183,33 +31183,29 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>391872</BitOffs>
       </SubItem>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
+        <Name>RemoveRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81600</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31333,6 +31329,31 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -31372,40 +31393,19 @@ These features efficiently address the addition, removal, and verification of be
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81600</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -42863,13 +42863,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -42890,7 +42890,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -49687,19 +49687,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Motion</Name>
-      </Action>
-      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_CalculatePositions</Name>
+        <Name>ACT_Motion</Name>
       </Action>
       <Action>
         <Name>ACT_BLOCK</Name>
+      </Action>
+      <Action>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -50449,10 +50449,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Properties>
         <Property>
@@ -50731,10 +50731,10 @@ Digital outputs</Comment>
         <BitOffs>253760</BitOffs>
       </SubItem>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Properties>
         <Property>
@@ -51122,13 +51122,13 @@ Digital outputs</Comment>
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -51401,10 +51401,10 @@ Digital outputs</Comment>
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -52504,89 +52504,6 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name>ENUM_ZonePlate_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Yag</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_1</Text>
-        <Enum>3</Enum>
-        <Comment>Ne1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_2</Text>
-        <Enum>4</Enum>
-        <Comment>Ne2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_3</Text>
-        <Enum>5</Enum>
-        <Comment>Ne3</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_1</Text>
-        <Enum>6</Enum>
-        <Comment>3w1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_2</Text>
-        <Enum>7</Enum>
-        <Comment>3w2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_1</Text>
-        <Enum>8</Enum>
-        <Comment>o1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_2</Text>
-        <Enum>9</Enum>
-        <Comment>o2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_1</Text>
-        <Enum>10</Enum>
-        <Comment>Ti1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_2</Text>
-        <Enum>11</Enum>
-        <Comment>Ti2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_1</Text>
-        <Enum>12</Enum>
-        <Comment>N1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_2</Text>
-        <Enum>13</Enum>
-        <Comment>N2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_1</Text>
-        <Enum>14</Enum>
-        <Comment> C1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_2</Text>
-        <Enum>15</Enum>
-        <Comment>C2
-	FZP250_1 := 16    //w1</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</Name>
       <BitSize>1506432</BitSize>
       <SubItem>
@@ -52956,6 +52873,122 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name>ENUM_ZonePlate_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Yag</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_1</Text>
+        <Enum>3</Enum>
+        <Comment>Ne1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_2</Text>
+        <Enum>4</Enum>
+        <Comment>Ne2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_3</Text>
+        <Enum>5</Enum>
+        <Comment>Ne3</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_1</Text>
+        <Enum>6</Enum>
+        <Comment>3w1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_2</Text>
+        <Enum>7</Enum>
+        <Comment>3w2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_1</Text>
+        <Enum>8</Enum>
+        <Comment>o1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_2</Text>
+        <Enum>9</Enum>
+        <Comment>o2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_1</Text>
+        <Enum>10</Enum>
+        <Comment>Ti1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_2</Text>
+        <Enum>11</Enum>
+        <Comment>Ti2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_1</Text>
+        <Enum>12</Enum>
+        <Comment>N1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_2</Text>
+        <Enum>13</Enum>
+        <Comment>N2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_1</Text>
+        <Enum>14</Enum>
+        <Comment> C1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_2</Text>
+        <Enum>15</Enum>
+        <Comment>C2
+	FZP250_1 := 16    //w1</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
@@ -53509,39 +53542,6 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
     </DataType>
     <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
@@ -54305,8 +54305,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85697216</GetCodeOffs>
-        <SetCodeOffs>85697224</SetCodeOffs>
+        <GetCodeOffs>85697252</GetCodeOffs>
+        <SetCodeOffs>85697260</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -54742,47 +54742,6 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -54830,6 +54789,21 @@ Digital outputs</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
@@ -54932,19 +54906,45 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -55600,31 +55600,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85696784</GetCodeOffs>
+        <GetCodeOffs>85696820</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85696816</GetCodeOffs>
+        <GetCodeOffs>85696852</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85696820</GetCodeOffs>
+        <GetCodeOffs>85696856</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85696808</GetCodeOffs>
+        <GetCodeOffs>85696844</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85696828</GetCodeOffs>
+        <GetCodeOffs>85696864</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -55638,6 +55638,30 @@ Digital outputs</Comment>
         <Local>
           <Name>b32IsBusy</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -55697,30 +55721,6 @@ Digital outputs</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -55856,9 +55856,9 @@ Digital outputs</Comment>
         <BitOffs>64</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -55872,29 +55872,27 @@ Digital outputs</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -55975,45 +55973,6 @@ Digital outputs</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -56147,6 +56106,47 @@ Digital outputs</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -56842,46 +56842,12 @@ Digital outputs</Comment>
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>32</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -57008,6 +56974,40 @@ Digital outputs</Comment>
               <Value>__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -58894,6 +58894,44 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -59699,44 +59737,6 @@ Digital outputs</Comment>
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
       </Hides>
     </DataType>
-    <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
-    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{A4C97A60-C95C-4787-A832-16AA681FD195}" TcSmClass="TComPlcObjDef">
@@ -59769,7 +59769,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640357696</BitOffs>
+            <BitOffs>640357952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -59781,7 +59781,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641921728</BitOffs>
+            <BitOffs>641921984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -59794,7 +59794,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929664</BitOffs>
+            <BitOffs>641929920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -59807,7 +59807,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929672</BitOffs>
+            <BitOffs>641929928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -59820,7 +59820,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929680</BitOffs>
+            <BitOffs>641929936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -59843,7 +59843,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929696</BitOffs>
+            <BitOffs>641929952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -59856,7 +59856,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929728</BitOffs>
+            <BitOffs>641929984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -59869,7 +59869,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929792</BitOffs>
+            <BitOffs>641930048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -59882,7 +59882,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929808</BitOffs>
+            <BitOffs>641930064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -59894,7 +59894,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641946944</BitOffs>
+            <BitOffs>641947200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -59907,7 +59907,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641954880</BitOffs>
+            <BitOffs>641955136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -59920,7 +59920,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641954888</BitOffs>
+            <BitOffs>641955144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -59933,7 +59933,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641954896</BitOffs>
+            <BitOffs>641955152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -59956,7 +59956,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641954912</BitOffs>
+            <BitOffs>641955168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -59969,7 +59969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641954944</BitOffs>
+            <BitOffs>641955200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -59982,7 +59982,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955008</BitOffs>
+            <BitOffs>641955264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -59995,7 +59995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955024</BitOffs>
+            <BitOffs>641955280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -60007,7 +60007,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641972160</BitOffs>
+            <BitOffs>641972416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -60020,7 +60020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980096</BitOffs>
+            <BitOffs>641980352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -60033,7 +60033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980104</BitOffs>
+            <BitOffs>641980360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -60046,7 +60046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980112</BitOffs>
+            <BitOffs>641980368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -60069,7 +60069,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980128</BitOffs>
+            <BitOffs>641980384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -60082,7 +60082,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980160</BitOffs>
+            <BitOffs>641980416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -60095,7 +60095,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980224</BitOffs>
+            <BitOffs>641980480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -60108,7 +60108,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980240</BitOffs>
+            <BitOffs>641980496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -60121,7 +60121,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642270304</BitOffs>
+            <BitOffs>642270560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60133,7 +60133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642293632</BitOffs>
+            <BitOffs>642293888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -60145,7 +60145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643857664</BitOffs>
+            <BitOffs>643857920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -60158,7 +60158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865600</BitOffs>
+            <BitOffs>643865856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -60171,7 +60171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865608</BitOffs>
+            <BitOffs>643865864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -60184,7 +60184,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865616</BitOffs>
+            <BitOffs>643865872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -60207,7 +60207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865632</BitOffs>
+            <BitOffs>643865888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -60220,7 +60220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865664</BitOffs>
+            <BitOffs>643865920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -60233,7 +60233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865728</BitOffs>
+            <BitOffs>643865984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -60246,7 +60246,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865744</BitOffs>
+            <BitOffs>643866000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -60258,7 +60258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643882880</BitOffs>
+            <BitOffs>643883136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -60271,7 +60271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890816</BitOffs>
+            <BitOffs>643891072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -60284,7 +60284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890824</BitOffs>
+            <BitOffs>643891080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -60297,7 +60297,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890832</BitOffs>
+            <BitOffs>643891088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -60320,7 +60320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890848</BitOffs>
+            <BitOffs>643891104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -60333,7 +60333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890880</BitOffs>
+            <BitOffs>643891136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -60346,7 +60346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890944</BitOffs>
+            <BitOffs>643891200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -60359,7 +60359,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643890960</BitOffs>
+            <BitOffs>643891216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -60371,7 +60371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643908096</BitOffs>
+            <BitOffs>643908352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -60384,7 +60384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916032</BitOffs>
+            <BitOffs>643916288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -60397,7 +60397,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916040</BitOffs>
+            <BitOffs>643916296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -60410,7 +60410,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916048</BitOffs>
+            <BitOffs>643916304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -60433,7 +60433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916064</BitOffs>
+            <BitOffs>643916320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -60446,7 +60446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916096</BitOffs>
+            <BitOffs>643916352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -60459,7 +60459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916160</BitOffs>
+            <BitOffs>643916416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -60472,7 +60472,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916176</BitOffs>
+            <BitOffs>643916432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -60484,7 +60484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644206048</BitOffs>
+            <BitOffs>644206304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60503,7 +60503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398408</BitOffs>
+            <BitOffs>644398664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60515,7 +60515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398416</BitOffs>
+            <BitOffs>644398672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60527,7 +60527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398424</BitOffs>
+            <BitOffs>644398680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60539,7 +60539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398432</BitOffs>
+            <BitOffs>644398688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60552,7 +60552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398688</BitOffs>
+            <BitOffs>644398944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60565,7 +60565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644784800</BitOffs>
+            <BitOffs>644785056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
@@ -60578,7 +60578,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644785888</BitOffs>
+            <BitOffs>644786144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -60597,7 +60597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786440</BitOffs>
+            <BitOffs>644786696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60609,7 +60609,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786448</BitOffs>
+            <BitOffs>644786704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -60621,7 +60621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786456</BitOffs>
+            <BitOffs>644786712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -60633,7 +60633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786464</BitOffs>
+            <BitOffs>644786720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60645,7 +60645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644807936</BitOffs>
+            <BitOffs>644808192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -60657,7 +60657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646371968</BitOffs>
+            <BitOffs>646372224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -60670,7 +60670,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646379904</BitOffs>
+            <BitOffs>646380160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -60683,7 +60683,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646379912</BitOffs>
+            <BitOffs>646380168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -60696,7 +60696,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646379920</BitOffs>
+            <BitOffs>646380176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -60719,7 +60719,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646379936</BitOffs>
+            <BitOffs>646380192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -60732,7 +60732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646379968</BitOffs>
+            <BitOffs>646380224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -60745,7 +60745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380032</BitOffs>
+            <BitOffs>646380288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -60758,7 +60758,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380048</BitOffs>
+            <BitOffs>646380304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -60770,7 +60770,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646397184</BitOffs>
+            <BitOffs>646397440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -60783,7 +60783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405120</BitOffs>
+            <BitOffs>646405376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -60796,7 +60796,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405128</BitOffs>
+            <BitOffs>646405384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -60809,7 +60809,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405136</BitOffs>
+            <BitOffs>646405392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -60832,7 +60832,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405152</BitOffs>
+            <BitOffs>646405408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -60845,7 +60845,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405184</BitOffs>
+            <BitOffs>646405440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -60858,7 +60858,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405248</BitOffs>
+            <BitOffs>646405504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -60871,7 +60871,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405264</BitOffs>
+            <BitOffs>646405520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -60883,7 +60883,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646422400</BitOffs>
+            <BitOffs>646422656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -60896,7 +60896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430336</BitOffs>
+            <BitOffs>646430592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -60909,7 +60909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430344</BitOffs>
+            <BitOffs>646430600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -60922,7 +60922,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430352</BitOffs>
+            <BitOffs>646430608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -60945,7 +60945,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430368</BitOffs>
+            <BitOffs>646430624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -60958,7 +60958,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430400</BitOffs>
+            <BitOffs>646430656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -60971,7 +60971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430464</BitOffs>
+            <BitOffs>646430720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -60984,7 +60984,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430480</BitOffs>
+            <BitOffs>646430736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -60996,7 +60996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646720352</BitOffs>
+            <BitOffs>646720608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -61015,7 +61015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912712</BitOffs>
+            <BitOffs>646912968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -61027,7 +61027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912720</BitOffs>
+            <BitOffs>646912976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -61039,7 +61039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912728</BitOffs>
+            <BitOffs>646912984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -61051,7 +61051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912736</BitOffs>
+            <BitOffs>646912992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -61064,7 +61064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912992</BitOffs>
+            <BitOffs>646913248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -61077,7 +61077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647299104</BitOffs>
+            <BitOffs>647299360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
@@ -61090,7 +61090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647300192</BitOffs>
+            <BitOffs>647300448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -61109,7 +61109,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647300744</BitOffs>
+            <BitOffs>647301000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -61121,7 +61121,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647300752</BitOffs>
+            <BitOffs>647301008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -61133,7 +61133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647300760</BitOffs>
+            <BitOffs>647301016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -61145,7 +61145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647300768</BitOffs>
+            <BitOffs>647301024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61157,7 +61157,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647322240</BitOffs>
+            <BitOffs>647322496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61169,7 +61169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648886272</BitOffs>
+            <BitOffs>648886528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61182,7 +61182,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894208</BitOffs>
+            <BitOffs>648894464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61195,7 +61195,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894216</BitOffs>
+            <BitOffs>648894472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -61208,7 +61208,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894224</BitOffs>
+            <BitOffs>648894480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61231,7 +61231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894240</BitOffs>
+            <BitOffs>648894496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61244,7 +61244,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894272</BitOffs>
+            <BitOffs>648894528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61257,7 +61257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894336</BitOffs>
+            <BitOffs>648894592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61270,7 +61270,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894352</BitOffs>
+            <BitOffs>648894608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61282,7 +61282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648911488</BitOffs>
+            <BitOffs>648911744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61295,7 +61295,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919424</BitOffs>
+            <BitOffs>648919680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61308,7 +61308,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919432</BitOffs>
+            <BitOffs>648919688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -61321,7 +61321,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919440</BitOffs>
+            <BitOffs>648919696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61344,7 +61344,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919456</BitOffs>
+            <BitOffs>648919712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61357,7 +61357,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919488</BitOffs>
+            <BitOffs>648919744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61370,7 +61370,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919552</BitOffs>
+            <BitOffs>648919808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61383,7 +61383,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919568</BitOffs>
+            <BitOffs>648919824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61395,7 +61395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648936704</BitOffs>
+            <BitOffs>648936960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61408,7 +61408,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944640</BitOffs>
+            <BitOffs>648944896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61421,7 +61421,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944648</BitOffs>
+            <BitOffs>648944904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -61434,7 +61434,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944656</BitOffs>
+            <BitOffs>648944912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61457,7 +61457,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944672</BitOffs>
+            <BitOffs>648944928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61470,7 +61470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944704</BitOffs>
+            <BitOffs>648944960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61483,7 +61483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944768</BitOffs>
+            <BitOffs>648945024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -61496,7 +61496,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944784</BitOffs>
+            <BitOffs>648945040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -61508,7 +61508,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649234656</BitOffs>
+            <BitOffs>649234912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -61527,7 +61527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427016</BitOffs>
+            <BitOffs>649427272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -61539,7 +61539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427024</BitOffs>
+            <BitOffs>649427280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -61551,7 +61551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427032</BitOffs>
+            <BitOffs>649427288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -61563,7 +61563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427040</BitOffs>
+            <BitOffs>649427296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -61576,7 +61576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427296</BitOffs>
+            <BitOffs>649427552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -61589,7 +61589,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649813408</BitOffs>
+            <BitOffs>649813664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
@@ -61602,7 +61602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649814496</BitOffs>
+            <BitOffs>649814752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -61621,7 +61621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815048</BitOffs>
+            <BitOffs>649815304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -61633,7 +61633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815056</BitOffs>
+            <BitOffs>649815312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -61645,7 +61645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815064</BitOffs>
+            <BitOffs>649815320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -61657,7 +61657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815072</BitOffs>
+            <BitOffs>649815328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61669,7 +61669,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649836544</BitOffs>
+            <BitOffs>649836800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61681,7 +61681,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651400576</BitOffs>
+            <BitOffs>651400832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61694,7 +61694,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408512</BitOffs>
+            <BitOffs>651408768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61707,7 +61707,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408520</BitOffs>
+            <BitOffs>651408776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -61720,7 +61720,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408528</BitOffs>
+            <BitOffs>651408784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61743,7 +61743,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408544</BitOffs>
+            <BitOffs>651408800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61756,7 +61756,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408576</BitOffs>
+            <BitOffs>651408832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61769,7 +61769,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408640</BitOffs>
+            <BitOffs>651408896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61782,7 +61782,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408656</BitOffs>
+            <BitOffs>651408912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61794,7 +61794,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651425792</BitOffs>
+            <BitOffs>651426048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61807,7 +61807,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433728</BitOffs>
+            <BitOffs>651433984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61820,7 +61820,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433736</BitOffs>
+            <BitOffs>651433992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -61833,7 +61833,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433744</BitOffs>
+            <BitOffs>651434000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61856,7 +61856,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433760</BitOffs>
+            <BitOffs>651434016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61869,7 +61869,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433792</BitOffs>
+            <BitOffs>651434048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61882,7 +61882,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433856</BitOffs>
+            <BitOffs>651434112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61895,7 +61895,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433872</BitOffs>
+            <BitOffs>651434128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61907,7 +61907,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651451008</BitOffs>
+            <BitOffs>651451264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61920,7 +61920,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651458944</BitOffs>
+            <BitOffs>651459200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61933,7 +61933,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651458952</BitOffs>
+            <BitOffs>651459208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -61946,7 +61946,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651458960</BitOffs>
+            <BitOffs>651459216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61969,7 +61969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651458976</BitOffs>
+            <BitOffs>651459232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61982,7 +61982,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459008</BitOffs>
+            <BitOffs>651459264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61995,7 +61995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459072</BitOffs>
+            <BitOffs>651459328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62008,7 +62008,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459088</BitOffs>
+            <BitOffs>651459344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -62020,7 +62020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651748960</BitOffs>
+            <BitOffs>651749216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -62039,7 +62039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941320</BitOffs>
+            <BitOffs>651941576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -62051,7 +62051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941328</BitOffs>
+            <BitOffs>651941584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -62063,7 +62063,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941336</BitOffs>
+            <BitOffs>651941592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -62075,7 +62075,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941344</BitOffs>
+            <BitOffs>651941600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -62088,7 +62088,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941600</BitOffs>
+            <BitOffs>651941856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -62101,7 +62101,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652327712</BitOffs>
+            <BitOffs>652327968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
@@ -62114,7 +62114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652328800</BitOffs>
+            <BitOffs>652329056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -62133,7 +62133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329352</BitOffs>
+            <BitOffs>652329608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -62145,7 +62145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329360</BitOffs>
+            <BitOffs>652329616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -62157,7 +62157,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329368</BitOffs>
+            <BitOffs>652329624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -62169,7 +62169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329376</BitOffs>
+            <BitOffs>652329632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -62181,7 +62181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652350848</BitOffs>
+            <BitOffs>652351104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -62193,7 +62193,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653914880</BitOffs>
+            <BitOffs>653915136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -62206,7 +62206,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922816</BitOffs>
+            <BitOffs>653923072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -62219,7 +62219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922824</BitOffs>
+            <BitOffs>653923080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -62232,7 +62232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922832</BitOffs>
+            <BitOffs>653923088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -62255,7 +62255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922848</BitOffs>
+            <BitOffs>653923104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -62268,7 +62268,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922880</BitOffs>
+            <BitOffs>653923136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -62281,7 +62281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922944</BitOffs>
+            <BitOffs>653923200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -62294,7 +62294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653922960</BitOffs>
+            <BitOffs>653923216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -62306,7 +62306,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653940096</BitOffs>
+            <BitOffs>653940352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -62319,7 +62319,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948032</BitOffs>
+            <BitOffs>653948288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -62332,7 +62332,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948040</BitOffs>
+            <BitOffs>653948296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -62345,7 +62345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948048</BitOffs>
+            <BitOffs>653948304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -62368,7 +62368,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948064</BitOffs>
+            <BitOffs>653948320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -62381,7 +62381,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948096</BitOffs>
+            <BitOffs>653948352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -62394,7 +62394,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948160</BitOffs>
+            <BitOffs>653948416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -62407,7 +62407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948176</BitOffs>
+            <BitOffs>653948432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62419,7 +62419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653965312</BitOffs>
+            <BitOffs>653965568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62432,7 +62432,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973248</BitOffs>
+            <BitOffs>653973504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62445,7 +62445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973256</BitOffs>
+            <BitOffs>653973512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -62458,7 +62458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973264</BitOffs>
+            <BitOffs>653973520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62481,7 +62481,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973280</BitOffs>
+            <BitOffs>653973536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -62494,7 +62494,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973312</BitOffs>
+            <BitOffs>653973568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -62507,7 +62507,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973376</BitOffs>
+            <BitOffs>653973632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62520,7 +62520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973392</BitOffs>
+            <BitOffs>653973648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -62532,7 +62532,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654263264</BitOffs>
+            <BitOffs>654263520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -62551,7 +62551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455624</BitOffs>
+            <BitOffs>654455880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -62563,7 +62563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455632</BitOffs>
+            <BitOffs>654455888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -62575,7 +62575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455640</BitOffs>
+            <BitOffs>654455896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -62587,7 +62587,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455648</BitOffs>
+            <BitOffs>654455904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -62600,7 +62600,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455904</BitOffs>
+            <BitOffs>654456160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -62613,7 +62613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654842016</BitOffs>
+            <BitOffs>654842272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
@@ -62626,7 +62626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843104</BitOffs>
+            <BitOffs>654843360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -62645,7 +62645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843656</BitOffs>
+            <BitOffs>654843912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -62657,7 +62657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843664</BitOffs>
+            <BitOffs>654843920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -62669,7 +62669,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843672</BitOffs>
+            <BitOffs>654843928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -62681,7 +62681,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843680</BitOffs>
+            <BitOffs>654843936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -62693,7 +62693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654865280</BitOffs>
+            <BitOffs>654865536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -62705,7 +62705,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656429312</BitOffs>
+            <BitOffs>656429568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -62718,7 +62718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437248</BitOffs>
+            <BitOffs>656437504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -62731,7 +62731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437256</BitOffs>
+            <BitOffs>656437512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -62744,7 +62744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437264</BitOffs>
+            <BitOffs>656437520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -62767,7 +62767,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437280</BitOffs>
+            <BitOffs>656437536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -62780,7 +62780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437312</BitOffs>
+            <BitOffs>656437568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -62793,7 +62793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437376</BitOffs>
+            <BitOffs>656437632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -62806,7 +62806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437392</BitOffs>
+            <BitOffs>656437648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -62818,7 +62818,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656454528</BitOffs>
+            <BitOffs>656454784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -62831,7 +62831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462464</BitOffs>
+            <BitOffs>656462720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -62844,7 +62844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462472</BitOffs>
+            <BitOffs>656462728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -62857,7 +62857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462480</BitOffs>
+            <BitOffs>656462736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -62880,7 +62880,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462496</BitOffs>
+            <BitOffs>656462752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -62893,7 +62893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462528</BitOffs>
+            <BitOffs>656462784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -62906,7 +62906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462592</BitOffs>
+            <BitOffs>656462848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -62919,7 +62919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462608</BitOffs>
+            <BitOffs>656462864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62931,7 +62931,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656479744</BitOffs>
+            <BitOffs>656480000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62944,7 +62944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487680</BitOffs>
+            <BitOffs>656487936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62957,7 +62957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487688</BitOffs>
+            <BitOffs>656487944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -62970,7 +62970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487696</BitOffs>
+            <BitOffs>656487952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62993,7 +62993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487712</BitOffs>
+            <BitOffs>656487968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -63006,7 +63006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487744</BitOffs>
+            <BitOffs>656488000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -63019,7 +63019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487808</BitOffs>
+            <BitOffs>656488064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -63032,7 +63032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487824</BitOffs>
+            <BitOffs>656488080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63044,7 +63044,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656808448</BitOffs>
+            <BitOffs>656808704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63056,7 +63056,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657106368</BitOffs>
+            <BitOffs>657106624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -63068,7 +63068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658670400</BitOffs>
+            <BitOffs>658670656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -63081,7 +63081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678336</BitOffs>
+            <BitOffs>658678592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -63094,7 +63094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678344</BitOffs>
+            <BitOffs>658678600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -63107,7 +63107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678352</BitOffs>
+            <BitOffs>658678608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -63130,7 +63130,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678368</BitOffs>
+            <BitOffs>658678624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -63143,7 +63143,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678400</BitOffs>
+            <BitOffs>658678656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -63156,7 +63156,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678464</BitOffs>
+            <BitOffs>658678720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -63169,7 +63169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678480</BitOffs>
+            <BitOffs>658678736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -63181,7 +63181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658695616</BitOffs>
+            <BitOffs>658695872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -63194,7 +63194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703552</BitOffs>
+            <BitOffs>658703808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -63207,7 +63207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703560</BitOffs>
+            <BitOffs>658703816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -63220,7 +63220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703568</BitOffs>
+            <BitOffs>658703824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -63243,7 +63243,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703584</BitOffs>
+            <BitOffs>658703840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -63256,7 +63256,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703616</BitOffs>
+            <BitOffs>658703872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -63269,7 +63269,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703680</BitOffs>
+            <BitOffs>658703936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -63282,7 +63282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703696</BitOffs>
+            <BitOffs>658703952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -63294,7 +63294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658720832</BitOffs>
+            <BitOffs>658721088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -63307,7 +63307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728768</BitOffs>
+            <BitOffs>658729024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -63320,7 +63320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728776</BitOffs>
+            <BitOffs>658729032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -63333,7 +63333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728784</BitOffs>
+            <BitOffs>658729040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -63356,7 +63356,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728800</BitOffs>
+            <BitOffs>658729056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -63369,7 +63369,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728832</BitOffs>
+            <BitOffs>658729088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -63382,7 +63382,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728896</BitOffs>
+            <BitOffs>658729152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -63395,7 +63395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658728912</BitOffs>
+            <BitOffs>658729168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -63419,7 +63419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659018952</BitOffs>
+            <BitOffs>659019208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -63431,7 +63431,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659018960</BitOffs>
+            <BitOffs>659019216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -63443,7 +63443,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659018968</BitOffs>
+            <BitOffs>659019224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -63455,7 +63455,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659018976</BitOffs>
+            <BitOffs>659019232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -63479,7 +63479,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019208</BitOffs>
+            <BitOffs>659019464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -63491,7 +63491,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019216</BitOffs>
+            <BitOffs>659019472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -63503,7 +63503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019224</BitOffs>
+            <BitOffs>659019480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -63515,7 +63515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019232</BitOffs>
+            <BitOffs>659019488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63527,7 +63527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659049728</BitOffs>
+            <BitOffs>659049984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63539,7 +63539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659347648</BitOffs>
+            <BitOffs>659347904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -63551,7 +63551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660911680</BitOffs>
+            <BitOffs>660911936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -63564,7 +63564,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919616</BitOffs>
+            <BitOffs>660919872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -63577,7 +63577,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919624</BitOffs>
+            <BitOffs>660919880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -63590,7 +63590,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919632</BitOffs>
+            <BitOffs>660919888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -63613,7 +63613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919648</BitOffs>
+            <BitOffs>660919904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -63626,7 +63626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919680</BitOffs>
+            <BitOffs>660919936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -63639,7 +63639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919744</BitOffs>
+            <BitOffs>660920000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -63652,7 +63652,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919760</BitOffs>
+            <BitOffs>660920016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -63664,7 +63664,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660936896</BitOffs>
+            <BitOffs>660937152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -63677,7 +63677,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944832</BitOffs>
+            <BitOffs>660945088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -63690,7 +63690,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944840</BitOffs>
+            <BitOffs>660945096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -63703,7 +63703,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944848</BitOffs>
+            <BitOffs>660945104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -63726,7 +63726,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944864</BitOffs>
+            <BitOffs>660945120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -63739,7 +63739,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944896</BitOffs>
+            <BitOffs>660945152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -63752,7 +63752,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944960</BitOffs>
+            <BitOffs>660945216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -63765,7 +63765,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660944976</BitOffs>
+            <BitOffs>660945232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -63777,7 +63777,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660962112</BitOffs>
+            <BitOffs>660962368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -63790,7 +63790,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970048</BitOffs>
+            <BitOffs>660970304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -63803,7 +63803,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970056</BitOffs>
+            <BitOffs>660970312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -63816,7 +63816,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970064</BitOffs>
+            <BitOffs>660970320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -63839,7 +63839,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970080</BitOffs>
+            <BitOffs>660970336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -63852,7 +63852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970112</BitOffs>
+            <BitOffs>660970368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -63865,7 +63865,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970176</BitOffs>
+            <BitOffs>660970432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -63878,7 +63878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970192</BitOffs>
+            <BitOffs>660970448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -63902,7 +63902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260232</BitOffs>
+            <BitOffs>661260488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -63914,7 +63914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260240</BitOffs>
+            <BitOffs>661260496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -63926,7 +63926,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260248</BitOffs>
+            <BitOffs>661260504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -63938,7 +63938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260256</BitOffs>
+            <BitOffs>661260512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -63962,7 +63962,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260488</BitOffs>
+            <BitOffs>661260744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -63974,7 +63974,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260496</BitOffs>
+            <BitOffs>661260752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -63986,7 +63986,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260504</BitOffs>
+            <BitOffs>661260760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -63998,7 +63998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260512</BitOffs>
+            <BitOffs>661260768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64010,7 +64010,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661266752</BitOffs>
+            <BitOffs>661267008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64022,7 +64022,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661564672</BitOffs>
+            <BitOffs>661564928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64034,7 +64034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661862592</BitOffs>
+            <BitOffs>661862848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64046,7 +64046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662160512</BitOffs>
+            <BitOffs>662160768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -64058,7 +64058,67 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662606208</BitOffs>
+            <BitOffs>662606464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>662613632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>662911552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663209472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663507392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663953088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -64074,7 +64134,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662609776</BitOffs>
+            <BitOffs>663953232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -64090,67 +64150,39 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662609784</BitOffs>
+            <BitOffs>663953240</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Name>PRG_SP1K4.bTL1High</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
+              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662613376</BitOffs>
+            <BitOffs>663956704</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Name>PRG_SP1K4.bTL1Low</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
+              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662911296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663209216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663507136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663952832</BitOffs>
+            <BitOffs>663956712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -64163,7 +64195,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664065312</BitOffs>
+            <BitOffs>664065632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -64175,7 +64207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664065320</BitOffs>
+            <BitOffs>664065640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64187,7 +64219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664100480</BitOffs>
+            <BitOffs>664100800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64199,7 +64231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664398400</BitOffs>
+            <BitOffs>664398720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -64223,7 +64255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389832</BitOffs>
+            <BitOffs>665390152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -64235,7 +64267,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389840</BitOffs>
+            <BitOffs>665390160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -64247,7 +64279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389848</BitOffs>
+            <BitOffs>665390168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -64259,39 +64291,39 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389856</BitOffs>
+            <BitOffs>665390176</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL1High</Name>
+            <Name>PRG_SP1K4.bTL2High</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390368</BitOffs>
+            <BitOffs>665390704</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL1Low</Name>
+            <Name>PRG_SP1K4.bTL2Low</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390376</BitOffs>
+            <BitOffs>665390712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64303,7 +64335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665416320</BitOffs>
+            <BitOffs>665416640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64315,7 +64347,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665714240</BitOffs>
+            <BitOffs>665714560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -64339,7 +64371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698376</BitOffs>
+            <BitOffs>666698696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -64351,7 +64383,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698384</BitOffs>
+            <BitOffs>666698704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -64363,7 +64395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698392</BitOffs>
+            <BitOffs>666698712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -64375,7 +64407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698400</BitOffs>
+            <BitOffs>666698720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64387,7 +64419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666701504</BitOffs>
+            <BitOffs>666701824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64399,7 +64431,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666999424</BitOffs>
+            <BitOffs>666999744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64411,7 +64443,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667297344</BitOffs>
+            <BitOffs>667297664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64423,7 +64455,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667595264</BitOffs>
+            <BitOffs>667595584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64435,7 +64467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667893184</BitOffs>
+            <BitOffs>667893504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64447,7 +64479,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668191104</BitOffs>
+            <BitOffs>668191424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64459,7 +64491,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668489024</BitOffs>
+            <BitOffs>668489344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64471,7 +64503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668786944</BitOffs>
+            <BitOffs>668787264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64483,7 +64515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669084864</BitOffs>
+            <BitOffs>669085184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64495,7 +64527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669382784</BitOffs>
+            <BitOffs>669383104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64507,7 +64539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669680704</BitOffs>
+            <BitOffs>669681024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64519,7 +64551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669978624</BitOffs>
+            <BitOffs>669978944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64531,39 +64563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670276544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL2High</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>670571984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL2Low</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>670571992</BitOffs>
+            <BitOffs>670276864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64575,7 +64575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671839808</BitOffs>
+            <BitOffs>671840064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64588,7 +64588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847744</BitOffs>
+            <BitOffs>671848000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64601,7 +64601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847752</BitOffs>
+            <BitOffs>671848008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -64614,7 +64614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847760</BitOffs>
+            <BitOffs>671848016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64637,7 +64637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847776</BitOffs>
+            <BitOffs>671848032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -64650,7 +64650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847808</BitOffs>
+            <BitOffs>671848064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -64663,7 +64663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847872</BitOffs>
+            <BitOffs>671848128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -64676,7 +64676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847888</BitOffs>
+            <BitOffs>671848144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -64688,7 +64688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671865024</BitOffs>
+            <BitOffs>671865280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -64701,7 +64701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872960</BitOffs>
+            <BitOffs>671873216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -64714,7 +64714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872968</BitOffs>
+            <BitOffs>671873224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -64727,7 +64727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872976</BitOffs>
+            <BitOffs>671873232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -64750,7 +64750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872992</BitOffs>
+            <BitOffs>671873248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -64763,7 +64763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873024</BitOffs>
+            <BitOffs>671873280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -64776,7 +64776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873088</BitOffs>
+            <BitOffs>671873344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -64789,7 +64789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873104</BitOffs>
+            <BitOffs>671873360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -64801,7 +64801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671890240</BitOffs>
+            <BitOffs>671890496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -64814,7 +64814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898176</BitOffs>
+            <BitOffs>671898432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -64827,7 +64827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898184</BitOffs>
+            <BitOffs>671898440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -64840,7 +64840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898192</BitOffs>
+            <BitOffs>671898448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -64863,7 +64863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898208</BitOffs>
+            <BitOffs>671898464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -64876,7 +64876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898240</BitOffs>
+            <BitOffs>671898496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -64889,7 +64889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898304</BitOffs>
+            <BitOffs>671898560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -64902,7 +64902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898320</BitOffs>
+            <BitOffs>671898576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64914,7 +64914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673601792</BitOffs>
+            <BitOffs>673602112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64927,7 +64927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609728</BitOffs>
+            <BitOffs>673610048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64940,7 +64940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609736</BitOffs>
+            <BitOffs>673610056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -64953,7 +64953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609744</BitOffs>
+            <BitOffs>673610064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64976,7 +64976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609760</BitOffs>
+            <BitOffs>673610080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -64989,7 +64989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609792</BitOffs>
+            <BitOffs>673610112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -65002,7 +65002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609856</BitOffs>
+            <BitOffs>673610176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -65015,7 +65015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609872</BitOffs>
+            <BitOffs>673610192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -65027,7 +65027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673627008</BitOffs>
+            <BitOffs>673627328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -65040,7 +65040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634944</BitOffs>
+            <BitOffs>673635264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -65053,7 +65053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634952</BitOffs>
+            <BitOffs>673635272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -65066,7 +65066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634960</BitOffs>
+            <BitOffs>673635280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -65089,7 +65089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634976</BitOffs>
+            <BitOffs>673635296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -65102,7 +65102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635008</BitOffs>
+            <BitOffs>673635328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -65115,7 +65115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635072</BitOffs>
+            <BitOffs>673635392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -65128,7 +65128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635088</BitOffs>
+            <BitOffs>673635408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -65140,7 +65140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673652224</BitOffs>
+            <BitOffs>673652544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -65153,7 +65153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660160</BitOffs>
+            <BitOffs>673660480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -65166,7 +65166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660168</BitOffs>
+            <BitOffs>673660488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -65179,7 +65179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660176</BitOffs>
+            <BitOffs>673660496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -65202,7 +65202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660192</BitOffs>
+            <BitOffs>673660512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -65215,7 +65215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660224</BitOffs>
+            <BitOffs>673660544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -65228,7 +65228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660288</BitOffs>
+            <BitOffs>673660608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -65241,7 +65241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660304</BitOffs>
+            <BitOffs>673660624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -65257,7 +65257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674042912</BitOffs>
+            <BitOffs>674043168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -65278,7 +65278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674046432</BitOffs>
+            <BitOffs>674046688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -65299,7 +65299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674046433</BitOffs>
+            <BitOffs>674046689</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -65311,7 +65311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684244864</BitOffs>
+            <BitOffs>684245120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -65324,7 +65324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252800</BitOffs>
+            <BitOffs>684253056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -65337,7 +65337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252808</BitOffs>
+            <BitOffs>684253064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -65350,7 +65350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252816</BitOffs>
+            <BitOffs>684253072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -65373,7 +65373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252832</BitOffs>
+            <BitOffs>684253088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -65386,7 +65386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252864</BitOffs>
+            <BitOffs>684253120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -65399,7 +65399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252928</BitOffs>
+            <BitOffs>684253184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -65412,7 +65412,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252944</BitOffs>
+            <BitOffs>684253200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -65424,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684270080</BitOffs>
+            <BitOffs>684270336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -65437,7 +65437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278016</BitOffs>
+            <BitOffs>684278272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -65450,7 +65450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278024</BitOffs>
+            <BitOffs>684278280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -65463,7 +65463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278032</BitOffs>
+            <BitOffs>684278288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -65486,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278048</BitOffs>
+            <BitOffs>684278304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -65499,7 +65499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278080</BitOffs>
+            <BitOffs>684278336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -65512,7 +65512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278144</BitOffs>
+            <BitOffs>684278400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -65525,7 +65525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278160</BitOffs>
+            <BitOffs>684278416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -65537,7 +65537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684295296</BitOffs>
+            <BitOffs>684295552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -65550,7 +65550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303232</BitOffs>
+            <BitOffs>684303488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -65563,7 +65563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303240</BitOffs>
+            <BitOffs>684303496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -65576,7 +65576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303248</BitOffs>
+            <BitOffs>684303504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -65599,7 +65599,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303264</BitOffs>
+            <BitOffs>684303520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -65612,7 +65612,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303296</BitOffs>
+            <BitOffs>684303552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -65625,7 +65625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303360</BitOffs>
+            <BitOffs>684303616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -65638,7 +65638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303376</BitOffs>
+            <BitOffs>684303632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -65650,7 +65650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684320512</BitOffs>
+            <BitOffs>684320768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -65663,7 +65663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328448</BitOffs>
+            <BitOffs>684328704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -65676,7 +65676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328456</BitOffs>
+            <BitOffs>684328712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -65689,7 +65689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328464</BitOffs>
+            <BitOffs>684328720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -65712,7 +65712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328480</BitOffs>
+            <BitOffs>684328736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -65725,7 +65725,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328512</BitOffs>
+            <BitOffs>684328768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -65738,7 +65738,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328576</BitOffs>
+            <BitOffs>684328832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -65751,7 +65751,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328592</BitOffs>
+            <BitOffs>684328848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -65763,7 +65763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684345728</BitOffs>
+            <BitOffs>684345984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -65776,7 +65776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353664</BitOffs>
+            <BitOffs>684353920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -65789,7 +65789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353672</BitOffs>
+            <BitOffs>684353928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -65802,7 +65802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353680</BitOffs>
+            <BitOffs>684353936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -65825,7 +65825,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353696</BitOffs>
+            <BitOffs>684353952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -65838,7 +65838,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353728</BitOffs>
+            <BitOffs>684353984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -65851,7 +65851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353792</BitOffs>
+            <BitOffs>684354048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -65864,7 +65864,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353808</BitOffs>
+            <BitOffs>684354064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -65876,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684370944</BitOffs>
+            <BitOffs>684371200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -65889,7 +65889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378880</BitOffs>
+            <BitOffs>684379136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -65902,7 +65902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378888</BitOffs>
+            <BitOffs>684379144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -65915,7 +65915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378896</BitOffs>
+            <BitOffs>684379152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -65938,7 +65938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378912</BitOffs>
+            <BitOffs>684379168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -65951,7 +65951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378944</BitOffs>
+            <BitOffs>684379200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -65964,7 +65964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379008</BitOffs>
+            <BitOffs>684379264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -65977,7 +65977,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379024</BitOffs>
+            <BitOffs>684379280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -65989,7 +65989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684396160</BitOffs>
+            <BitOffs>684396416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -66002,7 +66002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404096</BitOffs>
+            <BitOffs>684404352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -66015,7 +66015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404104</BitOffs>
+            <BitOffs>684404360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -66028,7 +66028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404112</BitOffs>
+            <BitOffs>684404368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -66051,7 +66051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404128</BitOffs>
+            <BitOffs>684404384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -66064,7 +66064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404160</BitOffs>
+            <BitOffs>684404416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -66077,7 +66077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404224</BitOffs>
+            <BitOffs>684404480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -66090,7 +66090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404240</BitOffs>
+            <BitOffs>684404496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -66102,7 +66102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684421376</BitOffs>
+            <BitOffs>684421632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -66115,7 +66115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429312</BitOffs>
+            <BitOffs>684429568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -66128,7 +66128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429320</BitOffs>
+            <BitOffs>684429576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -66141,7 +66141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429328</BitOffs>
+            <BitOffs>684429584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -66164,7 +66164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429344</BitOffs>
+            <BitOffs>684429600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -66177,7 +66177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429376</BitOffs>
+            <BitOffs>684429632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -66190,7 +66190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429440</BitOffs>
+            <BitOffs>684429696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -66203,7 +66203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429456</BitOffs>
+            <BitOffs>684429712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -66215,7 +66215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684446592</BitOffs>
+            <BitOffs>684446848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -66228,7 +66228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454528</BitOffs>
+            <BitOffs>684454784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -66241,7 +66241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454536</BitOffs>
+            <BitOffs>684454792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -66254,7 +66254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454544</BitOffs>
+            <BitOffs>684454800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -66277,7 +66277,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454560</BitOffs>
+            <BitOffs>684454816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -66290,7 +66290,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454592</BitOffs>
+            <BitOffs>684454848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -66303,7 +66303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454656</BitOffs>
+            <BitOffs>684454912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -66316,7 +66316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454672</BitOffs>
+            <BitOffs>684454928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -66328,7 +66328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684471808</BitOffs>
+            <BitOffs>684472064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -66341,7 +66341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479744</BitOffs>
+            <BitOffs>684480000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -66354,7 +66354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479752</BitOffs>
+            <BitOffs>684480008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -66367,7 +66367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479760</BitOffs>
+            <BitOffs>684480016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -66390,7 +66390,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479776</BitOffs>
+            <BitOffs>684480032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -66403,7 +66403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479808</BitOffs>
+            <BitOffs>684480064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -66416,7 +66416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479872</BitOffs>
+            <BitOffs>684480128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -66429,7 +66429,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479888</BitOffs>
+            <BitOffs>684480144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -66441,7 +66441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684497024</BitOffs>
+            <BitOffs>684497280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -66454,7 +66454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504960</BitOffs>
+            <BitOffs>684505216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -66467,7 +66467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504968</BitOffs>
+            <BitOffs>684505224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -66480,7 +66480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504976</BitOffs>
+            <BitOffs>684505232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -66503,7 +66503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504992</BitOffs>
+            <BitOffs>684505248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -66516,7 +66516,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505024</BitOffs>
+            <BitOffs>684505280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -66529,7 +66529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505088</BitOffs>
+            <BitOffs>684505344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -66542,7 +66542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505104</BitOffs>
+            <BitOffs>684505360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -66554,7 +66554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684522240</BitOffs>
+            <BitOffs>684522496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -66567,7 +66567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530176</BitOffs>
+            <BitOffs>684530432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -66580,7 +66580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530184</BitOffs>
+            <BitOffs>684530440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -66593,7 +66593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530192</BitOffs>
+            <BitOffs>684530448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -66616,7 +66616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530208</BitOffs>
+            <BitOffs>684530464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -66629,7 +66629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530240</BitOffs>
+            <BitOffs>684530496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -66642,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530304</BitOffs>
+            <BitOffs>684530560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -66655,7 +66655,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530320</BitOffs>
+            <BitOffs>684530576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -66667,7 +66667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684547456</BitOffs>
+            <BitOffs>684547712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -66680,7 +66680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555392</BitOffs>
+            <BitOffs>684555648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -66693,7 +66693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555400</BitOffs>
+            <BitOffs>684555656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -66706,7 +66706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555408</BitOffs>
+            <BitOffs>684555664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -66729,7 +66729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555424</BitOffs>
+            <BitOffs>684555680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -66742,7 +66742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555456</BitOffs>
+            <BitOffs>684555712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -66755,7 +66755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555520</BitOffs>
+            <BitOffs>684555776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -66768,7 +66768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555536</BitOffs>
+            <BitOffs>684555792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -66780,7 +66780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684572672</BitOffs>
+            <BitOffs>684572928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -66793,7 +66793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580608</BitOffs>
+            <BitOffs>684580864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -66806,7 +66806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580616</BitOffs>
+            <BitOffs>684580872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -66819,7 +66819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580624</BitOffs>
+            <BitOffs>684580880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -66842,7 +66842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580640</BitOffs>
+            <BitOffs>684580896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -66855,7 +66855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580672</BitOffs>
+            <BitOffs>684580928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -66868,7 +66868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580736</BitOffs>
+            <BitOffs>684580992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -66881,7 +66881,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580752</BitOffs>
+            <BitOffs>684581008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -66893,7 +66893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684597888</BitOffs>
+            <BitOffs>684598144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -66906,7 +66906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605824</BitOffs>
+            <BitOffs>684606080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -66919,7 +66919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605832</BitOffs>
+            <BitOffs>684606088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -66932,7 +66932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605840</BitOffs>
+            <BitOffs>684606096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -66955,7 +66955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605856</BitOffs>
+            <BitOffs>684606112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -66968,7 +66968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605888</BitOffs>
+            <BitOffs>684606144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -66981,7 +66981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605952</BitOffs>
+            <BitOffs>684606208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -66994,7 +66994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605968</BitOffs>
+            <BitOffs>684606224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -67006,7 +67006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684623104</BitOffs>
+            <BitOffs>684623360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -67019,7 +67019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631040</BitOffs>
+            <BitOffs>684631296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -67032,7 +67032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631048</BitOffs>
+            <BitOffs>684631304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -67045,7 +67045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631056</BitOffs>
+            <BitOffs>684631312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -67068,7 +67068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631072</BitOffs>
+            <BitOffs>684631328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -67081,7 +67081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631104</BitOffs>
+            <BitOffs>684631360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -67094,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631168</BitOffs>
+            <BitOffs>684631424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -67107,7 +67107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631184</BitOffs>
+            <BitOffs>684631440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -67119,7 +67119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684648320</BitOffs>
+            <BitOffs>684648576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -67132,7 +67132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656256</BitOffs>
+            <BitOffs>684656512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -67145,7 +67145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656264</BitOffs>
+            <BitOffs>684656520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -67158,7 +67158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656272</BitOffs>
+            <BitOffs>684656528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -67181,7 +67181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656288</BitOffs>
+            <BitOffs>684656544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -67194,7 +67194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656320</BitOffs>
+            <BitOffs>684656576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -67207,7 +67207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656384</BitOffs>
+            <BitOffs>684656640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -67220,7 +67220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656400</BitOffs>
+            <BitOffs>684656656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -67232,7 +67232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684673536</BitOffs>
+            <BitOffs>684673792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -67245,7 +67245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681472</BitOffs>
+            <BitOffs>684681728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -67258,7 +67258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681480</BitOffs>
+            <BitOffs>684681736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -67271,7 +67271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681488</BitOffs>
+            <BitOffs>684681744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -67294,7 +67294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681504</BitOffs>
+            <BitOffs>684681760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -67307,7 +67307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681536</BitOffs>
+            <BitOffs>684681792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -67320,7 +67320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681600</BitOffs>
+            <BitOffs>684681856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -67333,7 +67333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681616</BitOffs>
+            <BitOffs>684681872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -67345,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684698752</BitOffs>
+            <BitOffs>684699008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -67358,7 +67358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706688</BitOffs>
+            <BitOffs>684706944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -67371,7 +67371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706696</BitOffs>
+            <BitOffs>684706952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -67384,7 +67384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706704</BitOffs>
+            <BitOffs>684706960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -67407,7 +67407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706720</BitOffs>
+            <BitOffs>684706976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -67420,7 +67420,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706752</BitOffs>
+            <BitOffs>684707008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -67433,7 +67433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706816</BitOffs>
+            <BitOffs>684707072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -67446,7 +67446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706832</BitOffs>
+            <BitOffs>684707088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -67458,7 +67458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684723968</BitOffs>
+            <BitOffs>684724224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -67471,7 +67471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731904</BitOffs>
+            <BitOffs>684732160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -67484,7 +67484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731912</BitOffs>
+            <BitOffs>684732168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -67497,7 +67497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731920</BitOffs>
+            <BitOffs>684732176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -67520,7 +67520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731936</BitOffs>
+            <BitOffs>684732192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -67533,7 +67533,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731968</BitOffs>
+            <BitOffs>684732224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -67546,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732032</BitOffs>
+            <BitOffs>684732288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -67559,7 +67559,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732048</BitOffs>
+            <BitOffs>684732304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -67571,7 +67571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684749184</BitOffs>
+            <BitOffs>684749440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -67584,7 +67584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757120</BitOffs>
+            <BitOffs>684757376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -67597,7 +67597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757128</BitOffs>
+            <BitOffs>684757384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -67610,7 +67610,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757136</BitOffs>
+            <BitOffs>684757392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -67633,7 +67633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757152</BitOffs>
+            <BitOffs>684757408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -67646,7 +67646,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757184</BitOffs>
+            <BitOffs>684757440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -67659,7 +67659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757248</BitOffs>
+            <BitOffs>684757504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -67672,7 +67672,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757264</BitOffs>
+            <BitOffs>684757520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -67684,7 +67684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684774400</BitOffs>
+            <BitOffs>684774656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -67697,7 +67697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782336</BitOffs>
+            <BitOffs>684782592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -67710,7 +67710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782344</BitOffs>
+            <BitOffs>684782600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -67723,7 +67723,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782352</BitOffs>
+            <BitOffs>684782608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -67746,7 +67746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782368</BitOffs>
+            <BitOffs>684782624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -67759,7 +67759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782400</BitOffs>
+            <BitOffs>684782656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -67772,7 +67772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782464</BitOffs>
+            <BitOffs>684782720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -67785,7 +67785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782480</BitOffs>
+            <BitOffs>684782736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -67797,7 +67797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684799616</BitOffs>
+            <BitOffs>684799872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -67810,7 +67810,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807552</BitOffs>
+            <BitOffs>684807808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -67823,7 +67823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807560</BitOffs>
+            <BitOffs>684807816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -67836,7 +67836,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807568</BitOffs>
+            <BitOffs>684807824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -67859,7 +67859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807584</BitOffs>
+            <BitOffs>684807840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -67872,7 +67872,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807616</BitOffs>
+            <BitOffs>684807872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -67885,7 +67885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807680</BitOffs>
+            <BitOffs>684807936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -67898,7 +67898,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807696</BitOffs>
+            <BitOffs>684807952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -67910,7 +67910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684824832</BitOffs>
+            <BitOffs>684825088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -67923,7 +67923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832768</BitOffs>
+            <BitOffs>684833024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -67936,7 +67936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832776</BitOffs>
+            <BitOffs>684833032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -67949,7 +67949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832784</BitOffs>
+            <BitOffs>684833040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -67972,7 +67972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832800</BitOffs>
+            <BitOffs>684833056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -67985,7 +67985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832832</BitOffs>
+            <BitOffs>684833088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -67998,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832896</BitOffs>
+            <BitOffs>684833152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -68011,7 +68011,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832912</BitOffs>
+            <BitOffs>684833168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -68023,7 +68023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684850048</BitOffs>
+            <BitOffs>684850304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -68036,7 +68036,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857984</BitOffs>
+            <BitOffs>684858240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -68049,7 +68049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857992</BitOffs>
+            <BitOffs>684858248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -68062,7 +68062,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858000</BitOffs>
+            <BitOffs>684858256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -68085,7 +68085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858016</BitOffs>
+            <BitOffs>684858272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -68098,7 +68098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858048</BitOffs>
+            <BitOffs>684858304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -68111,7 +68111,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858112</BitOffs>
+            <BitOffs>684858368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -68124,7 +68124,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858128</BitOffs>
+            <BitOffs>684858384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -68136,7 +68136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684875264</BitOffs>
+            <BitOffs>684875520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -68149,7 +68149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883200</BitOffs>
+            <BitOffs>684883456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -68162,7 +68162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883208</BitOffs>
+            <BitOffs>684883464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -68175,7 +68175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883216</BitOffs>
+            <BitOffs>684883472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -68198,7 +68198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883232</BitOffs>
+            <BitOffs>684883488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -68211,7 +68211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883264</BitOffs>
+            <BitOffs>684883520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -68224,7 +68224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883328</BitOffs>
+            <BitOffs>684883584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -68237,7 +68237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883344</BitOffs>
+            <BitOffs>684883600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -68249,7 +68249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684900480</BitOffs>
+            <BitOffs>684900736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -68262,7 +68262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908416</BitOffs>
+            <BitOffs>684908672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -68275,7 +68275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908424</BitOffs>
+            <BitOffs>684908680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -68288,7 +68288,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908432</BitOffs>
+            <BitOffs>684908688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -68311,7 +68311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908448</BitOffs>
+            <BitOffs>684908704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -68324,7 +68324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908480</BitOffs>
+            <BitOffs>684908736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -68337,7 +68337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908544</BitOffs>
+            <BitOffs>684908800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -68350,7 +68350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908560</BitOffs>
+            <BitOffs>684908816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -68362,7 +68362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684925696</BitOffs>
+            <BitOffs>684925952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -68375,7 +68375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933632</BitOffs>
+            <BitOffs>684933888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -68388,7 +68388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933640</BitOffs>
+            <BitOffs>684933896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -68401,7 +68401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933648</BitOffs>
+            <BitOffs>684933904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -68424,7 +68424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933664</BitOffs>
+            <BitOffs>684933920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -68437,7 +68437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933696</BitOffs>
+            <BitOffs>684933952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -68450,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933760</BitOffs>
+            <BitOffs>684934016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -68463,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933776</BitOffs>
+            <BitOffs>684934032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -68475,7 +68475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684950912</BitOffs>
+            <BitOffs>684951168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -68488,7 +68488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958848</BitOffs>
+            <BitOffs>684959104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -68501,7 +68501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958856</BitOffs>
+            <BitOffs>684959112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -68514,7 +68514,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958864</BitOffs>
+            <BitOffs>684959120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -68537,7 +68537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958880</BitOffs>
+            <BitOffs>684959136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -68550,7 +68550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958912</BitOffs>
+            <BitOffs>684959168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -68563,7 +68563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958976</BitOffs>
+            <BitOffs>684959232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -68576,7 +68576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958992</BitOffs>
+            <BitOffs>684959248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -68588,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684976128</BitOffs>
+            <BitOffs>684976384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -68601,7 +68601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984064</BitOffs>
+            <BitOffs>684984320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -68614,7 +68614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984072</BitOffs>
+            <BitOffs>684984328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -68627,7 +68627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984080</BitOffs>
+            <BitOffs>684984336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -68650,7 +68650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984096</BitOffs>
+            <BitOffs>684984352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -68663,7 +68663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984128</BitOffs>
+            <BitOffs>684984384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -68676,7 +68676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984192</BitOffs>
+            <BitOffs>684984448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -68689,7 +68689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984208</BitOffs>
+            <BitOffs>684984464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -68701,7 +68701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685001344</BitOffs>
+            <BitOffs>685001600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -68714,7 +68714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009280</BitOffs>
+            <BitOffs>685009536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -68727,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009288</BitOffs>
+            <BitOffs>685009544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -68740,7 +68740,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009296</BitOffs>
+            <BitOffs>685009552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -68763,7 +68763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009312</BitOffs>
+            <BitOffs>685009568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -68776,7 +68776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009344</BitOffs>
+            <BitOffs>685009600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -68789,7 +68789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009408</BitOffs>
+            <BitOffs>685009664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -68802,7 +68802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009424</BitOffs>
+            <BitOffs>685009680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -68814,7 +68814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685026560</BitOffs>
+            <BitOffs>685026816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -68827,7 +68827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034496</BitOffs>
+            <BitOffs>685034752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -68840,7 +68840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034504</BitOffs>
+            <BitOffs>685034760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -68853,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034512</BitOffs>
+            <BitOffs>685034768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -68876,7 +68876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034528</BitOffs>
+            <BitOffs>685034784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -68889,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034560</BitOffs>
+            <BitOffs>685034816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -68902,7 +68902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034624</BitOffs>
+            <BitOffs>685034880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -68915,7 +68915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034640</BitOffs>
+            <BitOffs>685034896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -68927,7 +68927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685051776</BitOffs>
+            <BitOffs>685052032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -68940,7 +68940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059712</BitOffs>
+            <BitOffs>685059968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -68953,7 +68953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059720</BitOffs>
+            <BitOffs>685059976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -68966,7 +68966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059728</BitOffs>
+            <BitOffs>685059984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -68989,7 +68989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059744</BitOffs>
+            <BitOffs>685060000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -69002,7 +69002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059776</BitOffs>
+            <BitOffs>685060032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -69015,7 +69015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059840</BitOffs>
+            <BitOffs>685060096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -69028,7 +69028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059856</BitOffs>
+            <BitOffs>685060112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -69040,7 +69040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685076992</BitOffs>
+            <BitOffs>685077248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -69053,7 +69053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084928</BitOffs>
+            <BitOffs>685085184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -69066,7 +69066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084936</BitOffs>
+            <BitOffs>685085192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -69079,7 +69079,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084944</BitOffs>
+            <BitOffs>685085200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -69102,7 +69102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084960</BitOffs>
+            <BitOffs>685085216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -69115,7 +69115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084992</BitOffs>
+            <BitOffs>685085248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -69128,7 +69128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085056</BitOffs>
+            <BitOffs>685085312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -69141,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085072</BitOffs>
+            <BitOffs>685085328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -69153,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685102208</BitOffs>
+            <BitOffs>685102464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -69166,7 +69166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110144</BitOffs>
+            <BitOffs>685110400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -69179,7 +69179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110152</BitOffs>
+            <BitOffs>685110408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -69192,7 +69192,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110160</BitOffs>
+            <BitOffs>685110416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -69215,7 +69215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110176</BitOffs>
+            <BitOffs>685110432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -69228,7 +69228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110208</BitOffs>
+            <BitOffs>685110464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -69241,7 +69241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110272</BitOffs>
+            <BitOffs>685110528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -69254,7 +69254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110288</BitOffs>
+            <BitOffs>685110544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -69266,7 +69266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685127424</BitOffs>
+            <BitOffs>685127680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -69279,7 +69279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135360</BitOffs>
+            <BitOffs>685135616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -69292,7 +69292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135368</BitOffs>
+            <BitOffs>685135624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -69305,7 +69305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135376</BitOffs>
+            <BitOffs>685135632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -69328,7 +69328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135392</BitOffs>
+            <BitOffs>685135648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -69341,7 +69341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135424</BitOffs>
+            <BitOffs>685135680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -69354,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135488</BitOffs>
+            <BitOffs>685135744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -69367,7 +69367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135504</BitOffs>
+            <BitOffs>685135760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -69379,7 +69379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685152640</BitOffs>
+            <BitOffs>685152896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -69392,7 +69392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160576</BitOffs>
+            <BitOffs>685160832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -69405,7 +69405,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160584</BitOffs>
+            <BitOffs>685160840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -69418,7 +69418,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160592</BitOffs>
+            <BitOffs>685160848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -69441,7 +69441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160608</BitOffs>
+            <BitOffs>685160864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -69454,7 +69454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160640</BitOffs>
+            <BitOffs>685160896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -69467,7 +69467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160704</BitOffs>
+            <BitOffs>685160960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -69480,7 +69480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160720</BitOffs>
+            <BitOffs>685160976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -69492,7 +69492,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685177856</BitOffs>
+            <BitOffs>685178112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -69505,7 +69505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185792</BitOffs>
+            <BitOffs>685186048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -69518,7 +69518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185800</BitOffs>
+            <BitOffs>685186056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -69531,7 +69531,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185808</BitOffs>
+            <BitOffs>685186064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -69554,7 +69554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185824</BitOffs>
+            <BitOffs>685186080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -69567,7 +69567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185856</BitOffs>
+            <BitOffs>685186112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -69580,7 +69580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185920</BitOffs>
+            <BitOffs>685186176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -69593,7 +69593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185936</BitOffs>
+            <BitOffs>685186192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -69605,7 +69605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685203072</BitOffs>
+            <BitOffs>685203328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -69618,7 +69618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211008</BitOffs>
+            <BitOffs>685211264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -69631,7 +69631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211016</BitOffs>
+            <BitOffs>685211272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -69644,7 +69644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211024</BitOffs>
+            <BitOffs>685211280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -69667,7 +69667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211040</BitOffs>
+            <BitOffs>685211296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -69680,7 +69680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211072</BitOffs>
+            <BitOffs>685211328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -69693,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211136</BitOffs>
+            <BitOffs>685211392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -69706,7 +69706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211152</BitOffs>
+            <BitOffs>685211408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -69718,7 +69718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685228288</BitOffs>
+            <BitOffs>685228544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -69731,7 +69731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236224</BitOffs>
+            <BitOffs>685236480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -69744,7 +69744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236232</BitOffs>
+            <BitOffs>685236488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -69757,7 +69757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236240</BitOffs>
+            <BitOffs>685236496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -69780,7 +69780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236256</BitOffs>
+            <BitOffs>685236512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -69793,7 +69793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236288</BitOffs>
+            <BitOffs>685236544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -69806,7 +69806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236352</BitOffs>
+            <BitOffs>685236608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -69819,7 +69819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236368</BitOffs>
+            <BitOffs>685236624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -69831,7 +69831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685253504</BitOffs>
+            <BitOffs>685253760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -69844,7 +69844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261440</BitOffs>
+            <BitOffs>685261696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -69857,7 +69857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261448</BitOffs>
+            <BitOffs>685261704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -69870,7 +69870,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261456</BitOffs>
+            <BitOffs>685261712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -69893,7 +69893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261472</BitOffs>
+            <BitOffs>685261728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -69906,7 +69906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261504</BitOffs>
+            <BitOffs>685261760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -69919,7 +69919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261568</BitOffs>
+            <BitOffs>685261824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -69932,7 +69932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261584</BitOffs>
+            <BitOffs>685261840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -69944,7 +69944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685278720</BitOffs>
+            <BitOffs>685278976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -69957,7 +69957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286656</BitOffs>
+            <BitOffs>685286912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -69970,7 +69970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286664</BitOffs>
+            <BitOffs>685286920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -69983,7 +69983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286672</BitOffs>
+            <BitOffs>685286928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -70006,7 +70006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286688</BitOffs>
+            <BitOffs>685286944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -70019,7 +70019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286720</BitOffs>
+            <BitOffs>685286976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -70032,7 +70032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286784</BitOffs>
+            <BitOffs>685287040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -70045,7 +70045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286800</BitOffs>
+            <BitOffs>685287056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -70057,7 +70057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685303936</BitOffs>
+            <BitOffs>685304192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -70070,7 +70070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311872</BitOffs>
+            <BitOffs>685312128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -70083,7 +70083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311880</BitOffs>
+            <BitOffs>685312136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -70096,7 +70096,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311888</BitOffs>
+            <BitOffs>685312144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -70119,7 +70119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311904</BitOffs>
+            <BitOffs>685312160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -70132,7 +70132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311936</BitOffs>
+            <BitOffs>685312192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -70145,7 +70145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312000</BitOffs>
+            <BitOffs>685312256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -70158,7 +70158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312016</BitOffs>
+            <BitOffs>685312272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -70170,7 +70170,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685329152</BitOffs>
+            <BitOffs>685329408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -70183,7 +70183,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337088</BitOffs>
+            <BitOffs>685337344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -70196,7 +70196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337096</BitOffs>
+            <BitOffs>685337352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -70209,7 +70209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337104</BitOffs>
+            <BitOffs>685337360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -70232,7 +70232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337120</BitOffs>
+            <BitOffs>685337376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -70245,7 +70245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337152</BitOffs>
+            <BitOffs>685337408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -70258,7 +70258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337216</BitOffs>
+            <BitOffs>685337472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -70271,7 +70271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337232</BitOffs>
+            <BitOffs>685337488</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -70289,7 +70289,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640356672</BitOffs>
+            <BitOffs>640356928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70301,7 +70301,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641920704</BitOffs>
+            <BitOffs>641920960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70314,7 +70314,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641929688</BitOffs>
+            <BitOffs>641929944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70326,7 +70326,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641945920</BitOffs>
+            <BitOffs>641946176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70339,7 +70339,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641954904</BitOffs>
+            <BitOffs>641955160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70351,7 +70351,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641971136</BitOffs>
+            <BitOffs>641971392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70364,7 +70364,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641980120</BitOffs>
+            <BitOffs>641980376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -70376,7 +70376,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642270208</BitOffs>
+            <BitOffs>642270464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -70388,7 +70388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642270224</BitOffs>
+            <BitOffs>642270480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -70401,7 +70401,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642271168</BitOffs>
+            <BitOffs>642271424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70413,7 +70413,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642292608</BitOffs>
+            <BitOffs>642292864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70425,7 +70425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643856640</BitOffs>
+            <BitOffs>643856896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70438,7 +70438,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643865624</BitOffs>
+            <BitOffs>643865880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70450,7 +70450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643881856</BitOffs>
+            <BitOffs>643882112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70463,7 +70463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643890840</BitOffs>
+            <BitOffs>643891096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70475,7 +70475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643907072</BitOffs>
+            <BitOffs>643907328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70488,7 +70488,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643916056</BitOffs>
+            <BitOffs>643916312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -70500,7 +70500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644784672</BitOffs>
+            <BitOffs>644784928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -70520,7 +70520,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644784688</BitOffs>
+            <BitOffs>644784944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70533,7 +70533,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644785664</BitOffs>
+            <BitOffs>644785920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70545,7 +70545,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644806912</BitOffs>
+            <BitOffs>644807168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70557,7 +70557,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646370944</BitOffs>
+            <BitOffs>646371200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70570,7 +70570,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646379928</BitOffs>
+            <BitOffs>646380184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70582,7 +70582,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646396160</BitOffs>
+            <BitOffs>646396416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70595,7 +70595,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646405144</BitOffs>
+            <BitOffs>646405400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70607,7 +70607,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646421376</BitOffs>
+            <BitOffs>646421632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70620,7 +70620,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646430360</BitOffs>
+            <BitOffs>646430616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -70632,7 +70632,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647298976</BitOffs>
+            <BitOffs>647299232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -70652,7 +70652,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647298992</BitOffs>
+            <BitOffs>647299248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70665,7 +70665,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647299968</BitOffs>
+            <BitOffs>647300224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70677,7 +70677,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647321216</BitOffs>
+            <BitOffs>647321472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70689,7 +70689,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648885248</BitOffs>
+            <BitOffs>648885504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70702,7 +70702,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648894232</BitOffs>
+            <BitOffs>648894488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70714,7 +70714,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648910464</BitOffs>
+            <BitOffs>648910720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70727,7 +70727,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648919448</BitOffs>
+            <BitOffs>648919704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70739,7 +70739,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648935680</BitOffs>
+            <BitOffs>648935936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70752,7 +70752,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648944664</BitOffs>
+            <BitOffs>648944920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -70764,7 +70764,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649813280</BitOffs>
+            <BitOffs>649813536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -70784,7 +70784,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649813296</BitOffs>
+            <BitOffs>649813552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70797,7 +70797,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649814272</BitOffs>
+            <BitOffs>649814528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70809,7 +70809,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649835520</BitOffs>
+            <BitOffs>649835776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70821,7 +70821,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651399552</BitOffs>
+            <BitOffs>651399808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70834,7 +70834,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651408536</BitOffs>
+            <BitOffs>651408792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70846,7 +70846,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651424768</BitOffs>
+            <BitOffs>651425024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70859,7 +70859,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651433752</BitOffs>
+            <BitOffs>651434008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70871,7 +70871,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651449984</BitOffs>
+            <BitOffs>651450240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70884,7 +70884,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651458968</BitOffs>
+            <BitOffs>651459224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -70896,7 +70896,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652327584</BitOffs>
+            <BitOffs>652327840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -70916,7 +70916,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652327600</BitOffs>
+            <BitOffs>652327856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70929,7 +70929,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652328576</BitOffs>
+            <BitOffs>652328832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70941,7 +70941,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652349824</BitOffs>
+            <BitOffs>652350080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70953,7 +70953,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653913856</BitOffs>
+            <BitOffs>653914112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70966,7 +70966,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653922840</BitOffs>
+            <BitOffs>653923096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70978,7 +70978,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653939072</BitOffs>
+            <BitOffs>653939328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70991,7 +70991,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653948056</BitOffs>
+            <BitOffs>653948312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71003,7 +71003,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653964288</BitOffs>
+            <BitOffs>653964544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71016,7 +71016,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653973272</BitOffs>
+            <BitOffs>653973528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -71028,7 +71028,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654841888</BitOffs>
+            <BitOffs>654842144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -71048,7 +71048,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654841904</BitOffs>
+            <BitOffs>654842160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -71061,7 +71061,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654842880</BitOffs>
+            <BitOffs>654843136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71073,7 +71073,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654864256</BitOffs>
+            <BitOffs>654864512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71085,7 +71085,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656428288</BitOffs>
+            <BitOffs>656428544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71098,7 +71098,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656437272</BitOffs>
+            <BitOffs>656437528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71110,7 +71110,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656453504</BitOffs>
+            <BitOffs>656453760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71123,7 +71123,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656462488</BitOffs>
+            <BitOffs>656462744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71135,7 +71135,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656478720</BitOffs>
+            <BitOffs>656478976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71148,7 +71148,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656487704</BitOffs>
+            <BitOffs>656487960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71160,7 +71160,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656807424</BitOffs>
+            <BitOffs>656807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71172,7 +71172,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657105344</BitOffs>
+            <BitOffs>657105600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71184,7 +71184,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658669376</BitOffs>
+            <BitOffs>658669632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71197,7 +71197,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658678360</BitOffs>
+            <BitOffs>658678616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71209,7 +71209,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658694592</BitOffs>
+            <BitOffs>658694848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71222,7 +71222,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658703576</BitOffs>
+            <BitOffs>658703832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71234,7 +71234,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658719808</BitOffs>
+            <BitOffs>658720064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71247,7 +71247,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658728792</BitOffs>
+            <BitOffs>658729048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71259,7 +71259,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659048704</BitOffs>
+            <BitOffs>659048960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71271,7 +71271,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659346624</BitOffs>
+            <BitOffs>659346880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71283,7 +71283,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660910656</BitOffs>
+            <BitOffs>660910912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71296,7 +71296,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660919640</BitOffs>
+            <BitOffs>660919896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71308,7 +71308,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660935872</BitOffs>
+            <BitOffs>660936128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71321,7 +71321,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660944856</BitOffs>
+            <BitOffs>660945112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71333,7 +71333,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660961088</BitOffs>
+            <BitOffs>660961344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71346,7 +71346,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660970072</BitOffs>
+            <BitOffs>660970328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71358,7 +71358,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661265728</BitOffs>
+            <BitOffs>661265984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71370,7 +71370,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661563648</BitOffs>
+            <BitOffs>661563904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71382,7 +71382,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661861568</BitOffs>
+            <BitOffs>661861824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71394,7 +71394,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662159488</BitOffs>
+            <BitOffs>662159744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -71406,7 +71406,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662606112</BitOffs>
+            <BitOffs>662606368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71418,7 +71418,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662612352</BitOffs>
+            <BitOffs>662612608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71430,7 +71430,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662910272</BitOffs>
+            <BitOffs>662910528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71442,7 +71442,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663208192</BitOffs>
+            <BitOffs>663208448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71454,7 +71454,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663506112</BitOffs>
+            <BitOffs>663506368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -71466,7 +71466,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663952736</BitOffs>
+            <BitOffs>663952992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -71478,7 +71478,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664065328</BitOffs>
+            <BitOffs>664065648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -71490,7 +71490,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664065336</BitOffs>
+            <BitOffs>664065656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71502,7 +71502,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664099456</BitOffs>
+            <BitOffs>664099776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71514,7 +71514,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664397376</BitOffs>
+            <BitOffs>664397696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71526,7 +71526,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665415296</BitOffs>
+            <BitOffs>665415616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71538,7 +71538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665713216</BitOffs>
+            <BitOffs>665713536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71550,7 +71550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666700480</BitOffs>
+            <BitOffs>666700800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71562,7 +71562,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666998400</BitOffs>
+            <BitOffs>666998720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71574,7 +71574,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667296320</BitOffs>
+            <BitOffs>667296640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71586,7 +71586,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667594240</BitOffs>
+            <BitOffs>667594560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71598,7 +71598,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667892160</BitOffs>
+            <BitOffs>667892480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71610,7 +71610,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668190080</BitOffs>
+            <BitOffs>668190400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71622,7 +71622,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668488000</BitOffs>
+            <BitOffs>668488320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71634,7 +71634,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668785920</BitOffs>
+            <BitOffs>668786240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71646,7 +71646,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669083840</BitOffs>
+            <BitOffs>669084160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71658,7 +71658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669381760</BitOffs>
+            <BitOffs>669382080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71670,7 +71670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669679680</BitOffs>
+            <BitOffs>669680000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71682,7 +71682,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669977600</BitOffs>
+            <BitOffs>669977920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71694,7 +71694,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670275520</BitOffs>
+            <BitOffs>670275840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71706,7 +71706,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671838784</BitOffs>
+            <BitOffs>671839040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71719,7 +71719,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671847768</BitOffs>
+            <BitOffs>671848024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71731,7 +71731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671864000</BitOffs>
+            <BitOffs>671864256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71744,7 +71744,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671872984</BitOffs>
+            <BitOffs>671873240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71756,7 +71756,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671889216</BitOffs>
+            <BitOffs>671889472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71769,7 +71769,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671898200</BitOffs>
+            <BitOffs>671898456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71781,7 +71781,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673600768</BitOffs>
+            <BitOffs>673601088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71794,7 +71794,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673609752</BitOffs>
+            <BitOffs>673610072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71806,7 +71806,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673625984</BitOffs>
+            <BitOffs>673626304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71819,7 +71819,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673634968</BitOffs>
+            <BitOffs>673635288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71831,7 +71831,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673651200</BitOffs>
+            <BitOffs>673651520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71844,7 +71844,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673660184</BitOffs>
+            <BitOffs>673660504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -71863,26 +71863,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673840568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>674042080</BitOffs>
+            <BitOffs>674042360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -71898,7 +71879,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674044672</BitOffs>
+            <BitOffs>674044928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -71918,7 +71899,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>680950152</BitOffs>
+            <BitOffs>680950408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -71938,7 +71919,26 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>682597064</BitOffs>
+            <BitOffs>682597320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -71950,7 +71950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684243840</BitOffs>
+            <BitOffs>684244096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -71963,7 +71963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684252824</BitOffs>
+            <BitOffs>684253080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -71975,7 +71975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684269056</BitOffs>
+            <BitOffs>684269312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -71988,7 +71988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684278040</BitOffs>
+            <BitOffs>684278296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -72000,7 +72000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684294272</BitOffs>
+            <BitOffs>684294528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -72013,7 +72013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684303256</BitOffs>
+            <BitOffs>684303512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -72025,7 +72025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684319488</BitOffs>
+            <BitOffs>684319744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -72038,7 +72038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684328472</BitOffs>
+            <BitOffs>684328728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -72050,7 +72050,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684344704</BitOffs>
+            <BitOffs>684344960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -72063,7 +72063,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684353688</BitOffs>
+            <BitOffs>684353944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -72075,7 +72075,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684369920</BitOffs>
+            <BitOffs>684370176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -72088,7 +72088,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684378904</BitOffs>
+            <BitOffs>684379160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -72100,7 +72100,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684395136</BitOffs>
+            <BitOffs>684395392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -72113,7 +72113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684404120</BitOffs>
+            <BitOffs>684404376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -72125,7 +72125,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684420352</BitOffs>
+            <BitOffs>684420608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -72138,7 +72138,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684429336</BitOffs>
+            <BitOffs>684429592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -72150,7 +72150,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684445568</BitOffs>
+            <BitOffs>684445824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -72163,7 +72163,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684454552</BitOffs>
+            <BitOffs>684454808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -72175,7 +72175,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684470784</BitOffs>
+            <BitOffs>684471040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -72188,7 +72188,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684479768</BitOffs>
+            <BitOffs>684480024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -72200,7 +72200,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684496000</BitOffs>
+            <BitOffs>684496256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -72213,7 +72213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684504984</BitOffs>
+            <BitOffs>684505240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -72225,7 +72225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684521216</BitOffs>
+            <BitOffs>684521472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -72238,7 +72238,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684530200</BitOffs>
+            <BitOffs>684530456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -72250,7 +72250,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684546432</BitOffs>
+            <BitOffs>684546688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -72263,7 +72263,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684555416</BitOffs>
+            <BitOffs>684555672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -72275,7 +72275,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684571648</BitOffs>
+            <BitOffs>684571904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -72288,7 +72288,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684580632</BitOffs>
+            <BitOffs>684580888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -72300,7 +72300,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684596864</BitOffs>
+            <BitOffs>684597120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -72313,7 +72313,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684605848</BitOffs>
+            <BitOffs>684606104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -72325,7 +72325,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684622080</BitOffs>
+            <BitOffs>684622336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -72338,7 +72338,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684631064</BitOffs>
+            <BitOffs>684631320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -72350,7 +72350,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684647296</BitOffs>
+            <BitOffs>684647552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -72363,7 +72363,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684656280</BitOffs>
+            <BitOffs>684656536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -72375,7 +72375,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684672512</BitOffs>
+            <BitOffs>684672768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -72388,7 +72388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684681496</BitOffs>
+            <BitOffs>684681752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -72400,7 +72400,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684697728</BitOffs>
+            <BitOffs>684697984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -72413,7 +72413,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684706712</BitOffs>
+            <BitOffs>684706968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -72425,7 +72425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684722944</BitOffs>
+            <BitOffs>684723200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -72438,7 +72438,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684731928</BitOffs>
+            <BitOffs>684732184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -72450,7 +72450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684748160</BitOffs>
+            <BitOffs>684748416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -72463,7 +72463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684757144</BitOffs>
+            <BitOffs>684757400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -72475,7 +72475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684773376</BitOffs>
+            <BitOffs>684773632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -72488,7 +72488,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684782360</BitOffs>
+            <BitOffs>684782616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -72500,7 +72500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684798592</BitOffs>
+            <BitOffs>684798848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -72513,7 +72513,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684807576</BitOffs>
+            <BitOffs>684807832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -72525,7 +72525,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684823808</BitOffs>
+            <BitOffs>684824064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -72538,7 +72538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684832792</BitOffs>
+            <BitOffs>684833048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -72550,7 +72550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684849024</BitOffs>
+            <BitOffs>684849280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -72563,7 +72563,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684858008</BitOffs>
+            <BitOffs>684858264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -72575,7 +72575,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684874240</BitOffs>
+            <BitOffs>684874496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -72588,7 +72588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684883224</BitOffs>
+            <BitOffs>684883480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -72600,7 +72600,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684899456</BitOffs>
+            <BitOffs>684899712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -72613,7 +72613,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684908440</BitOffs>
+            <BitOffs>684908696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -72625,7 +72625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684924672</BitOffs>
+            <BitOffs>684924928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -72638,7 +72638,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684933656</BitOffs>
+            <BitOffs>684933912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -72650,7 +72650,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684949888</BitOffs>
+            <BitOffs>684950144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -72663,7 +72663,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684958872</BitOffs>
+            <BitOffs>684959128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -72675,7 +72675,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684975104</BitOffs>
+            <BitOffs>684975360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -72688,7 +72688,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684984088</BitOffs>
+            <BitOffs>684984344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -72700,7 +72700,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685000320</BitOffs>
+            <BitOffs>685000576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -72713,7 +72713,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685009304</BitOffs>
+            <BitOffs>685009560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -72725,7 +72725,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685025536</BitOffs>
+            <BitOffs>685025792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -72738,7 +72738,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685034520</BitOffs>
+            <BitOffs>685034776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -72750,7 +72750,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685050752</BitOffs>
+            <BitOffs>685051008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -72763,7 +72763,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685059736</BitOffs>
+            <BitOffs>685059992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -72775,7 +72775,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685075968</BitOffs>
+            <BitOffs>685076224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -72788,7 +72788,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685084952</BitOffs>
+            <BitOffs>685085208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -72800,7 +72800,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685101184</BitOffs>
+            <BitOffs>685101440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -72813,7 +72813,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685110168</BitOffs>
+            <BitOffs>685110424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -72825,7 +72825,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685126400</BitOffs>
+            <BitOffs>685126656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -72838,7 +72838,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685135384</BitOffs>
+            <BitOffs>685135640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -72850,7 +72850,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685151616</BitOffs>
+            <BitOffs>685151872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -72863,7 +72863,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685160600</BitOffs>
+            <BitOffs>685160856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -72875,7 +72875,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685176832</BitOffs>
+            <BitOffs>685177088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -72888,7 +72888,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685185816</BitOffs>
+            <BitOffs>685186072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -72900,7 +72900,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685202048</BitOffs>
+            <BitOffs>685202304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -72913,7 +72913,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685211032</BitOffs>
+            <BitOffs>685211288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -72925,7 +72925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685227264</BitOffs>
+            <BitOffs>685227520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -72938,7 +72938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685236248</BitOffs>
+            <BitOffs>685236504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -72950,7 +72950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685252480</BitOffs>
+            <BitOffs>685252736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -72963,7 +72963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685261464</BitOffs>
+            <BitOffs>685261720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -72975,7 +72975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685277696</BitOffs>
+            <BitOffs>685277952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -72988,7 +72988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685286680</BitOffs>
+            <BitOffs>685286936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -73000,7 +73000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685302912</BitOffs>
+            <BitOffs>685303168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -73013,7 +73013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685311896</BitOffs>
+            <BitOffs>685312152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -73025,7 +73025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685328128</BitOffs>
+            <BitOffs>685328384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -73038,7 +73038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685337112</BitOffs>
+            <BitOffs>685337368</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -78355,35 +78355,44 @@ Digital outputs</Comment>
             <BitOffs>8538368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>MOTION_GVL.nMaxStates</Name>
-            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <Name>Global_Version.stLibVersion_lcls_twincat_common_components</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>0.0.0</String>
+              </SubItem>
+            </Default>
             <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
             <BitOffs>8538656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
-            <Comment>
-    Arbitary cap on multidimensional states to simplify statements for the compiler.
-    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
-    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
-    </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>3</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8538672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbPmpsFileReader</Name>
@@ -78395,7 +78404,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8538688</BitOffs>
+            <BitOffs>8538944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbStandardPMPSDB</Name>
@@ -78414,7 +78423,38 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9466816</BitOffs>
+            <BitOffs>9467072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.nMaxStates</Name>
+            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9494816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
+            <Comment>
+    Arbitary cap on multidimensional states to simplify statements for the compiler.
+    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
+    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
+    </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9494832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -78434,7 +78474,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494560</BitOffs>
+            <BitOffs>9494848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -78454,7 +78494,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9496320</BitOffs>
+            <BitOffs>9496608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -78479,7 +78519,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9498080</BitOffs>
+            <BitOffs>9498368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -78491,7 +78531,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499104</BitOffs>
+            <BitOffs>9499392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -78506,21 +78546,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9499168</BitOffs>
+            <BitOffs>9499424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -78534,7 +78560,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499200</BitOffs>
+            <BitOffs>9499456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -78548,7 +78574,21 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499264</BitOffs>
+            <BitOffs>9499520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9499584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -78563,7 +78603,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499328</BitOffs>
+            <BitOffs>9499616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
@@ -78578,7 +78618,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499360</BitOffs>
+            <BitOffs>9499648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -78592,7 +78632,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499376</BitOffs>
+            <BitOffs>9499664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stAttenuators</Name>
@@ -78613,7 +78653,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499392</BitOffs>
+            <BitOffs>9499680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cstFullBeam</Name>
@@ -78633,7 +78673,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499456</BitOffs>
+            <BitOffs>9499744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cst0RateBeam</Name>
@@ -78653,7 +78693,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9501216</BitOffs>
+            <BitOffs>9501504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -78678,7 +78718,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9502976</BitOffs>
+            <BitOffs>9503264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -78693,7 +78733,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9502992</BitOffs>
+            <BitOffs>9503280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -78712,7 +78752,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503008</BitOffs>
+            <BitOffs>9503296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
@@ -78726,7 +78766,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504032</BitOffs>
+            <BitOffs>9504320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
@@ -78741,7 +78781,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504048</BitOffs>
+            <BitOffs>9504336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -78768,7 +78808,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504064</BitOffs>
+            <BitOffs>9504352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -78923,7 +78963,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504096</BitOffs>
+            <BitOffs>9504384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -79078,7 +79118,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9505120</BitOffs>
+            <BitOffs>9505408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -79093,7 +79133,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506144</BitOffs>
+            <BitOffs>9506432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -79108,7 +79148,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506176</BitOffs>
+            <BitOffs>9506464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -79119,7 +79159,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506208</BitOffs>
+            <BitOffs>9506496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
@@ -79133,7 +79173,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506464</BitOffs>
+            <BitOffs>9506752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -79147,7 +79187,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506480</BitOffs>
+            <BitOffs>9506768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -79161,7 +79201,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506496</BitOffs>
+            <BitOffs>9506784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -79188,7 +79228,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506512</BitOffs>
+            <BitOffs>9506800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -79203,7 +79243,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506520</BitOffs>
+            <BitOffs>9506808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -79218,7 +79258,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506528</BitOffs>
+            <BitOffs>9506816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -79233,7 +79273,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506560</BitOffs>
+            <BitOffs>9506848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -79251,7 +79291,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508608</BitOffs>
+            <BitOffs>9508896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -79263,7 +79303,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508624</BitOffs>
+            <BitOffs>9508912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -79275,7 +79315,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508632</BitOffs>
+            <BitOffs>9508920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -79291,7 +79331,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508640</BitOffs>
+            <BitOffs>9508928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
@@ -79302,7 +79342,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508672</BitOffs>
+            <BitOffs>9508960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -79314,7 +79354,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631335872</BitOffs>
+            <BitOffs>631336160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -79326,7 +79366,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631335904</BitOffs>
+            <BitOffs>631336192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -79340,7 +79380,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631337952</BitOffs>
+            <BitOffs>631338240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
@@ -79351,7 +79391,7 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>631337960</BitOffs>
+            <BitOffs>631338248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -79367,7 +79407,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631337968</BitOffs>
+            <BitOffs>631338256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -79382,7 +79422,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631337984</BitOffs>
+            <BitOffs>631338272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -79408,7 +79448,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631369984</BitOffs>
+            <BitOffs>631370272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -79420,7 +79460,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631385984</BitOffs>
+            <BitOffs>631386272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -79456,7 +79496,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639706848</BitOffs>
+            <BitOffs>639707136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -79492,7 +79532,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707136</BitOffs>
+            <BitOffs>639707424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -79503,7 +79543,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707424</BitOffs>
+            <BitOffs>639707712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -79517,7 +79557,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714432</BitOffs>
+            <BitOffs>639714688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -79531,7 +79571,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714496</BitOffs>
+            <BitOffs>639714752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -79567,67 +79607,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>639714848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>639714856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <BitOffs>639714864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL2K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>639714872</BitOffs>
+            <BitOffs>639714816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Physics.fbScatteringFactors</Name>
@@ -79638,7 +79618,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714880</BitOffs>
+            <BitOffs>639715136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
@@ -79658,17 +79638,67 @@ Digital outputs</Comment>
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
               </Property>
             </Properties>
-            <BitOffs>640343872</BitOffs>
+            <BitOffs>640344128</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>-15</Value>
+              <Value>0</Value>
             </Default>
-            <BitOffs>642272416</BitOffs>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>642272672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>642272680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <BitOffs>642272688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL2K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>642272696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
@@ -79697,7 +79727,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw := TIIB[IM2K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>642272448</BitOffs>
+            <BitOffs>642272704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fStartupVelo</Name>
@@ -79706,7 +79736,7 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>644786688</BitOffs>
+            <BitOffs>644786944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
@@ -79736,7 +79766,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>644786752</BitOffs>
+            <BitOffs>644787008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fStartupVelo</Name>
@@ -79745,7 +79775,7 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>647300992</BitOffs>
+            <BitOffs>647301248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
@@ -79774,7 +79804,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>647301056</BitOffs>
+            <BitOffs>647301312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fStartupVelo</Name>
@@ -79783,7 +79813,7 @@ Digital outputs</Comment>
             <Default>
               <Value>15</Value>
             </Default>
-            <BitOffs>649815296</BitOffs>
+            <BitOffs>649815552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
@@ -79812,7 +79842,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649815360</BitOffs>
+            <BitOffs>649815616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fStartupVelo</Name>
@@ -79821,7 +79851,7 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>652329600</BitOffs>
+            <BitOffs>652329856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
@@ -79850,7 +79880,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>652329664</BitOffs>
+            <BitOffs>652329920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fStartupVelo</Name>
@@ -79859,7 +79889,7 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>654843904</BitOffs>
+            <BitOffs>654844160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
@@ -79874,13 +79904,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654844160</BitOffs>
+            <BitOffs>654844416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>656777856</BitOffs>
+            <BitOffs>656778112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
@@ -79906,23 +79936,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>656779968</BitOffs>
+            <BitOffs>656780224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>659019456</BitOffs>
+            <BitOffs>659019712</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>659021216</BitOffs>
+            <BitOffs>659021472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -79948,23 +79978,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>659021248</BitOffs>
+            <BitOffs>659021504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>661260736</BitOffs>
+            <BitOffs>661260992</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>661263136</BitOffs>
+            <BitOffs>661263392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -79979,7 +80009,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>661263168</BitOffs>
+            <BitOffs>661263424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -79990,7 +80020,17 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>662606336</BitOffs>
+            <BitOffs>662606592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>662609664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -80000,22 +80040,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>662609408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>662609760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>662609768</BitOffs>
+            <BitOffs>662609696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -80030,7 +80055,32 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662609792</BitOffs>
+            <BitOffs>662610048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>663953216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>663953224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>663953248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -80041,17 +80091,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663952960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>663956032</BitOffs>
+            <BitOffs>663953280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -80061,7 +80101,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956064</BitOffs>
+            <BitOffs>663956352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -80071,7 +80111,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956096</BitOffs>
+            <BitOffs>663956384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -80081,7 +80121,13 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956128</BitOffs>
+            <BitOffs>663956416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL1HighCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>663956720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -80100,7 +80146,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663956416</BitOffs>
+            <BitOffs>663956736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -80122,13 +80168,13 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>664067264</BitOffs>
+            <BitOffs>664067584</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.nTL1HighCycles</Name>
+            <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>665390384</BitOffs>
+            <BitOffs>665390688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -80150,103 +80196,97 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>665390400</BitOffs>
+            <BitOffs>665390720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>666699008</BitOffs>
+            <BitOffs>666699328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>666996928</BitOffs>
+            <BitOffs>666997248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667294848</BitOffs>
+            <BitOffs>667295168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667592768</BitOffs>
+            <BitOffs>667593088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667890688</BitOffs>
+            <BitOffs>667891008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668188608</BitOffs>
+            <BitOffs>668188928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668486528</BitOffs>
+            <BitOffs>668486848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668784448</BitOffs>
+            <BitOffs>668784768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669082368</BitOffs>
+            <BitOffs>669082688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669380288</BitOffs>
+            <BitOffs>669380608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669678208</BitOffs>
+            <BitOffs>669678528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669976128</BitOffs>
+            <BitOffs>669976448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670274048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL1LowCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>670571968</BitOffs>
+            <BitOffs>670274368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>670572000</BitOffs>
+            <BitOffs>670572288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>670572016</BitOffs>
+            <BitOffs>670572304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -80255,7 +80295,7 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>670572032</BitOffs>
+            <BitOffs>670572320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -80264,44 +80304,14 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>670572048</BitOffs>
+            <BitOffs>670572336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>670572056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.zp_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_ZonePlate_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP:STATE:SET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>670572064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.zp_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_ZonePlate_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP:STATE:GET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>670572080</BitOffs>
+            <BitOffs>670572344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates</Name>
@@ -80316,13 +80326,73 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>670572096</BitOffs>
+            <BitOffs>670572352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.zp_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_ZonePlate_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:FZP:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.zp_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_ZonePlate_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:FZP:STATE:GET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>672078528</BitOffs>
+            <BitOffs>672078848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -80346,7 +80416,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>672166336</BitOffs>
+            <BitOffs>672166656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -80356,7 +80426,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672169984</BitOffs>
+            <BitOffs>672170304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -80366,7 +80436,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672224704</BitOffs>
+            <BitOffs>672225024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -80376,7 +80446,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672279424</BitOffs>
+            <BitOffs>672279744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -80391,61 +80461,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672334144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:SET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>673840512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>673840528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>673840544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>673840552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>673840560</BitOffs>
+            <BitOffs>672334464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>673840576</BitOffs>
+            <BitOffs>673840832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -80469,7 +80491,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>673928384</BitOffs>
+            <BitOffs>673928640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -80479,7 +80501,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673932032</BitOffs>
+            <BitOffs>673932288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -80489,36 +80511,43 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673986752</BitOffs>
+            <BitOffs>673987008</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcGVL.ePF1K4State</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>674042096</BitOffs>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>674042336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>674042344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>674042352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>674042112</BitOffs>
+            <BitOffs>674042368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>674180480</BitOffs>
+            <BitOffs>674180736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>674211328</BitOffs>
+            <BitOffs>674211584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -80537,7 +80566,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680002944</BitOffs>
+            <BitOffs>680003200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -80556,7 +80585,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680476416</BitOffs>
+            <BitOffs>680476672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -80586,7 +80615,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680949888</BitOffs>
+            <BitOffs>680950144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -80616,7 +80645,18 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>682596800</BitOffs>
+            <BitOffs>682597056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcGVL.ePF1K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -80627,7 +80667,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243712</BitOffs>
+            <BitOffs>684244000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -80642,7 +80682,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243728</BitOffs>
+            <BitOffs>684244016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -80657,37 +80697,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>684243744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>684243760</BitOffs>
+            <BitOffs>684244024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -80716,7 +80726,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243776</BitOffs>
+            <BitOffs>684244032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -80728,7 +80738,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684268992</BitOffs>
+            <BitOffs>684269248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -80739,7 +80749,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684294208</BitOffs>
+            <BitOffs>684294464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -80750,7 +80760,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684319424</BitOffs>
+            <BitOffs>684319680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -80761,7 +80771,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684344640</BitOffs>
+            <BitOffs>684344896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -80772,7 +80782,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684369856</BitOffs>
+            <BitOffs>684370112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -80783,7 +80793,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684395072</BitOffs>
+            <BitOffs>684395328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -80794,7 +80804,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684420288</BitOffs>
+            <BitOffs>684420544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -80823,7 +80833,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684445504</BitOffs>
+            <BitOffs>684445760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -80851,7 +80861,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684470720</BitOffs>
+            <BitOffs>684470976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -80878,7 +80888,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684495936</BitOffs>
+            <BitOffs>684496192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -80905,7 +80915,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684521152</BitOffs>
+            <BitOffs>684521408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -80932,7 +80942,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684546368</BitOffs>
+            <BitOffs>684546624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -80944,7 +80954,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684571584</BitOffs>
+            <BitOffs>684571840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -80973,7 +80983,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684596800</BitOffs>
+            <BitOffs>684597056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -81002,7 +81012,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684622016</BitOffs>
+            <BitOffs>684622272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -81031,7 +81041,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684647232</BitOffs>
+            <BitOffs>684647488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -81060,7 +81070,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684672448</BitOffs>
+            <BitOffs>684672704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -81085,7 +81095,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684697664</BitOffs>
+            <BitOffs>684697920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -81114,7 +81124,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684722880</BitOffs>
+            <BitOffs>684723136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -81143,7 +81153,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684748096</BitOffs>
+            <BitOffs>684748352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -81168,7 +81178,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684773312</BitOffs>
+            <BitOffs>684773568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -81196,7 +81206,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684798528</BitOffs>
+            <BitOffs>684798784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -81223,7 +81233,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684823744</BitOffs>
+            <BitOffs>684824000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -81250,7 +81260,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684848960</BitOffs>
+            <BitOffs>684849216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -81277,7 +81287,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684874176</BitOffs>
+            <BitOffs>684874432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -81306,7 +81316,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684899392</BitOffs>
+            <BitOffs>684899648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -81335,7 +81345,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684924608</BitOffs>
+            <BitOffs>684924864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -81360,7 +81370,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684949824</BitOffs>
+            <BitOffs>684950080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -81389,7 +81399,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684975040</BitOffs>
+            <BitOffs>684975296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -81414,7 +81424,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685000256</BitOffs>
+            <BitOffs>685000512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -81451,7 +81461,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685025472</BitOffs>
+            <BitOffs>685025728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -81496,7 +81506,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685050688</BitOffs>
+            <BitOffs>685050944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -81537,7 +81547,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685075904</BitOffs>
+            <BitOffs>685076160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -81578,7 +81588,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685101120</BitOffs>
+            <BitOffs>685101376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -81619,7 +81629,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685126336</BitOffs>
+            <BitOffs>685126592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -81660,7 +81670,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685151552</BitOffs>
+            <BitOffs>685151808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -81701,7 +81711,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685176768</BitOffs>
+            <BitOffs>685177024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -81742,7 +81752,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685201984</BitOffs>
+            <BitOffs>685202240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -81783,7 +81793,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685227200</BitOffs>
+            <BitOffs>685227456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -81819,7 +81829,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685252416</BitOffs>
+            <BitOffs>685252672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -81855,7 +81865,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685277632</BitOffs>
+            <BitOffs>685277888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -81891,7 +81901,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685302848</BitOffs>
+            <BitOffs>685303104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -81936,7 +81946,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685328064</BitOffs>
+            <BitOffs>685328320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -81966,7 +81976,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353280</BitOffs>
+            <BitOffs>685353536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -81996,7 +82006,37 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353344</BitOffs>
+            <BitOffs>685353600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -82010,7 +82050,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353408</BitOffs>
+            <BitOffs>685353696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -82024,7 +82064,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353440</BitOffs>
+            <BitOffs>685353728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -82038,7 +82078,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353472</BitOffs>
+            <BitOffs>685353760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82052,21 +82092,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685355552</BitOffs>
+            <BitOffs>685353792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -82084,7 +82110,21 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685355584</BitOffs>
+            <BitOffs>685355840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685356864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -82098,7 +82138,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685356608</BitOffs>
+            <BitOffs>685356896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -82119,7 +82159,30 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685356640</BitOffs>
+            <BitOffs>685356928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685400256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -82188,7 +82251,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370016</BitOffs>
+            <BitOffs>685409280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -82257,7 +82320,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370144</BitOffs>
+            <BitOffs>685409408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -82326,7 +82389,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370272</BitOffs>
+            <BitOffs>685409536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -82395,7 +82458,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370400</BitOffs>
+            <BitOffs>685409664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -82464,7 +82527,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370528</BitOffs>
+            <BitOffs>685409792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -82533,30 +82596,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685400992</BitOffs>
+            <BitOffs>685409920</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82618,6 +82658,9 @@ Digital outputs</Comment>
       <Deployment/>
       <EventClasses>
         <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
+        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -82632,9 +82675,6 @@ Digital outputs</Comment>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
-        <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -82643,15 +82683,15 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-29T13:19:11</Value>
+          <Value>2023-08-29T15:46:55</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1069056</Value>
+          <Value>995328</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>85258240</Value>
+          <Value>85184512</Value>
         </Property>
       </Properties>
     </Module>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FFAD9F7F-8F47-E9A2-2B04-1E1315764F5C}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{8CD16176-3054-962A-EB25-D5902B2E2C9A}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -1437,6 +1437,9 @@
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+      </Method>
+      <Method>
         <Name>ExtendName</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -1492,7 +1495,19 @@
         </Local>
       </Method>
       <Method>
-        <Name>Clear</Name>
+        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1539,21 +1554,6 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>32</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1773,7 +1773,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1974,6 +1974,9 @@
         </Local>
       </Method>
       <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2134,9 +2137,6 @@
             </Property>
           </Properties>
         </Local>
-      </Method>
-      <Method>
-        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -4066,69 +4066,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -4610,6 +4547,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4640,15 +4640,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetFailed</Name>
-      </Method>
-      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -4933,91 +4933,12 @@
         <BitOffs>8224288</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -5066,6 +4987,53 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5253,12 +5221,44 @@
         </Properties>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -5569,14 +5569,6 @@
         <BitOffs>4240224</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5616,6 +5608,46 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5782,39 +5814,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6158,105 +6158,6 @@
         <BitOffs>12687680</BitOffs>
       </SubItem>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6502,18 +6403,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_UINT</Name>
+        <Name>AssertEquals_STRING</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6668,6 +6569,115 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6803,6 +6813,21 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7177,26 +7202,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>128</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
+        <Name>AssertArrayEquals_DINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7210,8 +7220,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7275,16 +7285,6 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7299,6 +7299,42 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7335,210 +7371,6 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>7840</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7745,17 +7577,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertTrue</Name>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7764,16 +7590,6 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -8026,6 +7842,37 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertEquals_REAL</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -8094,18 +7941,34 @@
         </Local>
       </Method>
       <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>AssertEquals_LTIME</Name>
         <Parameter>
-          <Name>TestName</Name>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8270,6 +8133,340 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>7840</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UDINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -8369,204 +8566,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_STRING</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertFalse</Name>
         <Parameter>
           <Name>Condition</Name>
@@ -8597,11 +8596,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
+        <Name>AssertArrayEquals_LINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -8615,8 +8614,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9123,19 +9122,19 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>128</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9183,37 +9182,6 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LTIME</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9326,6 +9294,93 @@
         </Local>
       </Method>
       <Method>
+        <Name>FindTestSuiteInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -9425,41 +9480,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_LREAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9473,8 +9498,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9485,6 +9510,12 @@
               <Value>1</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9551,37 +9582,6 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -12965,14 +12965,6 @@
         </Default>
       </SubItem>
       <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13025,20 +13017,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13052,15 +13030,25 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13085,6 +13073,9 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>ResetDocument</Name>
+      </Method>
+      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13104,36 +13095,22 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>StartObject</Name>
       </Method>
       <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13160,6 +13137,20 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13203,6 +13194,21 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13254,7 +13260,35 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13267,9 +13301,20 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddRawObject</Name>
+        <Name>AddFileTime</Name>
         <Parameter>
-          <Name>rawJson</Name>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -13279,21 +13324,11 @@
             </Property>
           </Properties>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13302,21 +13337,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13340,7 +13360,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyDateTime</Name>
+        <Name>AddKeyNull</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13351,11 +13371,6 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13368,25 +13383,10 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>AddReal</Name>
         <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13705,11 +13705,22 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>Execute</Name>
-      </Action>
-      <Action>
         <Name>EvaluateOutput</Name>
       </Action>
+      <Action>
+        <Name>Execute</Name>
+      </Action>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
+      </Method>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13768,51 +13779,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
-        <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>7680</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IdxCheckIn</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>OK</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Reset</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stFF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>7680</BitSize>
-        </Local>
-        <Local>
-          <Name>BeamPermitted</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Register</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13850,15 +13816,49 @@
         </Properties>
       </Method>
       <Method>
-        <Name>EvaluateVetos</Name>
+        <Name>IdxCheckIn</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>OK</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Reset</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stFF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>7680</BitSize>
+        </Local>
+        <Local>
+          <Name>BeamPermitted</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
         <Properties>
           <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
+            <Name>no_check</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
+        <Parameter>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>7680</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -14126,12 +14126,22 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14218,14 +14228,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name>PushbackFileTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14269,6 +14284,32 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14291,6 +14332,16 @@
         <Parameter>
           <Name>reserve</Name>
           <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14326,23 +14377,34 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>PushbackUintValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ParseDocument</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14382,16 +14444,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14407,7 +14459,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
+        <Name>PushbackBoolValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14417,8 +14469,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14483,6 +14535,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14519,59 +14581,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddJsonMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint</Name>
+        <Name>PushbackUint64Value</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14581,8 +14591,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14601,9 +14611,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14616,16 +14626,6 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14636,18 +14636,13 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14719,6 +14714,36 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>SetDcTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetArray</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14729,19 +14754,24 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetStringLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -14792,9 +14822,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsBase64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14802,7 +14832,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
+        <Name>IsTrue</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -14900,7 +14930,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetArray</Name>
+        <Name>AddObjectMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14909,9 +14939,15 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14932,6 +14968,21 @@
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14976,38 +15027,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15043,32 +15062,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsHexBinary</Name>
+        <Name>Swap</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -15076,11 +15070,31 @@
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsHexBinary</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15114,9 +15128,34 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15179,9 +15218,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15189,17 +15228,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackFileTimeValue</Name>
+        <Name>AddJsonMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15208,9 +15237,26 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -15242,9 +15288,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15344,6 +15390,14 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15426,16 +15480,58 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
+        <Name>SetUint</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>dp</Name>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
@@ -15490,42 +15586,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackBoolValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15552,22 +15612,12 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15656,9 +15706,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15676,22 +15726,7 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
+          <Name>value</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -15723,28 +15758,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArrayValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15759,134 +15783,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackDoubleValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
+        <Name>GetDocument</Name>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -15924,7 +15823,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
+        <Name>PushbackDoubleValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15934,7 +15833,108 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>length</Name>
           <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18237,19 +18237,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18265,18 +18264,19 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18460,6 +18460,88 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Copy</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -18515,88 +18597,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type RpcDirection="in">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -18795,9 +18795,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ToStartBuffer</Name>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Parameter>
           <Name>Name</Name>
@@ -18816,6 +18813,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
         <ReturnType RpcDirection="out">UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -18831,20 +18844,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Parameter>
-          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -18865,12 +18867,10 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>ClearBuffer</Name>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
       </Method>
       <Properties>
         <Property>
@@ -19230,11 +19230,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -19246,6 +19241,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -19261,9 +19264,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -19300,17 +19303,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
+        <Name>GetTestOrder</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -19595,52 +19595,35 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640288</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19688,27 +19671,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
+        <Name>GetDetectionCountThisCycle</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19905,12 +19870,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -20056,7 +20056,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480224</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20064,7 +20094,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -20251,39 +20283,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20843,18 +20843,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -21585,666 +21585,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertFalse</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>AssertEquals</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -22549,6 +21889,514 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>AssertFalse</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -23092,21 +22940,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFinished</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23596,24 +23429,50 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AssertEquals_DWORD</Name>
         <Parameter>
-          <Name>TestName</Name>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -23678,18 +23537,42 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertArray2dEquals_REAL</Name>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -23698,7 +23581,22 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -23706,6 +23604,124 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -23976,34 +23992,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LWORD</Name>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
           <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
+        </Parameter>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -24376,32 +24376,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>WriteLog</Name>
         <Parameter>
           <Name>MsgCtrlMask</Name>
@@ -24435,6 +24409,32 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -30211,6 +30211,37 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -30255,37 +30286,6 @@ External Setpoint Generation:
 	</Value>
           </Property>
         </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -30901,28 +30901,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Properties>
         <Property>
@@ -31183,29 +31183,33 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>391872</BitOffs>
       </SubItem>
       <Method>
-        <Name>RemoveRequest</Name>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqId</Name>
+          <Name>nReqID</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81600</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31329,31 +31333,6 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
-        <Name>CheckRequestInPool</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AddRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -31393,19 +31372,40 @@ These features efficiently address the addition, removal, and verification of be
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
+        <Name>RemoveRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqId</Name>
+          <Type>DWORD</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81600</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
         </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CheckRequestInPool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -42863,13 +42863,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
-      </Action>
-      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
+      </Action>
+      <Action>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -42890,7 +42890,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>AssertFinalBP</Name>
+        <Name>DeauthorizeTransition</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -49687,19 +49687,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
+        <Name>ACT_Motion</Name>
+      </Action>
+      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_Motion</Name>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_BLOCK</Name>
-      </Action>
-      <Action>
-        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -50449,10 +50449,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Properties>
         <Property>
@@ -50731,10 +50731,10 @@ Digital outputs</Comment>
         <BitOffs>253760</BitOffs>
       </SubItem>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Properties>
         <Property>
@@ -51122,13 +51122,13 @@ Digital outputs</Comment>
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -51401,10 +51401,10 @@ Digital outputs</Comment>
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -54742,6 +54742,47 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
+        <Name>TcQueryInterface</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -54789,21 +54830,6 @@ Digital outputs</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>Execute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
@@ -54906,45 +54932,19 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
+        <Name>Execute</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -55651,30 +55651,6 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -55721,6 +55697,30 @@ Digital outputs</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -55856,9 +55856,9 @@ Digital outputs</Comment>
         <BitOffs>64</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>GetJsonFromSymbol</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -55872,27 +55872,29 @@ Digital outputs</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -55973,6 +55975,45 @@ Digital outputs</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -56106,47 +56147,6 @@ Digital outputs</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
-          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -56842,12 +56842,46 @@ Digital outputs</Comment>
         </Parameter>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>32</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -56974,40 +57008,6 @@ Digital outputs</Comment>
               <Value>__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -79801,7 +79801,8 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
             <BitOffs>647301312</BitOffs>
@@ -79839,7 +79840,8 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
             <BitOffs>649815616</BitOffs>
@@ -79877,7 +79879,8 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
             <BitOffs>652329920</BitOffs>
@@ -82683,15 +82686,15 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-29T15:46:55</Value>
+          <Value>2023-08-30T10:51:14</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>995328</Value>
+          <Value>1073152</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>85184512</Value>
+          <Value>85258240</Value>
         </Property>
       </Properties>
     </Module>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{8CD16176-3054-962A-EB25-D5902B2E2C9A}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{0F12739F-5C25-5C7A-BE7F-347F55021D9C}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85690536</GetCodeOffs>
+        <GetCodeOffs>85690500</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85690568</GetCodeOffs>
+        <GetCodeOffs>85690532</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690576</GetCodeOffs>
+        <GetCodeOffs>85690540</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690560</GetCodeOffs>
+        <GetCodeOffs>85690524</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690572</GetCodeOffs>
+        <GetCodeOffs>85690536</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690480</GetCodeOffs>
-        <SetCodeOffs>85690504</SetCodeOffs>
+        <GetCodeOffs>85690444</GetCodeOffs>
+        <SetCodeOffs>85690468</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690516</GetCodeOffs>
-        <SetCodeOffs>85690528</SetCodeOffs>
+        <GetCodeOffs>85690480</GetCodeOffs>
+        <SetCodeOffs>85690492</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>85690624</GetCodeOffs>
+        <GetCodeOffs>85690588</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690604</GetCodeOffs>
+        <GetCodeOffs>85690568</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690692</GetCodeOffs>
+        <GetCodeOffs>85690656</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690652</GetCodeOffs>
+        <GetCodeOffs>85690616</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690696</GetCodeOffs>
+        <GetCodeOffs>85690660</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85690720</GetCodeOffs>
+        <GetCodeOffs>85690684</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -52504,6 +52504,89 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name>ENUM_ZonePlate_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Yag</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_1</Text>
+        <Enum>3</Enum>
+        <Comment>Ne1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_2</Text>
+        <Enum>4</Enum>
+        <Comment>Ne2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_3</Text>
+        <Enum>5</Enum>
+        <Comment>Ne3</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_1</Text>
+        <Enum>6</Enum>
+        <Comment>3w1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_2</Text>
+        <Enum>7</Enum>
+        <Comment>3w2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_1</Text>
+        <Enum>8</Enum>
+        <Comment>o1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_2</Text>
+        <Enum>9</Enum>
+        <Comment>o2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_1</Text>
+        <Enum>10</Enum>
+        <Comment>Ti1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_2</Text>
+        <Enum>11</Enum>
+        <Comment>Ti2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_1</Text>
+        <Enum>12</Enum>
+        <Comment>N1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_2</Text>
+        <Enum>13</Enum>
+        <Comment>N2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_1</Text>
+        <Enum>14</Enum>
+        <Comment> C1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_2</Text>
+        <Enum>15</Enum>
+        <Comment>C2
+	FZP250_1 := 16    //w1</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</Name>
       <BitSize>1506432</BitSize>
       <SubItem>
@@ -52873,122 +52956,6 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_ZonePlate_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Yag</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_1</Text>
-        <Enum>3</Enum>
-        <Comment>Ne1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_2</Text>
-        <Enum>4</Enum>
-        <Comment>Ne2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_3</Text>
-        <Enum>5</Enum>
-        <Comment>Ne3</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_1</Text>
-        <Enum>6</Enum>
-        <Comment>3w1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_2</Text>
-        <Enum>7</Enum>
-        <Comment>3w2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_1</Text>
-        <Enum>8</Enum>
-        <Comment>o1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_2</Text>
-        <Enum>9</Enum>
-        <Comment>o2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_1</Text>
-        <Enum>10</Enum>
-        <Comment>Ti1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_2</Text>
-        <Enum>11</Enum>
-        <Comment>Ti2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_1</Text>
-        <Enum>12</Enum>
-        <Comment>N1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_2</Text>
-        <Enum>13</Enum>
-        <Comment>N2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_1</Text>
-        <Enum>14</Enum>
-        <Comment> C1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_2</Text>
-        <Enum>15</Enum>
-        <Comment>C2
-	FZP250_1 := 16    //w1</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
@@ -53542,6 +53509,39 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
@@ -54305,8 +54305,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85697252</GetCodeOffs>
-        <SetCodeOffs>85697260</SetCodeOffs>
+        <GetCodeOffs>85697216</GetCodeOffs>
+        <SetCodeOffs>85697224</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -55600,31 +55600,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85696820</GetCodeOffs>
+        <GetCodeOffs>85696784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85696852</GetCodeOffs>
+        <GetCodeOffs>85696816</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85696856</GetCodeOffs>
+        <GetCodeOffs>85696820</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85696844</GetCodeOffs>
+        <GetCodeOffs>85696808</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85696864</GetCodeOffs>
+        <GetCodeOffs>85696828</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -58894,44 +58894,6 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
-    </DataType>
-    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -59737,6 +59699,44 @@ Digital outputs</Comment>
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
       </Hides>
     </DataType>
+    <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{A4C97A60-C95C-4787-A832-16AA681FD195}" TcSmClass="TComPlcObjDef">
@@ -59769,7 +59769,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640357952</BitOffs>
+            <BitOffs>640357696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -59781,7 +59781,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641921984</BitOffs>
+            <BitOffs>641921728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -59794,7 +59794,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929920</BitOffs>
+            <BitOffs>641929664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -59807,7 +59807,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929928</BitOffs>
+            <BitOffs>641929672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -59820,7 +59820,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929936</BitOffs>
+            <BitOffs>641929680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -59843,7 +59843,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929952</BitOffs>
+            <BitOffs>641929696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -59856,7 +59856,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641929984</BitOffs>
+            <BitOffs>641929728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -59869,7 +59869,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641930048</BitOffs>
+            <BitOffs>641929792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -59882,7 +59882,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641930064</BitOffs>
+            <BitOffs>641929808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -59894,7 +59894,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641947200</BitOffs>
+            <BitOffs>641946944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -59907,7 +59907,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955136</BitOffs>
+            <BitOffs>641954880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -59920,7 +59920,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955144</BitOffs>
+            <BitOffs>641954888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -59933,7 +59933,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955152</BitOffs>
+            <BitOffs>641954896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -59956,7 +59956,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955168</BitOffs>
+            <BitOffs>641954912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -59969,7 +59969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955200</BitOffs>
+            <BitOffs>641954944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -59982,7 +59982,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955264</BitOffs>
+            <BitOffs>641955008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -59995,7 +59995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641955280</BitOffs>
+            <BitOffs>641955024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -60007,7 +60007,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641972416</BitOffs>
+            <BitOffs>641972160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -60020,7 +60020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980352</BitOffs>
+            <BitOffs>641980096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -60033,7 +60033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980360</BitOffs>
+            <BitOffs>641980104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -60046,7 +60046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980368</BitOffs>
+            <BitOffs>641980112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -60069,7 +60069,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980384</BitOffs>
+            <BitOffs>641980128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -60082,7 +60082,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980416</BitOffs>
+            <BitOffs>641980160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -60095,7 +60095,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980480</BitOffs>
+            <BitOffs>641980224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -60108,7 +60108,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641980496</BitOffs>
+            <BitOffs>641980240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -60121,7 +60121,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642270560</BitOffs>
+            <BitOffs>642270304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60133,7 +60133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642293888</BitOffs>
+            <BitOffs>642293632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -60145,7 +60145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643857920</BitOffs>
+            <BitOffs>643857664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -60158,7 +60158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865856</BitOffs>
+            <BitOffs>643865600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -60171,7 +60171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865864</BitOffs>
+            <BitOffs>643865608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -60184,7 +60184,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865872</BitOffs>
+            <BitOffs>643865616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -60207,7 +60207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865888</BitOffs>
+            <BitOffs>643865632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -60220,7 +60220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865920</BitOffs>
+            <BitOffs>643865664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -60233,7 +60233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643865984</BitOffs>
+            <BitOffs>643865728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -60246,7 +60246,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643866000</BitOffs>
+            <BitOffs>643865744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -60258,7 +60258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643883136</BitOffs>
+            <BitOffs>643882880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -60271,7 +60271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891072</BitOffs>
+            <BitOffs>643890816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -60284,7 +60284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891080</BitOffs>
+            <BitOffs>643890824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -60297,7 +60297,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891088</BitOffs>
+            <BitOffs>643890832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -60320,7 +60320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891104</BitOffs>
+            <BitOffs>643890848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -60333,7 +60333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891136</BitOffs>
+            <BitOffs>643890880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -60346,7 +60346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891200</BitOffs>
+            <BitOffs>643890944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -60359,7 +60359,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643891216</BitOffs>
+            <BitOffs>643890960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -60371,7 +60371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643908352</BitOffs>
+            <BitOffs>643908096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -60384,7 +60384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916288</BitOffs>
+            <BitOffs>643916032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -60397,7 +60397,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916296</BitOffs>
+            <BitOffs>643916040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -60410,7 +60410,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916304</BitOffs>
+            <BitOffs>643916048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -60433,7 +60433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916320</BitOffs>
+            <BitOffs>643916064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -60446,7 +60446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916352</BitOffs>
+            <BitOffs>643916096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -60459,7 +60459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916416</BitOffs>
+            <BitOffs>643916160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -60472,7 +60472,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643916432</BitOffs>
+            <BitOffs>643916176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -60484,7 +60484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644206304</BitOffs>
+            <BitOffs>644206048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60503,7 +60503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398664</BitOffs>
+            <BitOffs>644398408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60515,7 +60515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398672</BitOffs>
+            <BitOffs>644398416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60527,7 +60527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398680</BitOffs>
+            <BitOffs>644398424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60539,7 +60539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398688</BitOffs>
+            <BitOffs>644398432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60552,7 +60552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644398944</BitOffs>
+            <BitOffs>644398688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60565,7 +60565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644785056</BitOffs>
+            <BitOffs>644784800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
@@ -60578,7 +60578,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786144</BitOffs>
+            <BitOffs>644785888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -60597,7 +60597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786696</BitOffs>
+            <BitOffs>644786440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60609,7 +60609,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786704</BitOffs>
+            <BitOffs>644786448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -60621,7 +60621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786712</BitOffs>
+            <BitOffs>644786456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -60633,7 +60633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644786720</BitOffs>
+            <BitOffs>644786464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60645,7 +60645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644808192</BitOffs>
+            <BitOffs>644807936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -60657,7 +60657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646372224</BitOffs>
+            <BitOffs>646371968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -60670,7 +60670,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380160</BitOffs>
+            <BitOffs>646379904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -60683,7 +60683,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380168</BitOffs>
+            <BitOffs>646379912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -60696,7 +60696,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380176</BitOffs>
+            <BitOffs>646379920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -60719,7 +60719,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380192</BitOffs>
+            <BitOffs>646379936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -60732,7 +60732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380224</BitOffs>
+            <BitOffs>646379968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -60745,7 +60745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380288</BitOffs>
+            <BitOffs>646380032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -60758,7 +60758,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646380304</BitOffs>
+            <BitOffs>646380048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -60770,7 +60770,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646397440</BitOffs>
+            <BitOffs>646397184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -60783,7 +60783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405376</BitOffs>
+            <BitOffs>646405120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -60796,7 +60796,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405384</BitOffs>
+            <BitOffs>646405128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -60809,7 +60809,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405392</BitOffs>
+            <BitOffs>646405136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -60832,7 +60832,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405408</BitOffs>
+            <BitOffs>646405152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -60845,7 +60845,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405440</BitOffs>
+            <BitOffs>646405184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -60858,7 +60858,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405504</BitOffs>
+            <BitOffs>646405248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -60871,7 +60871,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646405520</BitOffs>
+            <BitOffs>646405264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -60883,7 +60883,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646422656</BitOffs>
+            <BitOffs>646422400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -60896,7 +60896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430592</BitOffs>
+            <BitOffs>646430336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -60909,7 +60909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430600</BitOffs>
+            <BitOffs>646430344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -60922,7 +60922,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430608</BitOffs>
+            <BitOffs>646430352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -60945,7 +60945,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430624</BitOffs>
+            <BitOffs>646430368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -60958,7 +60958,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430656</BitOffs>
+            <BitOffs>646430400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -60971,7 +60971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430720</BitOffs>
+            <BitOffs>646430464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -60984,7 +60984,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646430736</BitOffs>
+            <BitOffs>646430480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -60996,7 +60996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646720608</BitOffs>
+            <BitOffs>646720352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -61015,7 +61015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912968</BitOffs>
+            <BitOffs>646912712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -61027,7 +61027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912976</BitOffs>
+            <BitOffs>646912720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -61039,7 +61039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912984</BitOffs>
+            <BitOffs>646912728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -61051,7 +61051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646912992</BitOffs>
+            <BitOffs>646912736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -61064,7 +61064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646913248</BitOffs>
+            <BitOffs>646912992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -61077,7 +61077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647299360</BitOffs>
+            <BitOffs>647299104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
@@ -61090,7 +61090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647300448</BitOffs>
+            <BitOffs>647300192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -61109,7 +61109,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647301000</BitOffs>
+            <BitOffs>647300744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -61121,7 +61121,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647301008</BitOffs>
+            <BitOffs>647300752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -61133,7 +61133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647301016</BitOffs>
+            <BitOffs>647300760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -61145,7 +61145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647301024</BitOffs>
+            <BitOffs>647300768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61157,7 +61157,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647322496</BitOffs>
+            <BitOffs>647322240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61169,7 +61169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648886528</BitOffs>
+            <BitOffs>648886272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61182,7 +61182,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894464</BitOffs>
+            <BitOffs>648894208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61195,7 +61195,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894472</BitOffs>
+            <BitOffs>648894216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -61208,7 +61208,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894480</BitOffs>
+            <BitOffs>648894224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61231,7 +61231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894496</BitOffs>
+            <BitOffs>648894240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61244,7 +61244,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894528</BitOffs>
+            <BitOffs>648894272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61257,7 +61257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894592</BitOffs>
+            <BitOffs>648894336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61270,7 +61270,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648894608</BitOffs>
+            <BitOffs>648894352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61282,7 +61282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648911744</BitOffs>
+            <BitOffs>648911488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61295,7 +61295,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919680</BitOffs>
+            <BitOffs>648919424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61308,7 +61308,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919688</BitOffs>
+            <BitOffs>648919432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -61321,7 +61321,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919696</BitOffs>
+            <BitOffs>648919440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61344,7 +61344,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919712</BitOffs>
+            <BitOffs>648919456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61357,7 +61357,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919744</BitOffs>
+            <BitOffs>648919488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61370,7 +61370,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919808</BitOffs>
+            <BitOffs>648919552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61383,7 +61383,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648919824</BitOffs>
+            <BitOffs>648919568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61395,7 +61395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648936960</BitOffs>
+            <BitOffs>648936704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61408,7 +61408,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944896</BitOffs>
+            <BitOffs>648944640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61421,7 +61421,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944904</BitOffs>
+            <BitOffs>648944648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -61434,7 +61434,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944912</BitOffs>
+            <BitOffs>648944656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61457,7 +61457,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944928</BitOffs>
+            <BitOffs>648944672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61470,7 +61470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648944960</BitOffs>
+            <BitOffs>648944704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61483,7 +61483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648945024</BitOffs>
+            <BitOffs>648944768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -61496,7 +61496,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648945040</BitOffs>
+            <BitOffs>648944784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -61508,7 +61508,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649234912</BitOffs>
+            <BitOffs>649234656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -61527,7 +61527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427272</BitOffs>
+            <BitOffs>649427016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -61539,7 +61539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427280</BitOffs>
+            <BitOffs>649427024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -61551,7 +61551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427288</BitOffs>
+            <BitOffs>649427032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -61563,7 +61563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427296</BitOffs>
+            <BitOffs>649427040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -61576,7 +61576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649427552</BitOffs>
+            <BitOffs>649427296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -61589,7 +61589,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649813664</BitOffs>
+            <BitOffs>649813408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
@@ -61602,7 +61602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649814752</BitOffs>
+            <BitOffs>649814496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -61621,7 +61621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815304</BitOffs>
+            <BitOffs>649815048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -61633,7 +61633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815312</BitOffs>
+            <BitOffs>649815056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -61645,7 +61645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815320</BitOffs>
+            <BitOffs>649815064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -61657,7 +61657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649815328</BitOffs>
+            <BitOffs>649815072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61669,7 +61669,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649836800</BitOffs>
+            <BitOffs>649836544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61681,7 +61681,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651400832</BitOffs>
+            <BitOffs>651400576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61694,7 +61694,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408768</BitOffs>
+            <BitOffs>651408512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61707,7 +61707,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408776</BitOffs>
+            <BitOffs>651408520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -61720,7 +61720,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408784</BitOffs>
+            <BitOffs>651408528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61743,7 +61743,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408800</BitOffs>
+            <BitOffs>651408544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61756,7 +61756,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408832</BitOffs>
+            <BitOffs>651408576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61769,7 +61769,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408896</BitOffs>
+            <BitOffs>651408640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61782,7 +61782,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651408912</BitOffs>
+            <BitOffs>651408656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61794,7 +61794,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651426048</BitOffs>
+            <BitOffs>651425792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61807,7 +61807,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433984</BitOffs>
+            <BitOffs>651433728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61820,7 +61820,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651433992</BitOffs>
+            <BitOffs>651433736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -61833,7 +61833,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651434000</BitOffs>
+            <BitOffs>651433744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61856,7 +61856,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651434016</BitOffs>
+            <BitOffs>651433760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61869,7 +61869,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651434048</BitOffs>
+            <BitOffs>651433792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61882,7 +61882,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651434112</BitOffs>
+            <BitOffs>651433856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61895,7 +61895,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651434128</BitOffs>
+            <BitOffs>651433872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61907,7 +61907,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651451264</BitOffs>
+            <BitOffs>651451008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61920,7 +61920,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459200</BitOffs>
+            <BitOffs>651458944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61933,7 +61933,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459208</BitOffs>
+            <BitOffs>651458952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -61946,7 +61946,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459216</BitOffs>
+            <BitOffs>651458960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61969,7 +61969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459232</BitOffs>
+            <BitOffs>651458976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61982,7 +61982,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459264</BitOffs>
+            <BitOffs>651459008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61995,7 +61995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459328</BitOffs>
+            <BitOffs>651459072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62008,7 +62008,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651459344</BitOffs>
+            <BitOffs>651459088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -62020,7 +62020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651749216</BitOffs>
+            <BitOffs>651748960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -62039,7 +62039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941576</BitOffs>
+            <BitOffs>651941320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -62051,7 +62051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941584</BitOffs>
+            <BitOffs>651941328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -62063,7 +62063,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941592</BitOffs>
+            <BitOffs>651941336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -62075,7 +62075,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941600</BitOffs>
+            <BitOffs>651941344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -62088,7 +62088,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651941856</BitOffs>
+            <BitOffs>651941600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -62101,7 +62101,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652327968</BitOffs>
+            <BitOffs>652327712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
@@ -62114,7 +62114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329056</BitOffs>
+            <BitOffs>652328800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -62133,7 +62133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329608</BitOffs>
+            <BitOffs>652329352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -62145,7 +62145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329616</BitOffs>
+            <BitOffs>652329360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -62157,7 +62157,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329624</BitOffs>
+            <BitOffs>652329368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -62169,7 +62169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652329632</BitOffs>
+            <BitOffs>652329376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -62181,7 +62181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652351104</BitOffs>
+            <BitOffs>652350848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -62193,7 +62193,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653915136</BitOffs>
+            <BitOffs>653914880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -62206,7 +62206,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923072</BitOffs>
+            <BitOffs>653922816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -62219,7 +62219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923080</BitOffs>
+            <BitOffs>653922824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -62232,7 +62232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923088</BitOffs>
+            <BitOffs>653922832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -62255,7 +62255,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923104</BitOffs>
+            <BitOffs>653922848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -62268,7 +62268,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923136</BitOffs>
+            <BitOffs>653922880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -62281,7 +62281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923200</BitOffs>
+            <BitOffs>653922944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -62294,7 +62294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653923216</BitOffs>
+            <BitOffs>653922960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -62306,7 +62306,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653940352</BitOffs>
+            <BitOffs>653940096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -62319,7 +62319,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948288</BitOffs>
+            <BitOffs>653948032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -62332,7 +62332,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948296</BitOffs>
+            <BitOffs>653948040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -62345,7 +62345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948304</BitOffs>
+            <BitOffs>653948048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -62368,7 +62368,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948320</BitOffs>
+            <BitOffs>653948064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -62381,7 +62381,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948352</BitOffs>
+            <BitOffs>653948096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -62394,7 +62394,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948416</BitOffs>
+            <BitOffs>653948160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -62407,7 +62407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653948432</BitOffs>
+            <BitOffs>653948176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62419,7 +62419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653965568</BitOffs>
+            <BitOffs>653965312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62432,7 +62432,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973504</BitOffs>
+            <BitOffs>653973248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62445,7 +62445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973512</BitOffs>
+            <BitOffs>653973256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -62458,7 +62458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973520</BitOffs>
+            <BitOffs>653973264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62481,7 +62481,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973536</BitOffs>
+            <BitOffs>653973280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -62494,7 +62494,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973568</BitOffs>
+            <BitOffs>653973312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -62507,7 +62507,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973632</BitOffs>
+            <BitOffs>653973376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62520,7 +62520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653973648</BitOffs>
+            <BitOffs>653973392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -62532,7 +62532,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654263520</BitOffs>
+            <BitOffs>654263264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -62551,7 +62551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455880</BitOffs>
+            <BitOffs>654455624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -62563,7 +62563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455888</BitOffs>
+            <BitOffs>654455632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -62575,7 +62575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455896</BitOffs>
+            <BitOffs>654455640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -62587,7 +62587,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654455904</BitOffs>
+            <BitOffs>654455648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -62600,7 +62600,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654456160</BitOffs>
+            <BitOffs>654455904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -62613,7 +62613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654842272</BitOffs>
+            <BitOffs>654842016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
@@ -62626,7 +62626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843360</BitOffs>
+            <BitOffs>654843104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -62645,7 +62645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843912</BitOffs>
+            <BitOffs>654843656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -62657,7 +62657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843920</BitOffs>
+            <BitOffs>654843664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -62669,7 +62669,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843928</BitOffs>
+            <BitOffs>654843672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -62681,7 +62681,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654843936</BitOffs>
+            <BitOffs>654843680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -62693,7 +62693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654865536</BitOffs>
+            <BitOffs>654865280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -62705,7 +62705,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656429568</BitOffs>
+            <BitOffs>656429312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -62718,7 +62718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437504</BitOffs>
+            <BitOffs>656437248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -62731,7 +62731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437512</BitOffs>
+            <BitOffs>656437256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -62744,7 +62744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437520</BitOffs>
+            <BitOffs>656437264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -62767,7 +62767,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437536</BitOffs>
+            <BitOffs>656437280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -62780,7 +62780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437568</BitOffs>
+            <BitOffs>656437312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -62793,7 +62793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437632</BitOffs>
+            <BitOffs>656437376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -62806,7 +62806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656437648</BitOffs>
+            <BitOffs>656437392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -62818,7 +62818,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656454784</BitOffs>
+            <BitOffs>656454528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -62831,7 +62831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462720</BitOffs>
+            <BitOffs>656462464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -62844,7 +62844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462728</BitOffs>
+            <BitOffs>656462472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -62857,7 +62857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462736</BitOffs>
+            <BitOffs>656462480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -62880,7 +62880,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462752</BitOffs>
+            <BitOffs>656462496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -62893,7 +62893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462784</BitOffs>
+            <BitOffs>656462528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -62906,7 +62906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462848</BitOffs>
+            <BitOffs>656462592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -62919,7 +62919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656462864</BitOffs>
+            <BitOffs>656462608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62931,7 +62931,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656480000</BitOffs>
+            <BitOffs>656479744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62944,7 +62944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487936</BitOffs>
+            <BitOffs>656487680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62957,7 +62957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487944</BitOffs>
+            <BitOffs>656487688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -62970,7 +62970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487952</BitOffs>
+            <BitOffs>656487696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62993,7 +62993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656487968</BitOffs>
+            <BitOffs>656487712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -63006,7 +63006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656488000</BitOffs>
+            <BitOffs>656487744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -63019,7 +63019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656488064</BitOffs>
+            <BitOffs>656487808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -63032,7 +63032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656488080</BitOffs>
+            <BitOffs>656487824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63044,7 +63044,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656808704</BitOffs>
+            <BitOffs>656808448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63056,7 +63056,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657106624</BitOffs>
+            <BitOffs>657106368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -63068,7 +63068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658670656</BitOffs>
+            <BitOffs>658670400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -63081,7 +63081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678592</BitOffs>
+            <BitOffs>658678336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -63094,7 +63094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678600</BitOffs>
+            <BitOffs>658678344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -63107,7 +63107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678608</BitOffs>
+            <BitOffs>658678352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -63130,7 +63130,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678624</BitOffs>
+            <BitOffs>658678368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -63143,7 +63143,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678656</BitOffs>
+            <BitOffs>658678400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -63156,7 +63156,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678720</BitOffs>
+            <BitOffs>658678464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -63169,7 +63169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658678736</BitOffs>
+            <BitOffs>658678480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -63181,7 +63181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658695872</BitOffs>
+            <BitOffs>658695616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -63194,7 +63194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703808</BitOffs>
+            <BitOffs>658703552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -63207,7 +63207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703816</BitOffs>
+            <BitOffs>658703560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -63220,7 +63220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703824</BitOffs>
+            <BitOffs>658703568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -63243,7 +63243,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703840</BitOffs>
+            <BitOffs>658703584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -63256,7 +63256,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703872</BitOffs>
+            <BitOffs>658703616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -63269,7 +63269,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703936</BitOffs>
+            <BitOffs>658703680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -63282,7 +63282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658703952</BitOffs>
+            <BitOffs>658703696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -63294,7 +63294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658721088</BitOffs>
+            <BitOffs>658720832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -63307,7 +63307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729024</BitOffs>
+            <BitOffs>658728768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -63320,7 +63320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729032</BitOffs>
+            <BitOffs>658728776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -63333,7 +63333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729040</BitOffs>
+            <BitOffs>658728784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -63356,7 +63356,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729056</BitOffs>
+            <BitOffs>658728800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -63369,7 +63369,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729088</BitOffs>
+            <BitOffs>658728832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -63382,7 +63382,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729152</BitOffs>
+            <BitOffs>658728896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -63395,7 +63395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658729168</BitOffs>
+            <BitOffs>658728912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -63419,7 +63419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019208</BitOffs>
+            <BitOffs>659018952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -63431,7 +63431,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019216</BitOffs>
+            <BitOffs>659018960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -63443,7 +63443,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019224</BitOffs>
+            <BitOffs>659018968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -63455,7 +63455,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019232</BitOffs>
+            <BitOffs>659018976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -63479,7 +63479,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019464</BitOffs>
+            <BitOffs>659019208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -63491,7 +63491,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019472</BitOffs>
+            <BitOffs>659019216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -63503,7 +63503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019480</BitOffs>
+            <BitOffs>659019224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -63515,7 +63515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659019488</BitOffs>
+            <BitOffs>659019232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63527,7 +63527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659049984</BitOffs>
+            <BitOffs>659049728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63539,7 +63539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659347904</BitOffs>
+            <BitOffs>659347648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -63551,7 +63551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660911936</BitOffs>
+            <BitOffs>660911680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -63564,7 +63564,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919872</BitOffs>
+            <BitOffs>660919616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -63577,7 +63577,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919880</BitOffs>
+            <BitOffs>660919624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -63590,7 +63590,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919888</BitOffs>
+            <BitOffs>660919632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -63613,7 +63613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919904</BitOffs>
+            <BitOffs>660919648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -63626,7 +63626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660919936</BitOffs>
+            <BitOffs>660919680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -63639,7 +63639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660920000</BitOffs>
+            <BitOffs>660919744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -63652,7 +63652,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660920016</BitOffs>
+            <BitOffs>660919760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -63664,7 +63664,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660937152</BitOffs>
+            <BitOffs>660936896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -63677,7 +63677,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945088</BitOffs>
+            <BitOffs>660944832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -63690,7 +63690,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945096</BitOffs>
+            <BitOffs>660944840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -63703,7 +63703,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945104</BitOffs>
+            <BitOffs>660944848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -63726,7 +63726,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945120</BitOffs>
+            <BitOffs>660944864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -63739,7 +63739,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945152</BitOffs>
+            <BitOffs>660944896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -63752,7 +63752,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945216</BitOffs>
+            <BitOffs>660944960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -63765,7 +63765,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660945232</BitOffs>
+            <BitOffs>660944976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -63777,7 +63777,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660962368</BitOffs>
+            <BitOffs>660962112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -63790,7 +63790,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970304</BitOffs>
+            <BitOffs>660970048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -63803,7 +63803,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970312</BitOffs>
+            <BitOffs>660970056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -63816,7 +63816,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970320</BitOffs>
+            <BitOffs>660970064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -63839,7 +63839,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970336</BitOffs>
+            <BitOffs>660970080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -63852,7 +63852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970368</BitOffs>
+            <BitOffs>660970112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -63865,7 +63865,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970432</BitOffs>
+            <BitOffs>660970176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -63878,7 +63878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660970448</BitOffs>
+            <BitOffs>660970192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -63902,7 +63902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260488</BitOffs>
+            <BitOffs>661260232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -63914,7 +63914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260496</BitOffs>
+            <BitOffs>661260240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -63926,7 +63926,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260504</BitOffs>
+            <BitOffs>661260248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -63938,7 +63938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260512</BitOffs>
+            <BitOffs>661260256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -63962,7 +63962,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260744</BitOffs>
+            <BitOffs>661260488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -63974,7 +63974,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260752</BitOffs>
+            <BitOffs>661260496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -63986,7 +63986,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260760</BitOffs>
+            <BitOffs>661260504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -63998,7 +63998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661260768</BitOffs>
+            <BitOffs>661260512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64010,7 +64010,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661267008</BitOffs>
+            <BitOffs>661266752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64022,7 +64022,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661564928</BitOffs>
+            <BitOffs>661564672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64034,7 +64034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661862848</BitOffs>
+            <BitOffs>661862592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64046,7 +64046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662160768</BitOffs>
+            <BitOffs>662160512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -64058,67 +64058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662606464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662613632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662911552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663209472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663507392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663953088</BitOffs>
+            <BitOffs>662606208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -64134,7 +64074,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663953232</BitOffs>
+            <BitOffs>662609776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -64150,39 +64090,67 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663953240</BitOffs>
+            <BitOffs>662609784</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL1High</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663956704</BitOffs>
+            <BitOffs>662613376</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL1Low</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663956712</BitOffs>
+            <BitOffs>662911296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663209216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663507136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663952832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -64195,7 +64163,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664065632</BitOffs>
+            <BitOffs>664065312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -64207,7 +64175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664065640</BitOffs>
+            <BitOffs>664065320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64219,7 +64187,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664100800</BitOffs>
+            <BitOffs>664100480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64231,7 +64199,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664398720</BitOffs>
+            <BitOffs>664398400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -64255,7 +64223,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390152</BitOffs>
+            <BitOffs>665389832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -64267,7 +64235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390160</BitOffs>
+            <BitOffs>665389840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -64279,7 +64247,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390168</BitOffs>
+            <BitOffs>665389848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -64291,39 +64259,39 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390176</BitOffs>
+            <BitOffs>665389856</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL2High</Name>
+            <Name>PRG_SP1K4.bTL1High</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390704</BitOffs>
+            <BitOffs>665390368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL2Low</Name>
+            <Name>PRG_SP1K4.bTL1Low</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390712</BitOffs>
+            <BitOffs>665390376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64335,7 +64303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665416640</BitOffs>
+            <BitOffs>665416320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64347,7 +64315,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665714560</BitOffs>
+            <BitOffs>665714240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -64371,7 +64339,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698696</BitOffs>
+            <BitOffs>666698376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -64383,7 +64351,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698704</BitOffs>
+            <BitOffs>666698384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -64395,7 +64363,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698712</BitOffs>
+            <BitOffs>666698392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -64407,7 +64375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698720</BitOffs>
+            <BitOffs>666698400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64419,7 +64387,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666701824</BitOffs>
+            <BitOffs>666701504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64431,7 +64399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666999744</BitOffs>
+            <BitOffs>666999424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64443,7 +64411,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667297664</BitOffs>
+            <BitOffs>667297344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64455,7 +64423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667595584</BitOffs>
+            <BitOffs>667595264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64467,7 +64435,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667893504</BitOffs>
+            <BitOffs>667893184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64479,7 +64447,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668191424</BitOffs>
+            <BitOffs>668191104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64491,7 +64459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668489344</BitOffs>
+            <BitOffs>668489024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64503,7 +64471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668787264</BitOffs>
+            <BitOffs>668786944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64515,7 +64483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669085184</BitOffs>
+            <BitOffs>669084864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64527,7 +64495,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669383104</BitOffs>
+            <BitOffs>669382784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64539,7 +64507,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669681024</BitOffs>
+            <BitOffs>669680704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64551,7 +64519,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669978944</BitOffs>
+            <BitOffs>669978624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64563,7 +64531,39 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670276864</BitOffs>
+            <BitOffs>670276544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL2High</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>670571984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL2Low</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>670571992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64575,7 +64575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671840064</BitOffs>
+            <BitOffs>671839808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64588,7 +64588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848000</BitOffs>
+            <BitOffs>671847744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64601,7 +64601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848008</BitOffs>
+            <BitOffs>671847752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -64614,7 +64614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848016</BitOffs>
+            <BitOffs>671847760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64637,7 +64637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848032</BitOffs>
+            <BitOffs>671847776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -64650,7 +64650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848064</BitOffs>
+            <BitOffs>671847808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -64663,7 +64663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848128</BitOffs>
+            <BitOffs>671847872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -64676,7 +64676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671848144</BitOffs>
+            <BitOffs>671847888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -64688,7 +64688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671865280</BitOffs>
+            <BitOffs>671865024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -64701,7 +64701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873216</BitOffs>
+            <BitOffs>671872960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -64714,7 +64714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873224</BitOffs>
+            <BitOffs>671872968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -64727,7 +64727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873232</BitOffs>
+            <BitOffs>671872976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -64750,7 +64750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873248</BitOffs>
+            <BitOffs>671872992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -64763,7 +64763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873280</BitOffs>
+            <BitOffs>671873024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -64776,7 +64776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873344</BitOffs>
+            <BitOffs>671873088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -64789,7 +64789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873360</BitOffs>
+            <BitOffs>671873104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -64801,7 +64801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671890496</BitOffs>
+            <BitOffs>671890240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -64814,7 +64814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898432</BitOffs>
+            <BitOffs>671898176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -64827,7 +64827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898440</BitOffs>
+            <BitOffs>671898184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -64840,7 +64840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898448</BitOffs>
+            <BitOffs>671898192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -64863,7 +64863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898464</BitOffs>
+            <BitOffs>671898208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -64876,7 +64876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898496</BitOffs>
+            <BitOffs>671898240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -64889,7 +64889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898560</BitOffs>
+            <BitOffs>671898304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -64902,7 +64902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898576</BitOffs>
+            <BitOffs>671898320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64914,7 +64914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673602112</BitOffs>
+            <BitOffs>673601792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64927,7 +64927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610048</BitOffs>
+            <BitOffs>673609728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64940,7 +64940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610056</BitOffs>
+            <BitOffs>673609736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -64953,7 +64953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610064</BitOffs>
+            <BitOffs>673609744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64976,7 +64976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610080</BitOffs>
+            <BitOffs>673609760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -64989,7 +64989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610112</BitOffs>
+            <BitOffs>673609792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -65002,7 +65002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610176</BitOffs>
+            <BitOffs>673609856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -65015,7 +65015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673610192</BitOffs>
+            <BitOffs>673609872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -65027,7 +65027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673627328</BitOffs>
+            <BitOffs>673627008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -65040,7 +65040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635264</BitOffs>
+            <BitOffs>673634944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -65053,7 +65053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635272</BitOffs>
+            <BitOffs>673634952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -65066,7 +65066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635280</BitOffs>
+            <BitOffs>673634960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -65089,7 +65089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635296</BitOffs>
+            <BitOffs>673634976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -65102,7 +65102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635328</BitOffs>
+            <BitOffs>673635008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -65115,7 +65115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635392</BitOffs>
+            <BitOffs>673635072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -65128,7 +65128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635408</BitOffs>
+            <BitOffs>673635088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -65140,7 +65140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673652544</BitOffs>
+            <BitOffs>673652224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -65153,7 +65153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660480</BitOffs>
+            <BitOffs>673660160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -65166,7 +65166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660488</BitOffs>
+            <BitOffs>673660168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -65179,7 +65179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660496</BitOffs>
+            <BitOffs>673660176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -65202,7 +65202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660512</BitOffs>
+            <BitOffs>673660192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -65215,7 +65215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660544</BitOffs>
+            <BitOffs>673660224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -65228,7 +65228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660608</BitOffs>
+            <BitOffs>673660288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -65241,7 +65241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660624</BitOffs>
+            <BitOffs>673660304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -65257,7 +65257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674043168</BitOffs>
+            <BitOffs>674042912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -65278,7 +65278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674046688</BitOffs>
+            <BitOffs>674046432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -65299,7 +65299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674046689</BitOffs>
+            <BitOffs>674046433</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -65311,7 +65311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684245120</BitOffs>
+            <BitOffs>684244864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -65324,7 +65324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253056</BitOffs>
+            <BitOffs>684252800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -65337,7 +65337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253064</BitOffs>
+            <BitOffs>684252808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -65350,7 +65350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253072</BitOffs>
+            <BitOffs>684252816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -65373,7 +65373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253088</BitOffs>
+            <BitOffs>684252832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -65386,7 +65386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253120</BitOffs>
+            <BitOffs>684252864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -65399,7 +65399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253184</BitOffs>
+            <BitOffs>684252928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -65412,7 +65412,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684253200</BitOffs>
+            <BitOffs>684252944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -65424,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684270336</BitOffs>
+            <BitOffs>684270080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -65437,7 +65437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278272</BitOffs>
+            <BitOffs>684278016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -65450,7 +65450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278280</BitOffs>
+            <BitOffs>684278024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -65463,7 +65463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278288</BitOffs>
+            <BitOffs>684278032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -65486,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278304</BitOffs>
+            <BitOffs>684278048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -65499,7 +65499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278336</BitOffs>
+            <BitOffs>684278080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -65512,7 +65512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278400</BitOffs>
+            <BitOffs>684278144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -65525,7 +65525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278416</BitOffs>
+            <BitOffs>684278160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -65537,7 +65537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684295552</BitOffs>
+            <BitOffs>684295296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -65550,7 +65550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303488</BitOffs>
+            <BitOffs>684303232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -65563,7 +65563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303496</BitOffs>
+            <BitOffs>684303240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -65576,7 +65576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303504</BitOffs>
+            <BitOffs>684303248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -65599,7 +65599,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303520</BitOffs>
+            <BitOffs>684303264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -65612,7 +65612,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303552</BitOffs>
+            <BitOffs>684303296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -65625,7 +65625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303616</BitOffs>
+            <BitOffs>684303360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -65638,7 +65638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303632</BitOffs>
+            <BitOffs>684303376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -65650,7 +65650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684320768</BitOffs>
+            <BitOffs>684320512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -65663,7 +65663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328704</BitOffs>
+            <BitOffs>684328448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -65676,7 +65676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328712</BitOffs>
+            <BitOffs>684328456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -65689,7 +65689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328720</BitOffs>
+            <BitOffs>684328464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -65712,7 +65712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328736</BitOffs>
+            <BitOffs>684328480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -65725,7 +65725,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328768</BitOffs>
+            <BitOffs>684328512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -65738,7 +65738,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328832</BitOffs>
+            <BitOffs>684328576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -65751,7 +65751,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328848</BitOffs>
+            <BitOffs>684328592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -65763,7 +65763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684345984</BitOffs>
+            <BitOffs>684345728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -65776,7 +65776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353920</BitOffs>
+            <BitOffs>684353664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -65789,7 +65789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353928</BitOffs>
+            <BitOffs>684353672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -65802,7 +65802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353936</BitOffs>
+            <BitOffs>684353680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -65825,7 +65825,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353952</BitOffs>
+            <BitOffs>684353696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -65838,7 +65838,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353984</BitOffs>
+            <BitOffs>684353728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -65851,7 +65851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684354048</BitOffs>
+            <BitOffs>684353792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -65864,7 +65864,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684354064</BitOffs>
+            <BitOffs>684353808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -65876,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684371200</BitOffs>
+            <BitOffs>684370944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -65889,7 +65889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379136</BitOffs>
+            <BitOffs>684378880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -65902,7 +65902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379144</BitOffs>
+            <BitOffs>684378888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -65915,7 +65915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379152</BitOffs>
+            <BitOffs>684378896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -65938,7 +65938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379168</BitOffs>
+            <BitOffs>684378912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -65951,7 +65951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379200</BitOffs>
+            <BitOffs>684378944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -65964,7 +65964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379264</BitOffs>
+            <BitOffs>684379008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -65977,7 +65977,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379280</BitOffs>
+            <BitOffs>684379024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -65989,7 +65989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684396416</BitOffs>
+            <BitOffs>684396160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -66002,7 +66002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404352</BitOffs>
+            <BitOffs>684404096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -66015,7 +66015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404360</BitOffs>
+            <BitOffs>684404104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -66028,7 +66028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404368</BitOffs>
+            <BitOffs>684404112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -66051,7 +66051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404384</BitOffs>
+            <BitOffs>684404128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -66064,7 +66064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404416</BitOffs>
+            <BitOffs>684404160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -66077,7 +66077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404480</BitOffs>
+            <BitOffs>684404224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -66090,7 +66090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404496</BitOffs>
+            <BitOffs>684404240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -66102,7 +66102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684421632</BitOffs>
+            <BitOffs>684421376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -66115,7 +66115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429568</BitOffs>
+            <BitOffs>684429312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -66128,7 +66128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429576</BitOffs>
+            <BitOffs>684429320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -66141,7 +66141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429584</BitOffs>
+            <BitOffs>684429328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -66164,7 +66164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429600</BitOffs>
+            <BitOffs>684429344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -66177,7 +66177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429632</BitOffs>
+            <BitOffs>684429376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -66190,7 +66190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429696</BitOffs>
+            <BitOffs>684429440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -66203,7 +66203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429712</BitOffs>
+            <BitOffs>684429456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -66215,7 +66215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684446848</BitOffs>
+            <BitOffs>684446592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -66228,7 +66228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454784</BitOffs>
+            <BitOffs>684454528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -66241,7 +66241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454792</BitOffs>
+            <BitOffs>684454536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -66254,7 +66254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454800</BitOffs>
+            <BitOffs>684454544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -66277,7 +66277,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454816</BitOffs>
+            <BitOffs>684454560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -66290,7 +66290,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454848</BitOffs>
+            <BitOffs>684454592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -66303,7 +66303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454912</BitOffs>
+            <BitOffs>684454656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -66316,7 +66316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454928</BitOffs>
+            <BitOffs>684454672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -66328,7 +66328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684472064</BitOffs>
+            <BitOffs>684471808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -66341,7 +66341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480000</BitOffs>
+            <BitOffs>684479744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -66354,7 +66354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480008</BitOffs>
+            <BitOffs>684479752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -66367,7 +66367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480016</BitOffs>
+            <BitOffs>684479760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -66390,7 +66390,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480032</BitOffs>
+            <BitOffs>684479776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -66403,7 +66403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480064</BitOffs>
+            <BitOffs>684479808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -66416,7 +66416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480128</BitOffs>
+            <BitOffs>684479872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -66429,7 +66429,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684480144</BitOffs>
+            <BitOffs>684479888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -66441,7 +66441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684497280</BitOffs>
+            <BitOffs>684497024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -66454,7 +66454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505216</BitOffs>
+            <BitOffs>684504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -66467,7 +66467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505224</BitOffs>
+            <BitOffs>684504968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -66480,7 +66480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505232</BitOffs>
+            <BitOffs>684504976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -66503,7 +66503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505248</BitOffs>
+            <BitOffs>684504992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -66516,7 +66516,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505280</BitOffs>
+            <BitOffs>684505024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -66529,7 +66529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505344</BitOffs>
+            <BitOffs>684505088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -66542,7 +66542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505360</BitOffs>
+            <BitOffs>684505104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -66554,7 +66554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684522496</BitOffs>
+            <BitOffs>684522240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -66567,7 +66567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530432</BitOffs>
+            <BitOffs>684530176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -66580,7 +66580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530440</BitOffs>
+            <BitOffs>684530184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -66593,7 +66593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530448</BitOffs>
+            <BitOffs>684530192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -66616,7 +66616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530464</BitOffs>
+            <BitOffs>684530208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -66629,7 +66629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530496</BitOffs>
+            <BitOffs>684530240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -66642,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530560</BitOffs>
+            <BitOffs>684530304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -66655,7 +66655,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530576</BitOffs>
+            <BitOffs>684530320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -66667,7 +66667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684547712</BitOffs>
+            <BitOffs>684547456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -66680,7 +66680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555648</BitOffs>
+            <BitOffs>684555392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -66693,7 +66693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555656</BitOffs>
+            <BitOffs>684555400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -66706,7 +66706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555664</BitOffs>
+            <BitOffs>684555408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -66729,7 +66729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555680</BitOffs>
+            <BitOffs>684555424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -66742,7 +66742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555712</BitOffs>
+            <BitOffs>684555456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -66755,7 +66755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555776</BitOffs>
+            <BitOffs>684555520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -66768,7 +66768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555792</BitOffs>
+            <BitOffs>684555536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -66780,7 +66780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684572928</BitOffs>
+            <BitOffs>684572672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -66793,7 +66793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580864</BitOffs>
+            <BitOffs>684580608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -66806,7 +66806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580872</BitOffs>
+            <BitOffs>684580616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -66819,7 +66819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580880</BitOffs>
+            <BitOffs>684580624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -66842,7 +66842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580896</BitOffs>
+            <BitOffs>684580640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -66855,7 +66855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580928</BitOffs>
+            <BitOffs>684580672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -66868,7 +66868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580992</BitOffs>
+            <BitOffs>684580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -66881,7 +66881,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684581008</BitOffs>
+            <BitOffs>684580752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -66893,7 +66893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684598144</BitOffs>
+            <BitOffs>684597888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -66906,7 +66906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606080</BitOffs>
+            <BitOffs>684605824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -66919,7 +66919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606088</BitOffs>
+            <BitOffs>684605832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -66932,7 +66932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606096</BitOffs>
+            <BitOffs>684605840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -66955,7 +66955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606112</BitOffs>
+            <BitOffs>684605856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -66968,7 +66968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606144</BitOffs>
+            <BitOffs>684605888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -66981,7 +66981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606208</BitOffs>
+            <BitOffs>684605952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -66994,7 +66994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684606224</BitOffs>
+            <BitOffs>684605968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -67006,7 +67006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684623360</BitOffs>
+            <BitOffs>684623104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -67019,7 +67019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631296</BitOffs>
+            <BitOffs>684631040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -67032,7 +67032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631304</BitOffs>
+            <BitOffs>684631048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -67045,7 +67045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631312</BitOffs>
+            <BitOffs>684631056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -67068,7 +67068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631328</BitOffs>
+            <BitOffs>684631072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -67081,7 +67081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631360</BitOffs>
+            <BitOffs>684631104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -67094,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631424</BitOffs>
+            <BitOffs>684631168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -67107,7 +67107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631440</BitOffs>
+            <BitOffs>684631184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -67119,7 +67119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684648576</BitOffs>
+            <BitOffs>684648320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -67132,7 +67132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656512</BitOffs>
+            <BitOffs>684656256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -67145,7 +67145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656520</BitOffs>
+            <BitOffs>684656264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -67158,7 +67158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656528</BitOffs>
+            <BitOffs>684656272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -67181,7 +67181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656544</BitOffs>
+            <BitOffs>684656288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -67194,7 +67194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656576</BitOffs>
+            <BitOffs>684656320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -67207,7 +67207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656640</BitOffs>
+            <BitOffs>684656384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -67220,7 +67220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656656</BitOffs>
+            <BitOffs>684656400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -67232,7 +67232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684673792</BitOffs>
+            <BitOffs>684673536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -67245,7 +67245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681728</BitOffs>
+            <BitOffs>684681472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -67258,7 +67258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681736</BitOffs>
+            <BitOffs>684681480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -67271,7 +67271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681744</BitOffs>
+            <BitOffs>684681488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -67294,7 +67294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681760</BitOffs>
+            <BitOffs>684681504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -67307,7 +67307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681792</BitOffs>
+            <BitOffs>684681536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -67320,7 +67320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681856</BitOffs>
+            <BitOffs>684681600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -67333,7 +67333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681872</BitOffs>
+            <BitOffs>684681616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -67345,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684699008</BitOffs>
+            <BitOffs>684698752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -67358,7 +67358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706944</BitOffs>
+            <BitOffs>684706688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -67371,7 +67371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706952</BitOffs>
+            <BitOffs>684706696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -67384,7 +67384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706960</BitOffs>
+            <BitOffs>684706704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -67407,7 +67407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706976</BitOffs>
+            <BitOffs>684706720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -67420,7 +67420,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684707008</BitOffs>
+            <BitOffs>684706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -67433,7 +67433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684707072</BitOffs>
+            <BitOffs>684706816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -67446,7 +67446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684707088</BitOffs>
+            <BitOffs>684706832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -67458,7 +67458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684724224</BitOffs>
+            <BitOffs>684723968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -67471,7 +67471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732160</BitOffs>
+            <BitOffs>684731904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -67484,7 +67484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732168</BitOffs>
+            <BitOffs>684731912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -67497,7 +67497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732176</BitOffs>
+            <BitOffs>684731920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -67520,7 +67520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732192</BitOffs>
+            <BitOffs>684731936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -67533,7 +67533,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732224</BitOffs>
+            <BitOffs>684731968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -67546,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732288</BitOffs>
+            <BitOffs>684732032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -67559,7 +67559,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732304</BitOffs>
+            <BitOffs>684732048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -67571,7 +67571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684749440</BitOffs>
+            <BitOffs>684749184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -67584,7 +67584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757376</BitOffs>
+            <BitOffs>684757120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -67597,7 +67597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757384</BitOffs>
+            <BitOffs>684757128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -67610,7 +67610,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757392</BitOffs>
+            <BitOffs>684757136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -67633,7 +67633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757408</BitOffs>
+            <BitOffs>684757152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -67646,7 +67646,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757440</BitOffs>
+            <BitOffs>684757184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -67659,7 +67659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757504</BitOffs>
+            <BitOffs>684757248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -67672,7 +67672,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757520</BitOffs>
+            <BitOffs>684757264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -67684,7 +67684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684774656</BitOffs>
+            <BitOffs>684774400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -67697,7 +67697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782592</BitOffs>
+            <BitOffs>684782336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -67710,7 +67710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782600</BitOffs>
+            <BitOffs>684782344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -67723,7 +67723,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782608</BitOffs>
+            <BitOffs>684782352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -67746,7 +67746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782624</BitOffs>
+            <BitOffs>684782368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -67759,7 +67759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782656</BitOffs>
+            <BitOffs>684782400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -67772,7 +67772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782720</BitOffs>
+            <BitOffs>684782464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -67785,7 +67785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782736</BitOffs>
+            <BitOffs>684782480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -67797,7 +67797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684799872</BitOffs>
+            <BitOffs>684799616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -67810,7 +67810,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807808</BitOffs>
+            <BitOffs>684807552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -67823,7 +67823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807816</BitOffs>
+            <BitOffs>684807560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -67836,7 +67836,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807824</BitOffs>
+            <BitOffs>684807568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -67859,7 +67859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807840</BitOffs>
+            <BitOffs>684807584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -67872,7 +67872,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807872</BitOffs>
+            <BitOffs>684807616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -67885,7 +67885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807936</BitOffs>
+            <BitOffs>684807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -67898,7 +67898,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807952</BitOffs>
+            <BitOffs>684807696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -67910,7 +67910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684825088</BitOffs>
+            <BitOffs>684824832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -67923,7 +67923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833024</BitOffs>
+            <BitOffs>684832768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -67936,7 +67936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833032</BitOffs>
+            <BitOffs>684832776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -67949,7 +67949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833040</BitOffs>
+            <BitOffs>684832784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -67972,7 +67972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833056</BitOffs>
+            <BitOffs>684832800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -67985,7 +67985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833088</BitOffs>
+            <BitOffs>684832832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -67998,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833152</BitOffs>
+            <BitOffs>684832896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -68011,7 +68011,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684833168</BitOffs>
+            <BitOffs>684832912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -68023,7 +68023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684850304</BitOffs>
+            <BitOffs>684850048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -68036,7 +68036,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858240</BitOffs>
+            <BitOffs>684857984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -68049,7 +68049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858248</BitOffs>
+            <BitOffs>684857992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -68062,7 +68062,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858256</BitOffs>
+            <BitOffs>684858000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -68085,7 +68085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858272</BitOffs>
+            <BitOffs>684858016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -68098,7 +68098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858304</BitOffs>
+            <BitOffs>684858048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -68111,7 +68111,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858368</BitOffs>
+            <BitOffs>684858112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -68124,7 +68124,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858384</BitOffs>
+            <BitOffs>684858128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -68136,7 +68136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684875520</BitOffs>
+            <BitOffs>684875264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -68149,7 +68149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883456</BitOffs>
+            <BitOffs>684883200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -68162,7 +68162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883464</BitOffs>
+            <BitOffs>684883208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -68175,7 +68175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883472</BitOffs>
+            <BitOffs>684883216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -68198,7 +68198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883488</BitOffs>
+            <BitOffs>684883232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -68211,7 +68211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883520</BitOffs>
+            <BitOffs>684883264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -68224,7 +68224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883584</BitOffs>
+            <BitOffs>684883328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -68237,7 +68237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883600</BitOffs>
+            <BitOffs>684883344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -68249,7 +68249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684900736</BitOffs>
+            <BitOffs>684900480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -68262,7 +68262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908672</BitOffs>
+            <BitOffs>684908416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -68275,7 +68275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908680</BitOffs>
+            <BitOffs>684908424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -68288,7 +68288,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908688</BitOffs>
+            <BitOffs>684908432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -68311,7 +68311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908704</BitOffs>
+            <BitOffs>684908448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -68324,7 +68324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908736</BitOffs>
+            <BitOffs>684908480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -68337,7 +68337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908800</BitOffs>
+            <BitOffs>684908544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -68350,7 +68350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908816</BitOffs>
+            <BitOffs>684908560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -68362,7 +68362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684925952</BitOffs>
+            <BitOffs>684925696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -68375,7 +68375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933888</BitOffs>
+            <BitOffs>684933632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -68388,7 +68388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933896</BitOffs>
+            <BitOffs>684933640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -68401,7 +68401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933904</BitOffs>
+            <BitOffs>684933648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -68424,7 +68424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933920</BitOffs>
+            <BitOffs>684933664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -68437,7 +68437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933952</BitOffs>
+            <BitOffs>684933696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -68450,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684934016</BitOffs>
+            <BitOffs>684933760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -68463,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684934032</BitOffs>
+            <BitOffs>684933776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -68475,7 +68475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684951168</BitOffs>
+            <BitOffs>684950912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -68488,7 +68488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959104</BitOffs>
+            <BitOffs>684958848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -68501,7 +68501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959112</BitOffs>
+            <BitOffs>684958856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -68514,7 +68514,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959120</BitOffs>
+            <BitOffs>684958864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -68537,7 +68537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959136</BitOffs>
+            <BitOffs>684958880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -68550,7 +68550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959168</BitOffs>
+            <BitOffs>684958912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -68563,7 +68563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959232</BitOffs>
+            <BitOffs>684958976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -68576,7 +68576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684959248</BitOffs>
+            <BitOffs>684958992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -68588,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684976384</BitOffs>
+            <BitOffs>684976128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -68601,7 +68601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984320</BitOffs>
+            <BitOffs>684984064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -68614,7 +68614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984328</BitOffs>
+            <BitOffs>684984072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -68627,7 +68627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984336</BitOffs>
+            <BitOffs>684984080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -68650,7 +68650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984352</BitOffs>
+            <BitOffs>684984096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -68663,7 +68663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984384</BitOffs>
+            <BitOffs>684984128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -68676,7 +68676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984448</BitOffs>
+            <BitOffs>684984192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -68689,7 +68689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984464</BitOffs>
+            <BitOffs>684984208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -68701,7 +68701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685001600</BitOffs>
+            <BitOffs>685001344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -68714,7 +68714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009536</BitOffs>
+            <BitOffs>685009280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -68727,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009544</BitOffs>
+            <BitOffs>685009288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -68740,7 +68740,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009552</BitOffs>
+            <BitOffs>685009296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -68763,7 +68763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009568</BitOffs>
+            <BitOffs>685009312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -68776,7 +68776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009600</BitOffs>
+            <BitOffs>685009344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -68789,7 +68789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009664</BitOffs>
+            <BitOffs>685009408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -68802,7 +68802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009680</BitOffs>
+            <BitOffs>685009424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -68814,7 +68814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685026816</BitOffs>
+            <BitOffs>685026560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -68827,7 +68827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034752</BitOffs>
+            <BitOffs>685034496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -68840,7 +68840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034760</BitOffs>
+            <BitOffs>685034504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -68853,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034768</BitOffs>
+            <BitOffs>685034512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -68876,7 +68876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034784</BitOffs>
+            <BitOffs>685034528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -68889,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034816</BitOffs>
+            <BitOffs>685034560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -68902,7 +68902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034880</BitOffs>
+            <BitOffs>685034624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -68915,7 +68915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034896</BitOffs>
+            <BitOffs>685034640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -68927,7 +68927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685052032</BitOffs>
+            <BitOffs>685051776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -68940,7 +68940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059968</BitOffs>
+            <BitOffs>685059712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -68953,7 +68953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059976</BitOffs>
+            <BitOffs>685059720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -68966,7 +68966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059984</BitOffs>
+            <BitOffs>685059728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -68989,7 +68989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685060000</BitOffs>
+            <BitOffs>685059744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -69002,7 +69002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685060032</BitOffs>
+            <BitOffs>685059776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -69015,7 +69015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685060096</BitOffs>
+            <BitOffs>685059840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -69028,7 +69028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685060112</BitOffs>
+            <BitOffs>685059856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -69040,7 +69040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685077248</BitOffs>
+            <BitOffs>685076992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -69053,7 +69053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085184</BitOffs>
+            <BitOffs>685084928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -69066,7 +69066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085192</BitOffs>
+            <BitOffs>685084936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -69079,7 +69079,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085200</BitOffs>
+            <BitOffs>685084944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -69102,7 +69102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085216</BitOffs>
+            <BitOffs>685084960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -69115,7 +69115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085248</BitOffs>
+            <BitOffs>685084992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -69128,7 +69128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085312</BitOffs>
+            <BitOffs>685085056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -69141,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085328</BitOffs>
+            <BitOffs>685085072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -69153,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685102464</BitOffs>
+            <BitOffs>685102208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -69166,7 +69166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110400</BitOffs>
+            <BitOffs>685110144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -69179,7 +69179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110408</BitOffs>
+            <BitOffs>685110152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -69192,7 +69192,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110416</BitOffs>
+            <BitOffs>685110160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -69215,7 +69215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110432</BitOffs>
+            <BitOffs>685110176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -69228,7 +69228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110464</BitOffs>
+            <BitOffs>685110208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -69241,7 +69241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110528</BitOffs>
+            <BitOffs>685110272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -69254,7 +69254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110544</BitOffs>
+            <BitOffs>685110288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -69266,7 +69266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685127680</BitOffs>
+            <BitOffs>685127424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -69279,7 +69279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135616</BitOffs>
+            <BitOffs>685135360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -69292,7 +69292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135624</BitOffs>
+            <BitOffs>685135368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -69305,7 +69305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135632</BitOffs>
+            <BitOffs>685135376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -69328,7 +69328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135648</BitOffs>
+            <BitOffs>685135392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -69341,7 +69341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135680</BitOffs>
+            <BitOffs>685135424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -69354,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135744</BitOffs>
+            <BitOffs>685135488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -69367,7 +69367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135760</BitOffs>
+            <BitOffs>685135504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -69379,7 +69379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685152896</BitOffs>
+            <BitOffs>685152640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -69392,7 +69392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160832</BitOffs>
+            <BitOffs>685160576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -69405,7 +69405,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160840</BitOffs>
+            <BitOffs>685160584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -69418,7 +69418,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160848</BitOffs>
+            <BitOffs>685160592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -69441,7 +69441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160864</BitOffs>
+            <BitOffs>685160608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -69454,7 +69454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160896</BitOffs>
+            <BitOffs>685160640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -69467,7 +69467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160960</BitOffs>
+            <BitOffs>685160704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -69480,7 +69480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160976</BitOffs>
+            <BitOffs>685160720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -69492,7 +69492,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685178112</BitOffs>
+            <BitOffs>685177856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -69505,7 +69505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186048</BitOffs>
+            <BitOffs>685185792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -69518,7 +69518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186056</BitOffs>
+            <BitOffs>685185800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -69531,7 +69531,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186064</BitOffs>
+            <BitOffs>685185808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -69554,7 +69554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186080</BitOffs>
+            <BitOffs>685185824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -69567,7 +69567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186112</BitOffs>
+            <BitOffs>685185856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -69580,7 +69580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186176</BitOffs>
+            <BitOffs>685185920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -69593,7 +69593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685186192</BitOffs>
+            <BitOffs>685185936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -69605,7 +69605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685203328</BitOffs>
+            <BitOffs>685203072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -69618,7 +69618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211264</BitOffs>
+            <BitOffs>685211008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -69631,7 +69631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211272</BitOffs>
+            <BitOffs>685211016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -69644,7 +69644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211280</BitOffs>
+            <BitOffs>685211024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -69667,7 +69667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211296</BitOffs>
+            <BitOffs>685211040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -69680,7 +69680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211328</BitOffs>
+            <BitOffs>685211072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -69693,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211392</BitOffs>
+            <BitOffs>685211136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -69706,7 +69706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211408</BitOffs>
+            <BitOffs>685211152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -69718,7 +69718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685228544</BitOffs>
+            <BitOffs>685228288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -69731,7 +69731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236480</BitOffs>
+            <BitOffs>685236224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -69744,7 +69744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236488</BitOffs>
+            <BitOffs>685236232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -69757,7 +69757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236496</BitOffs>
+            <BitOffs>685236240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -69780,7 +69780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236512</BitOffs>
+            <BitOffs>685236256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -69793,7 +69793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236544</BitOffs>
+            <BitOffs>685236288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -69806,7 +69806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236608</BitOffs>
+            <BitOffs>685236352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -69819,7 +69819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236624</BitOffs>
+            <BitOffs>685236368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -69831,7 +69831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685253760</BitOffs>
+            <BitOffs>685253504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -69844,7 +69844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261696</BitOffs>
+            <BitOffs>685261440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -69857,7 +69857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261704</BitOffs>
+            <BitOffs>685261448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -69870,7 +69870,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261712</BitOffs>
+            <BitOffs>685261456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -69893,7 +69893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261728</BitOffs>
+            <BitOffs>685261472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -69906,7 +69906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261760</BitOffs>
+            <BitOffs>685261504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -69919,7 +69919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261824</BitOffs>
+            <BitOffs>685261568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -69932,7 +69932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261840</BitOffs>
+            <BitOffs>685261584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -69944,7 +69944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685278976</BitOffs>
+            <BitOffs>685278720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -69957,7 +69957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286912</BitOffs>
+            <BitOffs>685286656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -69970,7 +69970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286920</BitOffs>
+            <BitOffs>685286664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -69983,7 +69983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286928</BitOffs>
+            <BitOffs>685286672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -70006,7 +70006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286944</BitOffs>
+            <BitOffs>685286688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -70019,7 +70019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286976</BitOffs>
+            <BitOffs>685286720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -70032,7 +70032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685287040</BitOffs>
+            <BitOffs>685286784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -70045,7 +70045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685287056</BitOffs>
+            <BitOffs>685286800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -70057,7 +70057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685304192</BitOffs>
+            <BitOffs>685303936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -70070,7 +70070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312128</BitOffs>
+            <BitOffs>685311872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -70083,7 +70083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312136</BitOffs>
+            <BitOffs>685311880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -70096,7 +70096,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312144</BitOffs>
+            <BitOffs>685311888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -70119,7 +70119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312160</BitOffs>
+            <BitOffs>685311904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -70132,7 +70132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312192</BitOffs>
+            <BitOffs>685311936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -70145,7 +70145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312256</BitOffs>
+            <BitOffs>685312000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -70158,7 +70158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312272</BitOffs>
+            <BitOffs>685312016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -70170,7 +70170,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685329408</BitOffs>
+            <BitOffs>685329152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -70183,7 +70183,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337344</BitOffs>
+            <BitOffs>685337088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -70196,7 +70196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337352</BitOffs>
+            <BitOffs>685337096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -70209,7 +70209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337360</BitOffs>
+            <BitOffs>685337104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -70232,7 +70232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337376</BitOffs>
+            <BitOffs>685337120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -70245,7 +70245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337408</BitOffs>
+            <BitOffs>685337152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -70258,7 +70258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337472</BitOffs>
+            <BitOffs>685337216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -70271,7 +70271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337488</BitOffs>
+            <BitOffs>685337232</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -70289,7 +70289,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640356928</BitOffs>
+            <BitOffs>640356672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70301,7 +70301,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641920960</BitOffs>
+            <BitOffs>641920704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70314,7 +70314,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641929944</BitOffs>
+            <BitOffs>641929688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70326,7 +70326,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641946176</BitOffs>
+            <BitOffs>641945920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70339,7 +70339,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641955160</BitOffs>
+            <BitOffs>641954904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70351,7 +70351,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641971392</BitOffs>
+            <BitOffs>641971136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70364,7 +70364,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641980376</BitOffs>
+            <BitOffs>641980120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -70376,7 +70376,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642270464</BitOffs>
+            <BitOffs>642270208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -70388,7 +70388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642270480</BitOffs>
+            <BitOffs>642270224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -70401,7 +70401,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642271424</BitOffs>
+            <BitOffs>642271168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70413,7 +70413,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642292864</BitOffs>
+            <BitOffs>642292608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70425,7 +70425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643856896</BitOffs>
+            <BitOffs>643856640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70438,7 +70438,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643865880</BitOffs>
+            <BitOffs>643865624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70450,7 +70450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643882112</BitOffs>
+            <BitOffs>643881856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70463,7 +70463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643891096</BitOffs>
+            <BitOffs>643890840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70475,7 +70475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643907328</BitOffs>
+            <BitOffs>643907072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70488,7 +70488,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643916312</BitOffs>
+            <BitOffs>643916056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -70500,7 +70500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644784928</BitOffs>
+            <BitOffs>644784672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -70520,7 +70520,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644784944</BitOffs>
+            <BitOffs>644784688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70533,7 +70533,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644785920</BitOffs>
+            <BitOffs>644785664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70545,7 +70545,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644807168</BitOffs>
+            <BitOffs>644806912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70557,7 +70557,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646371200</BitOffs>
+            <BitOffs>646370944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70570,7 +70570,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646380184</BitOffs>
+            <BitOffs>646379928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70582,7 +70582,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646396416</BitOffs>
+            <BitOffs>646396160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70595,7 +70595,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646405400</BitOffs>
+            <BitOffs>646405144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70607,7 +70607,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646421632</BitOffs>
+            <BitOffs>646421376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70620,7 +70620,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646430616</BitOffs>
+            <BitOffs>646430360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -70632,7 +70632,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647299232</BitOffs>
+            <BitOffs>647298976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -70652,7 +70652,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647299248</BitOffs>
+            <BitOffs>647298992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70665,7 +70665,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647300224</BitOffs>
+            <BitOffs>647299968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70677,7 +70677,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647321472</BitOffs>
+            <BitOffs>647321216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70689,7 +70689,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648885504</BitOffs>
+            <BitOffs>648885248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70702,7 +70702,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648894488</BitOffs>
+            <BitOffs>648894232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70714,7 +70714,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648910720</BitOffs>
+            <BitOffs>648910464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70727,7 +70727,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648919704</BitOffs>
+            <BitOffs>648919448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70739,7 +70739,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648935936</BitOffs>
+            <BitOffs>648935680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70752,7 +70752,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648944920</BitOffs>
+            <BitOffs>648944664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -70764,7 +70764,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649813536</BitOffs>
+            <BitOffs>649813280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -70784,7 +70784,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649813552</BitOffs>
+            <BitOffs>649813296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70797,7 +70797,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649814528</BitOffs>
+            <BitOffs>649814272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70809,7 +70809,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649835776</BitOffs>
+            <BitOffs>649835520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70821,7 +70821,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651399808</BitOffs>
+            <BitOffs>651399552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70834,7 +70834,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651408792</BitOffs>
+            <BitOffs>651408536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70846,7 +70846,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651425024</BitOffs>
+            <BitOffs>651424768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70859,7 +70859,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651434008</BitOffs>
+            <BitOffs>651433752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -70871,7 +70871,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651450240</BitOffs>
+            <BitOffs>651449984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -70884,7 +70884,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651459224</BitOffs>
+            <BitOffs>651458968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -70896,7 +70896,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652327840</BitOffs>
+            <BitOffs>652327584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -70916,7 +70916,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652327856</BitOffs>
+            <BitOffs>652327600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -70929,7 +70929,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652328832</BitOffs>
+            <BitOffs>652328576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -70941,7 +70941,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652350080</BitOffs>
+            <BitOffs>652349824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -70953,7 +70953,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653914112</BitOffs>
+            <BitOffs>653913856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -70966,7 +70966,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653923096</BitOffs>
+            <BitOffs>653922840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -70978,7 +70978,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653939328</BitOffs>
+            <BitOffs>653939072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -70991,7 +70991,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653948312</BitOffs>
+            <BitOffs>653948056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71003,7 +71003,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653964544</BitOffs>
+            <BitOffs>653964288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71016,7 +71016,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653973528</BitOffs>
+            <BitOffs>653973272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -71028,7 +71028,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654842144</BitOffs>
+            <BitOffs>654841888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -71048,7 +71048,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654842160</BitOffs>
+            <BitOffs>654841904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -71061,7 +71061,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654843136</BitOffs>
+            <BitOffs>654842880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71073,7 +71073,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654864512</BitOffs>
+            <BitOffs>654864256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71085,7 +71085,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656428544</BitOffs>
+            <BitOffs>656428288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71098,7 +71098,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656437528</BitOffs>
+            <BitOffs>656437272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71110,7 +71110,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656453760</BitOffs>
+            <BitOffs>656453504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71123,7 +71123,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656462744</BitOffs>
+            <BitOffs>656462488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71135,7 +71135,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656478976</BitOffs>
+            <BitOffs>656478720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71148,7 +71148,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656487960</BitOffs>
+            <BitOffs>656487704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71160,7 +71160,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656807680</BitOffs>
+            <BitOffs>656807424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71172,7 +71172,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657105600</BitOffs>
+            <BitOffs>657105344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71184,7 +71184,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658669632</BitOffs>
+            <BitOffs>658669376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71197,7 +71197,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658678616</BitOffs>
+            <BitOffs>658678360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71209,7 +71209,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658694848</BitOffs>
+            <BitOffs>658694592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71222,7 +71222,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658703832</BitOffs>
+            <BitOffs>658703576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71234,7 +71234,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658720064</BitOffs>
+            <BitOffs>658719808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71247,7 +71247,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658729048</BitOffs>
+            <BitOffs>658728792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71259,7 +71259,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659048960</BitOffs>
+            <BitOffs>659048704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71271,7 +71271,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659346880</BitOffs>
+            <BitOffs>659346624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71283,7 +71283,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660910912</BitOffs>
+            <BitOffs>660910656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71296,7 +71296,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660919896</BitOffs>
+            <BitOffs>660919640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71308,7 +71308,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660936128</BitOffs>
+            <BitOffs>660935872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71321,7 +71321,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660945112</BitOffs>
+            <BitOffs>660944856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71333,7 +71333,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660961344</BitOffs>
+            <BitOffs>660961088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71346,7 +71346,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660970328</BitOffs>
+            <BitOffs>660970072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71358,7 +71358,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661265984</BitOffs>
+            <BitOffs>661265728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71370,7 +71370,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661563904</BitOffs>
+            <BitOffs>661563648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71382,7 +71382,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661861824</BitOffs>
+            <BitOffs>661861568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71394,7 +71394,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662159744</BitOffs>
+            <BitOffs>662159488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -71406,7 +71406,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662606368</BitOffs>
+            <BitOffs>662606112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71418,7 +71418,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662612608</BitOffs>
+            <BitOffs>662612352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71430,7 +71430,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662910528</BitOffs>
+            <BitOffs>662910272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71442,7 +71442,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663208448</BitOffs>
+            <BitOffs>663208192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71454,7 +71454,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663506368</BitOffs>
+            <BitOffs>663506112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -71466,7 +71466,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663952992</BitOffs>
+            <BitOffs>663952736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -71478,7 +71478,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664065648</BitOffs>
+            <BitOffs>664065328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -71490,7 +71490,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664065656</BitOffs>
+            <BitOffs>664065336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71502,7 +71502,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664099776</BitOffs>
+            <BitOffs>664099456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71514,7 +71514,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664397696</BitOffs>
+            <BitOffs>664397376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71526,7 +71526,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665415616</BitOffs>
+            <BitOffs>665415296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71538,7 +71538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665713536</BitOffs>
+            <BitOffs>665713216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71550,7 +71550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666700800</BitOffs>
+            <BitOffs>666700480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71562,7 +71562,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666998720</BitOffs>
+            <BitOffs>666998400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71574,7 +71574,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667296640</BitOffs>
+            <BitOffs>667296320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71586,7 +71586,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667594560</BitOffs>
+            <BitOffs>667594240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71598,7 +71598,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667892480</BitOffs>
+            <BitOffs>667892160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71610,7 +71610,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668190400</BitOffs>
+            <BitOffs>668190080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71622,7 +71622,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668488320</BitOffs>
+            <BitOffs>668488000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71634,7 +71634,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668786240</BitOffs>
+            <BitOffs>668785920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71646,7 +71646,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669084160</BitOffs>
+            <BitOffs>669083840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71658,7 +71658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669382080</BitOffs>
+            <BitOffs>669381760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71670,7 +71670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669680000</BitOffs>
+            <BitOffs>669679680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71682,7 +71682,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669977920</BitOffs>
+            <BitOffs>669977600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71694,7 +71694,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670275840</BitOffs>
+            <BitOffs>670275520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71706,7 +71706,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671839040</BitOffs>
+            <BitOffs>671838784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71719,7 +71719,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671848024</BitOffs>
+            <BitOffs>671847768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71731,7 +71731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671864256</BitOffs>
+            <BitOffs>671864000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71744,7 +71744,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671873240</BitOffs>
+            <BitOffs>671872984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71756,7 +71756,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671889472</BitOffs>
+            <BitOffs>671889216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71769,7 +71769,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671898456</BitOffs>
+            <BitOffs>671898200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71781,7 +71781,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673601088</BitOffs>
+            <BitOffs>673600768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71794,7 +71794,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673610072</BitOffs>
+            <BitOffs>673609752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71806,7 +71806,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673626304</BitOffs>
+            <BitOffs>673625984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71819,7 +71819,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673635288</BitOffs>
+            <BitOffs>673634968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71831,7 +71831,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673651520</BitOffs>
+            <BitOffs>673651200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71844,7 +71844,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673660504</BitOffs>
+            <BitOffs>673660184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -71863,7 +71863,26 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674042360</BitOffs>
+            <BitOffs>673840568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>674042080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -71879,7 +71898,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674044928</BitOffs>
+            <BitOffs>674044672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -71899,7 +71918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>680950408</BitOffs>
+            <BitOffs>680950152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -71919,26 +71938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>682597320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>684243968</BitOffs>
+            <BitOffs>682597064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -71950,7 +71950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684244096</BitOffs>
+            <BitOffs>684243840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -71963,7 +71963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684253080</BitOffs>
+            <BitOffs>684252824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -71975,7 +71975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684269312</BitOffs>
+            <BitOffs>684269056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -71988,7 +71988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684278296</BitOffs>
+            <BitOffs>684278040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -72000,7 +72000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684294528</BitOffs>
+            <BitOffs>684294272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -72013,7 +72013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684303512</BitOffs>
+            <BitOffs>684303256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -72025,7 +72025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684319744</BitOffs>
+            <BitOffs>684319488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -72038,7 +72038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684328728</BitOffs>
+            <BitOffs>684328472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -72050,7 +72050,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684344960</BitOffs>
+            <BitOffs>684344704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -72063,7 +72063,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684353944</BitOffs>
+            <BitOffs>684353688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -72075,7 +72075,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684370176</BitOffs>
+            <BitOffs>684369920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -72088,7 +72088,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684379160</BitOffs>
+            <BitOffs>684378904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -72100,7 +72100,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684395392</BitOffs>
+            <BitOffs>684395136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -72113,7 +72113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684404376</BitOffs>
+            <BitOffs>684404120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -72125,7 +72125,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684420608</BitOffs>
+            <BitOffs>684420352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -72138,7 +72138,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684429592</BitOffs>
+            <BitOffs>684429336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -72150,7 +72150,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684445824</BitOffs>
+            <BitOffs>684445568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -72163,7 +72163,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684454808</BitOffs>
+            <BitOffs>684454552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -72175,7 +72175,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684471040</BitOffs>
+            <BitOffs>684470784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -72188,7 +72188,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684480024</BitOffs>
+            <BitOffs>684479768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -72200,7 +72200,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684496256</BitOffs>
+            <BitOffs>684496000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -72213,7 +72213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684505240</BitOffs>
+            <BitOffs>684504984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -72225,7 +72225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684521472</BitOffs>
+            <BitOffs>684521216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -72238,7 +72238,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684530456</BitOffs>
+            <BitOffs>684530200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -72250,7 +72250,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684546688</BitOffs>
+            <BitOffs>684546432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -72263,7 +72263,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684555672</BitOffs>
+            <BitOffs>684555416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -72275,7 +72275,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684571904</BitOffs>
+            <BitOffs>684571648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -72288,7 +72288,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684580888</BitOffs>
+            <BitOffs>684580632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -72300,7 +72300,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684597120</BitOffs>
+            <BitOffs>684596864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -72313,7 +72313,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684606104</BitOffs>
+            <BitOffs>684605848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -72325,7 +72325,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684622336</BitOffs>
+            <BitOffs>684622080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -72338,7 +72338,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684631320</BitOffs>
+            <BitOffs>684631064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -72350,7 +72350,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684647552</BitOffs>
+            <BitOffs>684647296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -72363,7 +72363,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684656536</BitOffs>
+            <BitOffs>684656280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -72375,7 +72375,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684672768</BitOffs>
+            <BitOffs>684672512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -72388,7 +72388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684681752</BitOffs>
+            <BitOffs>684681496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -72400,7 +72400,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684697984</BitOffs>
+            <BitOffs>684697728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -72413,7 +72413,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684706968</BitOffs>
+            <BitOffs>684706712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -72425,7 +72425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684723200</BitOffs>
+            <BitOffs>684722944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -72438,7 +72438,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684732184</BitOffs>
+            <BitOffs>684731928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -72450,7 +72450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684748416</BitOffs>
+            <BitOffs>684748160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -72463,7 +72463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684757400</BitOffs>
+            <BitOffs>684757144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -72475,7 +72475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684773632</BitOffs>
+            <BitOffs>684773376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -72488,7 +72488,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684782616</BitOffs>
+            <BitOffs>684782360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -72500,7 +72500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684798848</BitOffs>
+            <BitOffs>684798592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -72513,7 +72513,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684807832</BitOffs>
+            <BitOffs>684807576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -72525,7 +72525,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684824064</BitOffs>
+            <BitOffs>684823808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -72538,7 +72538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684833048</BitOffs>
+            <BitOffs>684832792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -72550,7 +72550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684849280</BitOffs>
+            <BitOffs>684849024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -72563,7 +72563,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684858264</BitOffs>
+            <BitOffs>684858008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -72575,7 +72575,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684874496</BitOffs>
+            <BitOffs>684874240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -72588,7 +72588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684883480</BitOffs>
+            <BitOffs>684883224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -72600,7 +72600,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684899712</BitOffs>
+            <BitOffs>684899456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -72613,7 +72613,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684908696</BitOffs>
+            <BitOffs>684908440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -72625,7 +72625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684924928</BitOffs>
+            <BitOffs>684924672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -72638,7 +72638,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684933912</BitOffs>
+            <BitOffs>684933656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -72650,7 +72650,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684950144</BitOffs>
+            <BitOffs>684949888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -72663,7 +72663,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684959128</BitOffs>
+            <BitOffs>684958872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -72675,7 +72675,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684975360</BitOffs>
+            <BitOffs>684975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -72688,7 +72688,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684984344</BitOffs>
+            <BitOffs>684984088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -72700,7 +72700,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685000576</BitOffs>
+            <BitOffs>685000320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -72713,7 +72713,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685009560</BitOffs>
+            <BitOffs>685009304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -72725,7 +72725,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685025792</BitOffs>
+            <BitOffs>685025536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -72738,7 +72738,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685034776</BitOffs>
+            <BitOffs>685034520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -72750,7 +72750,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685051008</BitOffs>
+            <BitOffs>685050752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -72763,7 +72763,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685059992</BitOffs>
+            <BitOffs>685059736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -72775,7 +72775,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685076224</BitOffs>
+            <BitOffs>685075968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -72788,7 +72788,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685085208</BitOffs>
+            <BitOffs>685084952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -72800,7 +72800,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685101440</BitOffs>
+            <BitOffs>685101184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -72813,7 +72813,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685110424</BitOffs>
+            <BitOffs>685110168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -72825,7 +72825,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685126656</BitOffs>
+            <BitOffs>685126400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -72838,7 +72838,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685135640</BitOffs>
+            <BitOffs>685135384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -72850,7 +72850,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685151872</BitOffs>
+            <BitOffs>685151616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -72863,7 +72863,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685160856</BitOffs>
+            <BitOffs>685160600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -72875,7 +72875,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685177088</BitOffs>
+            <BitOffs>685176832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -72888,7 +72888,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685186072</BitOffs>
+            <BitOffs>685185816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -72900,7 +72900,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685202304</BitOffs>
+            <BitOffs>685202048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -72913,7 +72913,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685211288</BitOffs>
+            <BitOffs>685211032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -72925,7 +72925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685227520</BitOffs>
+            <BitOffs>685227264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -72938,7 +72938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685236504</BitOffs>
+            <BitOffs>685236248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -72950,7 +72950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685252736</BitOffs>
+            <BitOffs>685252480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -72963,7 +72963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685261720</BitOffs>
+            <BitOffs>685261464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -72975,7 +72975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685277952</BitOffs>
+            <BitOffs>685277696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -72988,7 +72988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685286936</BitOffs>
+            <BitOffs>685286680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -73000,7 +73000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685303168</BitOffs>
+            <BitOffs>685302912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -73013,7 +73013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685312152</BitOffs>
+            <BitOffs>685311896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -73025,7 +73025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685328384</BitOffs>
+            <BitOffs>685328128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -73038,7 +73038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685337368</BitOffs>
+            <BitOffs>685337112</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -78355,77 +78355,6 @@ Digital outputs</Comment>
             <BitOffs>8538368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_common_components</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8538656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.fbPmpsFileReader</Name>
-            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
-            <BitSize>928128</BitSize>
-            <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8538944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
-            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
-            <BitSize>27744</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)DB
-        io: io
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9467072</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>MOTION_GVL.nMaxStates</Name>
             <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
             <BitSize>16</BitSize>
@@ -78435,7 +78364,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494816</BitOffs>
+            <BitOffs>8538656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MotionConstants.MAX_STATE_MOTORS</Name>
@@ -78454,7 +78383,38 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494832</BitOffs>
+            <BitOffs>8538672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbPmpsFileReader</Name>
+            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
+            <BitSize>928128</BitSize>
+            <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8538688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
+            <BitSize>27744</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)DB
+        io: io
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9466816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -78474,7 +78434,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9494848</BitOffs>
+            <BitOffs>9494560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -78494,7 +78454,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9496608</BitOffs>
+            <BitOffs>9496320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -78519,7 +78479,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9498368</BitOffs>
+            <BitOffs>9498080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -78531,7 +78491,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499392</BitOffs>
+            <BitOffs>9499104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -78546,35 +78506,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9499456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>9499520</BitOffs>
+            <BitOffs>9499136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -78588,7 +78520,35 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499584</BitOffs>
+            <BitOffs>9499168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9499200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>9499264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -78603,7 +78563,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499616</BitOffs>
+            <BitOffs>9499328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
@@ -78618,7 +78578,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499648</BitOffs>
+            <BitOffs>9499360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -78632,7 +78592,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499664</BitOffs>
+            <BitOffs>9499376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stAttenuators</Name>
@@ -78653,7 +78613,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499680</BitOffs>
+            <BitOffs>9499392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cstFullBeam</Name>
@@ -78673,7 +78633,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9499744</BitOffs>
+            <BitOffs>9499456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cst0RateBeam</Name>
@@ -78693,7 +78653,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9501504</BitOffs>
+            <BitOffs>9501216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -78718,7 +78678,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503264</BitOffs>
+            <BitOffs>9502976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -78733,7 +78693,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503280</BitOffs>
+            <BitOffs>9502992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -78752,7 +78712,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9503296</BitOffs>
+            <BitOffs>9503008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_cBoundaries</Name>
@@ -78766,7 +78726,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504320</BitOffs>
+            <BitOffs>9504032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
@@ -78781,7 +78741,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504336</BitOffs>
+            <BitOffs>9504048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -78808,7 +78768,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504352</BitOffs>
+            <BitOffs>9504064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -78963,7 +78923,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9504384</BitOffs>
+            <BitOffs>9504096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -79118,7 +79078,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9505408</BitOffs>
+            <BitOffs>9505120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -79133,7 +79093,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506432</BitOffs>
+            <BitOffs>9506144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -79148,7 +79108,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506464</BitOffs>
+            <BitOffs>9506176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -79159,7 +79119,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506496</BitOffs>
+            <BitOffs>9506208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
@@ -79173,7 +79133,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506752</BitOffs>
+            <BitOffs>9506464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -79187,7 +79147,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506768</BitOffs>
+            <BitOffs>9506480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -79201,7 +79161,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506784</BitOffs>
+            <BitOffs>9506496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -79228,7 +79188,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506800</BitOffs>
+            <BitOffs>9506512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -79243,7 +79203,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506808</BitOffs>
+            <BitOffs>9506520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -79258,7 +79218,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506816</BitOffs>
+            <BitOffs>9506528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -79273,7 +79233,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9506848</BitOffs>
+            <BitOffs>9506560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -79291,7 +79251,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508896</BitOffs>
+            <BitOffs>9508608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -79303,7 +79263,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508912</BitOffs>
+            <BitOffs>9508624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -79315,7 +79275,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508920</BitOffs>
+            <BitOffs>9508632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -79331,7 +79291,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508928</BitOffs>
+            <BitOffs>9508640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
@@ -79342,7 +79302,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>9508960</BitOffs>
+            <BitOffs>9508672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -79354,7 +79314,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631336160</BitOffs>
+            <BitOffs>631335872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -79366,7 +79326,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631336192</BitOffs>
+            <BitOffs>631335904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -79380,7 +79340,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631338240</BitOffs>
+            <BitOffs>631337952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
@@ -79391,7 +79351,7 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>631338248</BitOffs>
+            <BitOffs>631337960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -79407,7 +79367,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631338256</BitOffs>
+            <BitOffs>631337968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -79422,7 +79382,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631338272</BitOffs>
+            <BitOffs>631337984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -79448,7 +79408,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631370272</BitOffs>
+            <BitOffs>631369984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -79460,7 +79420,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>631386272</BitOffs>
+            <BitOffs>631385984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -79496,7 +79456,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707136</BitOffs>
+            <BitOffs>639706848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -79532,7 +79492,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707424</BitOffs>
+            <BitOffs>639707136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -79543,7 +79503,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639707712</BitOffs>
+            <BitOffs>639707424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -79557,7 +79517,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714688</BitOffs>
+            <BitOffs>639714432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -79571,7 +79531,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714752</BitOffs>
+            <BitOffs>639714496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -79607,38 +79567,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639714816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Physics.fbScatteringFactors</Name>
-            <BitSize>575872</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>639715136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
-            <BitSize>1927552</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">FB_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: AL1K4:L2SI
-        io: io
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbLaser.iLaserINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 1^Analog output;
-                              .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640344128</BitOffs>
+            <BitOffs>639714560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
@@ -79658,7 +79587,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642272672</BitOffs>
+            <BitOffs>639714848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.bTest</Name>
@@ -79667,7 +79596,7 @@ Digital outputs</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>642272680</BitOffs>
+            <BitOffs>639714856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
@@ -79678,7 +79607,7 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>642272688</BitOffs>
+            <BitOffs>639714864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
@@ -79698,7 +79627,48 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>642272696</BitOffs>
+            <BitOffs>639714872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Physics.fbScatteringFactors</Name>
+            <BitSize>575872</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639714880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
+            <BitSize>1927552</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: AL1K4:L2SI
+        io: io
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbLaser.iLaserINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 1^Analog output;
+                              .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>640343872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>642272416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
@@ -79727,7 +79697,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw := TIIB[IM2K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>642272704</BitOffs>
+            <BitOffs>642272448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fStartupVelo</Name>
@@ -79736,7 +79706,7 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>644786944</BitOffs>
+            <BitOffs>644786688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
@@ -79766,7 +79736,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>644787008</BitOffs>
+            <BitOffs>644786752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fStartupVelo</Name>
@@ -79775,7 +79745,7 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>647301248</BitOffs>
+            <BitOffs>647300992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
@@ -79805,7 +79775,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>647301312</BitOffs>
+            <BitOffs>647301056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fStartupVelo</Name>
@@ -79814,7 +79784,7 @@ Digital outputs</Comment>
             <Default>
               <Value>15</Value>
             </Default>
-            <BitOffs>649815552</BitOffs>
+            <BitOffs>649815296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
@@ -79844,7 +79814,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649815616</BitOffs>
+            <BitOffs>649815360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fStartupVelo</Name>
@@ -79853,7 +79823,7 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>652329856</BitOffs>
+            <BitOffs>652329600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
@@ -79883,7 +79853,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>652329920</BitOffs>
+            <BitOffs>652329664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fStartupVelo</Name>
@@ -79892,7 +79862,7 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>654844160</BitOffs>
+            <BitOffs>654843904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
@@ -79907,13 +79877,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654844416</BitOffs>
+            <BitOffs>654844160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>656778112</BitOffs>
+            <BitOffs>656777856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
@@ -79939,23 +79909,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>656780224</BitOffs>
+            <BitOffs>656779968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>659019712</BitOffs>
+            <BitOffs>659019456</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>659021472</BitOffs>
+            <BitOffs>659021216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -79981,23 +79951,23 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>659021504</BitOffs>
+            <BitOffs>659021248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>661260992</BitOffs>
+            <BitOffs>661260736</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>661263392</BitOffs>
+            <BitOffs>661263136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -80012,7 +79982,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>661263424</BitOffs>
+            <BitOffs>661263168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -80023,17 +79993,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>662606592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>662609664</BitOffs>
+            <BitOffs>662606336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -80043,7 +80003,22 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>662609696</BitOffs>
+            <BitOffs>662609408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>662609760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>662609768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -80058,32 +80033,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662610048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>663953216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>663953224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>663953248</BitOffs>
+            <BitOffs>662609792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -80094,7 +80044,17 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663953280</BitOffs>
+            <BitOffs>663952960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>663956032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -80104,7 +80064,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956352</BitOffs>
+            <BitOffs>663956064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -80114,7 +80074,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956384</BitOffs>
+            <BitOffs>663956096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -80124,13 +80084,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL1HighCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>663956720</BitOffs>
+            <BitOffs>663956128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -80149,7 +80103,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663956736</BitOffs>
+            <BitOffs>663956416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -80171,13 +80125,13 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>664067584</BitOffs>
+            <BitOffs>664067264</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.nTL1LowCycles</Name>
+            <Name>PRG_SP1K4.nTL1HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>665390688</BitOffs>
+            <BitOffs>665390384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -80199,97 +80153,103 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>665390720</BitOffs>
+            <BitOffs>665390400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>666699328</BitOffs>
+            <BitOffs>666699008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>666997248</BitOffs>
+            <BitOffs>666996928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667295168</BitOffs>
+            <BitOffs>667294848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667593088</BitOffs>
+            <BitOffs>667592768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667891008</BitOffs>
+            <BitOffs>667890688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668188928</BitOffs>
+            <BitOffs>668188608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668486848</BitOffs>
+            <BitOffs>668486528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668784768</BitOffs>
+            <BitOffs>668784448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669082688</BitOffs>
+            <BitOffs>669082368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669380608</BitOffs>
+            <BitOffs>669380288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669678528</BitOffs>
+            <BitOffs>669678208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669976448</BitOffs>
+            <BitOffs>669976128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670274368</BitOffs>
+            <BitOffs>670274048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL1LowCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>670571968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>670572288</BitOffs>
+            <BitOffs>670572000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>670572304</BitOffs>
+            <BitOffs>670572016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -80298,7 +80258,7 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>670572320</BitOffs>
+            <BitOffs>670572032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -80307,29 +80267,14 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>670572336</BitOffs>
+            <BitOffs>670572048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>670572344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.fbZPStates</Name>
-            <Comment>/ZP states start</Comment>
-            <BitSize>1506432</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>670572352</BitOffs>
+            <BitOffs>670572056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -80344,7 +80289,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672078784</BitOffs>
+            <BitOffs>670572064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -80359,43 +80304,28 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672078800</BitOffs>
+            <BitOffs>670572080</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.att_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Name>PRG_SP1K4.fbZPStates</Name>
+            <Comment>/ZP states start</Comment>
+            <BitSize>1506432</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: SP1K4:ATT:STATE:SET
-        io: io
+        pv: SP1K4:FZP
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672078816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>672078832</BitOffs>
+            <BitOffs>670572096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>672078848</BitOffs>
+            <BitOffs>672078528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -80419,7 +80349,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>672166656</BitOffs>
+            <BitOffs>672166336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -80429,7 +80359,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672170304</BitOffs>
+            <BitOffs>672169984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -80439,7 +80369,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672225024</BitOffs>
+            <BitOffs>672224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -80449,7 +80379,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672279744</BitOffs>
+            <BitOffs>672279424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -80464,13 +80394,61 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672334464</BitOffs>
+            <BitOffs>672334144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673840512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673840528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>673840544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>673840552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>673840560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>673840832</BitOffs>
+            <BitOffs>673840576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -80494,7 +80472,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>673928640</BitOffs>
+            <BitOffs>673928384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -80504,7 +80482,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673932288</BitOffs>
+            <BitOffs>673932032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -80514,43 +80492,36 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673987008</BitOffs>
+            <BitOffs>673986752</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>674042336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>674042344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>674042352</BitOffs>
+            <Name>GVL_TcGVL.ePF1K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>674042096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>674042368</BitOffs>
+            <BitOffs>674042112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>674180736</BitOffs>
+            <BitOffs>674180480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>674211584</BitOffs>
+            <BitOffs>674211328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -80569,7 +80540,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680003200</BitOffs>
+            <BitOffs>680002944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -80588,7 +80559,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680476672</BitOffs>
+            <BitOffs>680476416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -80618,7 +80589,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680950144</BitOffs>
+            <BitOffs>680949888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -80648,18 +80619,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>682597056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcGVL.ePF1K4State</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>684243984</BitOffs>
+            <BitOffs>682596800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -80670,7 +80630,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684244000</BitOffs>
+            <BitOffs>684243712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -80685,7 +80645,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684244016</BitOffs>
+            <BitOffs>684243728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -80700,7 +80660,37 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684244024</BitOffs>
+            <BitOffs>684243736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -80729,7 +80719,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684244032</BitOffs>
+            <BitOffs>684243776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -80741,7 +80731,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684269248</BitOffs>
+            <BitOffs>684268992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -80752,7 +80742,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684294464</BitOffs>
+            <BitOffs>684294208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -80763,7 +80753,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684319680</BitOffs>
+            <BitOffs>684319424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -80774,7 +80764,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684344896</BitOffs>
+            <BitOffs>684344640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -80785,7 +80775,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684370112</BitOffs>
+            <BitOffs>684369856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -80796,7 +80786,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684395328</BitOffs>
+            <BitOffs>684395072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -80807,7 +80797,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684420544</BitOffs>
+            <BitOffs>684420288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -80836,7 +80826,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684445760</BitOffs>
+            <BitOffs>684445504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -80864,7 +80854,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684470976</BitOffs>
+            <BitOffs>684470720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -80891,7 +80881,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684496192</BitOffs>
+            <BitOffs>684495936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -80918,7 +80908,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684521408</BitOffs>
+            <BitOffs>684521152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -80945,7 +80935,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684546624</BitOffs>
+            <BitOffs>684546368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -80957,7 +80947,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684571840</BitOffs>
+            <BitOffs>684571584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -80986,7 +80976,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684597056</BitOffs>
+            <BitOffs>684596800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -81015,7 +81005,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684622272</BitOffs>
+            <BitOffs>684622016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -81044,7 +81034,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684647488</BitOffs>
+            <BitOffs>684647232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -81073,7 +81063,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684672704</BitOffs>
+            <BitOffs>684672448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -81098,7 +81088,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684697920</BitOffs>
+            <BitOffs>684697664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -81127,7 +81117,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684723136</BitOffs>
+            <BitOffs>684722880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -81156,7 +81146,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684748352</BitOffs>
+            <BitOffs>684748096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -81181,7 +81171,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684773568</BitOffs>
+            <BitOffs>684773312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -81209,7 +81199,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684798784</BitOffs>
+            <BitOffs>684798528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -81236,7 +81226,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684824000</BitOffs>
+            <BitOffs>684823744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -81263,7 +81253,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684849216</BitOffs>
+            <BitOffs>684848960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -81290,7 +81280,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684874432</BitOffs>
+            <BitOffs>684874176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -81319,7 +81309,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684899648</BitOffs>
+            <BitOffs>684899392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -81348,7 +81338,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684924864</BitOffs>
+            <BitOffs>684924608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -81373,7 +81363,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684950080</BitOffs>
+            <BitOffs>684949824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -81402,7 +81392,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684975296</BitOffs>
+            <BitOffs>684975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -81427,7 +81417,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685000512</BitOffs>
+            <BitOffs>685000256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -81464,7 +81454,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685025728</BitOffs>
+            <BitOffs>685025472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -81496,8 +81486,8 @@ Digital outputs</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 2</Value>
+                <Value>.bLimitForwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[FoilX-EL7041]^STM Status^Status^Digital input 1</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -81509,7 +81499,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685050944</BitOffs>
+            <BitOffs>685050688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -81550,7 +81540,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685076160</BitOffs>
+            <BitOffs>685075904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -81591,7 +81581,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685101376</BitOffs>
+            <BitOffs>685101120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -81632,7 +81622,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685126592</BitOffs>
+            <BitOffs>685126336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -81673,7 +81663,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685151808</BitOffs>
+            <BitOffs>685151552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -81714,7 +81704,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685177024</BitOffs>
+            <BitOffs>685176768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -81755,7 +81745,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685202240</BitOffs>
+            <BitOffs>685201984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -81796,7 +81786,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685227456</BitOffs>
+            <BitOffs>685227200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -81832,7 +81822,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685252672</BitOffs>
+            <BitOffs>685252416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -81868,7 +81858,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685277888</BitOffs>
+            <BitOffs>685277632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -81904,7 +81894,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685303104</BitOffs>
+            <BitOffs>685302848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -81949,7 +81939,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685328320</BitOffs>
+            <BitOffs>685328064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -81979,7 +81969,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353536</BitOffs>
+            <BitOffs>685353280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -82009,37 +81999,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353680</BitOffs>
+            <BitOffs>685353344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -82053,7 +82013,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353696</BitOffs>
+            <BitOffs>685353408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -82067,7 +82027,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353728</BitOffs>
+            <BitOffs>685353440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -82081,7 +82041,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353760</BitOffs>
+            <BitOffs>685353472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82095,7 +82055,21 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353792</BitOffs>
+            <BitOffs>685353504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685355552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -82113,21 +82087,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685355840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685356864</BitOffs>
+            <BitOffs>685355584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -82141,7 +82101,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685356896</BitOffs>
+            <BitOffs>685356608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -82162,30 +82122,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685356928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685400256</BitOffs>
+            <BitOffs>685356640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -82254,7 +82191,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409280</BitOffs>
+            <BitOffs>685370016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -82323,7 +82260,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409408</BitOffs>
+            <BitOffs>685370144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -82392,7 +82329,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409536</BitOffs>
+            <BitOffs>685370272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -82461,7 +82398,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409664</BitOffs>
+            <BitOffs>685370400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -82530,7 +82467,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409792</BitOffs>
+            <BitOffs>685370528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -82599,7 +82536,30 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409920</BitOffs>
+            <BitOffs>685370656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685400992</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82661,9 +82621,6 @@ Digital outputs</Comment>
       <Deployment/>
       <EventClasses>
         <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
-        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -82678,6 +82635,9 @@ Digital outputs</Comment>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
+        <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -82686,7 +82646,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-30T10:51:14</Value>
+          <Value>2023-09-06T09:56:11</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{019B9B34-B5E0-94EB-1305-41F0A47AF844}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{92FA8D93-60CA-5735-A4C9-15F0C8DAF7B8}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84563784</GetCodeOffs>
+        <GetCodeOffs>85690500</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84563816</GetCodeOffs>
+        <GetCodeOffs>85690532</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563824</GetCodeOffs>
+        <GetCodeOffs>85690540</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563808</GetCodeOffs>
+        <GetCodeOffs>85690524</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563820</GetCodeOffs>
+        <GetCodeOffs>85690536</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563728</GetCodeOffs>
-        <SetCodeOffs>84563752</SetCodeOffs>
+        <GetCodeOffs>85690444</GetCodeOffs>
+        <SetCodeOffs>85690468</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563764</GetCodeOffs>
-        <SetCodeOffs>84563776</SetCodeOffs>
+        <GetCodeOffs>85690480</GetCodeOffs>
+        <SetCodeOffs>85690492</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>84563872</GetCodeOffs>
+        <GetCodeOffs>85690588</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563852</GetCodeOffs>
+        <GetCodeOffs>85690568</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84563940</GetCodeOffs>
+        <GetCodeOffs>85690656</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563900</GetCodeOffs>
+        <GetCodeOffs>85690616</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84563944</GetCodeOffs>
+        <GetCodeOffs>85690660</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84563968</GetCodeOffs>
+        <GetCodeOffs>85690684</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -17625,7 +17625,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Name>
       <BitSize>8</BitSize>
       <BaseType>BYTE</BaseType>
       <EnumInfo>
@@ -17804,7 +17804,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Name>
       <BitSize>6192</BitSize>
       <SubItem>
         <Name>TestName</Name>
@@ -17838,7 +17838,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>FailureType</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
         <BitSize>8</BitSize>
         <BitOffs>6160</BitOffs>
       </SubItem>
@@ -17850,7 +17850,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Name>
       <BitSize>621296</BitSize>
       <SubItem>
         <Name>Name</Name>
@@ -17880,7 +17880,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestCaseResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -17890,7 +17890,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Name>
       <BitSize>621296064</BitSize>
       <SubItem>
         <Name>NumberOfTestSuites</Name>
@@ -17922,7 +17922,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestSuiteResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -17933,7 +17933,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -17943,7 +17943,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestSuiteResults</Name>
-        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
     </DataType>
@@ -17963,13 +17963,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Name>
       <Comment> This function block holds results of the complete test run, i.e. results for all test suites </Comment>
       <BitSize>621296256</BitSize>
-      <Implements Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Implements>
+      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Implements>
       <SubItem>
         <Name>TestSuiteResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Type>
         <Comment> Test results </Comment>
         <BitSize>621296064</BitSize>
         <BitOffs>64</BitOffs>
@@ -18012,7 +18012,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestSuiteResults</Name>
-        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Properties>
@@ -18023,7 +18023,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -18046,17 +18046,17 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Name>
       <Comment>
     This function block reports the results from the tests using the built-in ADSLOGSTR functionality
     provided by the Tc2_System library. This sends the result using ADS, which is consumed by the "Error List"
     of Visual Studio (which can print Errors, Warnings and Messages).
 </Comment>
       <BitSize>224</BitSize>
-      <Implements Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
+      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
@@ -18090,7 +18090,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>TcUnitTestResults</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
@@ -18182,7 +18182,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BaseType PointerTo="1">BYTE</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Name>
       <Comment>
     This functionblock can open, close, read, write and delete files on the local filesystem
 </Comment>
@@ -18288,7 +18288,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Name>
       <BitSize>8</BitSize>
       <BaseType>BYTE</BaseType>
       <EnumInfo>
@@ -18309,7 +18309,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Name>
       <Comment>
     This functionblock acts as a stream buffer for use with FB_XmlControl
 </Comment>
@@ -18354,7 +18354,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Parameter>
           <Name>XmlError</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -18568,7 +18568,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Parameter>
           <Name>XmlError</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -18606,7 +18606,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Name>
       <Comment>
     Organizes parsing and composing of XML data. Data can be treated as STRING or char array.
     Buffer size of file can be set via GVL_Param_TcUnit (xUnitBufferSize)
@@ -18614,13 +18614,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>5696</BitSize>
       <SubItem>
         <Name>XmlBuffer</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>32</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TagListBuffer</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>160</BitOffs>
       </SubItem>
@@ -18632,7 +18632,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TagListSeekBuffer</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>2336</BitOffs>
       </SubItem>
@@ -18644,7 +18644,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TagBuffer</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>3136</BitOffs>
       </SubItem>
@@ -18880,15 +18880,15 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Name>
       <Comment>
     Publishes test results into an xUnit compatible Xml file
 </Comment>
       <BitSize>530304</BitSize>
-      <Implements Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
+      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
         <Comment> Dependancy Injection via FB_Init</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
@@ -18905,13 +18905,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>File</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Type>
         <BitSize>96</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Xml</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Type>
         <BitSize>5696</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
@@ -18955,7 +18955,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>UnitTestResults</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
@@ -18997,7 +18997,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</Name>
       <Comment>
     This function block is responsible for holding track of the tests and executing them.
 </Comment>
@@ -19014,14 +19014,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Type>
         <Comment> Test result information </Comment>
         <BitSize>621296256</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsTestResultLogger</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Type>
         <Comment> Prints the results to ADS so that Visual Studio can display the results.
        This test result formatter can be replaced with something else than ADS </Comment>
         <BitSize>224</BitSize>
@@ -19034,7 +19034,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestResultLogger</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
         <BitSize>32</BitSize>
         <BitOffs>621296544</BitOffs>
       </SubItem>
@@ -19048,7 +19048,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>xUnitXmlPublisher</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Type>
         <Comment> Publishes a xUnit compatible XML file </Comment>
         <BitSize>530304</BitSize>
         <BitOffs>621296608</BitOffs>
@@ -19060,7 +19060,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>XmlTestResultPublisher</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
         <BitSize>32</BitSize>
         <BitOffs>621826912</BitOffs>
       </SubItem>
@@ -19161,7 +19161,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_Test</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
 </Comment>
@@ -19216,14 +19216,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertionType</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
         <Comment> Assertion type for the first assertion in this test</Comment>
         <BitSize>8</BitSize>
         <BitOffs>4184</BitOffs>
       </SubItem>
       <Method>
         <Name>GetAssertionType</Name>
-        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</ReturnType>
+        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
@@ -19293,7 +19293,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetAssertionType</Name>
         <Parameter>
           <Name>AssertType</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
           <BitSize>8</BitSize>
         </Parameter>
       </Method>
@@ -19335,7 +19335,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Name>
       <BitSize>4096</BitSize>
       <SubItem>
         <Name>boolExpectedOrActual</Name>
@@ -19477,17 +19477,17 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Name>
       <BitSize>12288</BitSize>
       <SubItem>
         <Name>Expected</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>4096</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Actual</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>4096</BitSize>
         <BitOffs>4096</BitOffs>
       </SubItem>
@@ -19505,11 +19505,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Name>
       <BitSize>12352</BitSize>
       <SubItem>
         <Name>AssertResult</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
         <BitSize>12288</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -19529,7 +19529,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which asserts that have been made. The reason we need to
     keep track of these is because if the user does the same assert twice (because of running a test suite over several
@@ -19543,7 +19543,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>24640320</BitSize>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19571,7 +19571,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertResultInstances</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19920,7 +19920,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Name>
       <BitSize>4224</BitSize>
       <SubItem>
         <Name>ExpectedsSize</Name>
@@ -19964,11 +19964,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
       <BitSize>4256</BitSize>
       <SubItem>
         <Name>AssertArrayResult</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
         <BitSize>4224</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -19988,7 +19988,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which array-asserts that have been made.
     The reason we need to keep track of these is because if the user does the same assert twice
@@ -20004,7 +20004,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>8480256</BitSize>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -20032,7 +20032,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertArrayResultInstances</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -20331,7 +20331,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -20359,7 +20359,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
       <Comment>
     This function block is responsible for making sure that the asserted test instance path and test message are not
     loo long. The total printed message can not be more than 253 characters long.
@@ -20457,14 +20457,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Name>
       <Comment>
     This function block is responsible for printing the results of the assertions using the built-in
     ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
     is consumed by the error list of Visual Studio.
 </Comment>
       <BitSize>64</BitSize>
-      <Implements Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Implements>
+      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Implements>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -20489,7 +20489,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Local>
           <Name>AdjustAssertFailureMessageToMax253CharLength</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
           <BitSize>11584</BitSize>
         </Local>
         <Local>
@@ -20526,7 +20526,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</Name>
       <Comment> This function block is responsible for holding the internal state of the test suite.
    Every test suite can have one or more tests, and every test can do one or more asserts.
    It's also responsible for providing all the assert-methods for asserting different data types.
@@ -20568,7 +20568,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>Tests</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_Test</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -20602,19 +20602,19 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Type>
         <BitSize>24640320</BitSize>
         <BitOffs>431040</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
         <BitSize>8480256</BitSize>
         <BitOffs>25071360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsAssertMessageFormatter</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Type>
         <Comment> Prints the failed asserts to ADS so that Visual Studio can display the assert message.
        This assert formatter can be replaced with something else than ADS </Comment>
         <BitSize>64</BitSize>
@@ -20622,7 +20622,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertMessageFormatter</Name>
-        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Type>
+        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Type>
         <BitSize>32</BitSize>
         <BitOffs>33551680</BitOffs>
       </SubItem>
@@ -20931,7 +20931,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestByPosition</Name>
-        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_Test</ReturnType>
+        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</ReturnType>
         <ReturnBitSize>4192</ReturnBitSize>
         <Parameter>
           <Name>Position</Name>
@@ -22354,7 +22354,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetTestFailed</Name>
         <Parameter>
           <Name>AssertionType</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -24286,7 +24286,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Name>
       <BitSize>4128</BitSize>
       <SubItem>
         <Name>MsgCtrlMask</Name>
@@ -24314,7 +24314,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
+      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
       <Comment> This function block is responsible for making sure that the ADSLOGSTR-messages to the ADS-router are transmitted
    cyclically and not in a burst. The reason this is necessary is because that if too many messages are sent at the
    same time some get lost and are never printed to the error list output
@@ -24406,7 +24406,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Local>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
       </Method>
@@ -24414,7 +24414,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetAndRemoveLogFromQueue</Name>
         <Parameter>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
           <Properties>
             <Property>
@@ -26400,6 +26400,257 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Property>
         <Property>
           <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</Name>
+      <Comment> WARNING: This file is auto-generated. Do not modify it.</Comment>
+      <BitSize>575872</BitSize>
+      <SubItem>
+        <Name>sTableName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEnergyEV</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>f1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>f2</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> Was the table name or data invalid? </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFound</Name>
+        <Type>BOOL</Type>
+        <Comment> Was the input found in the table? </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> Has the FB finished? </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>912</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTableLookupLow</Name>
+        <Type>LREAL</Type>
+        <Comment> The lowest accepted lookup value. </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTableLookupHigh</Name>
+        <Type>LREAL</Type>
+        <Comment> The highest accepted lookup value. </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iRowSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRow1</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo PointerTo="1">
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>32</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRow2</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo PointerTo="1">
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>32</BitSize>
+        <BitOffs>1184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEnergyEV_RowDelta</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iRowCount</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iRowIdx</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSlope</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTable_Ge</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>506</Elements>
+        </ArrayInfo>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The data tables. These are Initialized on the first function block call. </Comment>
+        <BitSize>97152</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTable_C</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>502</Elements>
+        </ArrayInfo>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>96384</BitSize>
+        <BitOffs>98560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTable_Al</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>504</Elements>
+        </ArrayInfo>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>96768</BitSize>
+        <BitOffs>194944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTable_Be</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>724</Elements>
+        </ArrayInfo>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>139008</BitSize>
+        <BitOffs>291712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTable_Si</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>756</Elements>
+        </ArrayInfo>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>145152</BitSize>
+        <BitOffs>430720</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -28482,6 +28733,16 @@ External Setpoint Generation:
         <Default>
           <Value>1</Value>
         </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: bEPS_OK
+        io: i
+        field: DESC check if nFlags are all true
+    </Value>
+          </Property>
+        </Properties>
       </SubItem>
     </DataType>
     <DataType>
@@ -29287,16 +29548,6 @@ External Setpoint Generation:
         <BitOffs>9024</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-          </Property>
-          <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
           </Property>
@@ -29309,16 +29560,6 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9032</BitOffs>
         <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-          </Property>
           <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
@@ -29333,16 +29574,6 @@ External Setpoint Generation:
         <BitOffs>9040</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-          </Property>
-          <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
           </Property>
@@ -29355,16 +29586,6 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9048</BitOffs>
         <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-          </Property>
           <Property>
             <Name>TcAddressType</Name>
             <Value>Output</Value>
@@ -29443,18 +29664,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move forward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bAllBackwardEnable</Name>
@@ -29465,18 +29674,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move backward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bAllEnable</Name>
@@ -29487,18 +29684,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to have power
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryForwardEnable</Name>
@@ -29509,18 +29694,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move forward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryBackwardEnable</Name>
@@ -29531,18 +29704,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move backward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nEncoderCount</Name>
@@ -29619,16 +29780,6 @@ External Setpoint Generation:
  Name to use for log messages, fast faults, etc.</Comment>
         <BitSize>648</BitSize>
         <BitOffs>13312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:sName
-        io: i
-        field: DESC PLC program name
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bPowerSelf</Name>
@@ -29639,18 +29790,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bPowerSelf
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if axis is in PMPS
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nEnableMode</Name>
@@ -29661,16 +29800,6 @@ External Setpoint Generation:
         <Default>
           <Value>2</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nEnableMode
-        io: i
-        field: DESC Describes when the axis will automatically get power
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nBrakeMode</Name>
@@ -29681,16 +29810,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nBrakeMode
-        io: i
-        field: DESC Describes when the brake will be released
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nHomingMode</Name>
@@ -29701,16 +29820,6 @@ External Setpoint Generation:
         <Default>
           <Value>-1</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nHomingMode
-        io: i
-        field: DESC Describes our homing strategy
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryAxis</Name>
@@ -29721,18 +29830,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryAxis
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry EPS active
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nGantryTol</Name>
@@ -29761,18 +29858,6 @@ External Setpoint Generation:
  Used internally to request enables</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnable
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally to request enables
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bReset</Name>
@@ -29799,18 +29884,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to start or stop a move</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bExecute
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally and by the IOC to start or stop
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bUserEnable</Name>
@@ -29841,16 +29914,6 @@ External Setpoint Generation:
  Start a move to fPosition with fVelocity</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bMoveCmd
-        io: io
-        field: DESC Start a move
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bHomeCmd</Name>
@@ -29876,16 +29939,6 @@ External Setpoint Generation:
  Used internally and by the IOC to pick what kind of move to do</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCommand
-        io: io
-        field: DESC Used internally and by the IOC to pick move type
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nCmdData</Name>
@@ -29893,16 +29946,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCmdData
-        io: io
-        field: DESC Used internally and by the IOC to pass extra args
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fPosition</Name>
@@ -29910,16 +29953,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fPosition
-        io: io
-        field: DESC Used internally and by the IOC as the set position
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fVelocity</Name>
@@ -29927,16 +29960,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a move velocity</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fVelocity
-        io: io
-        field: DESC Used internally and by the IOC to set velocity
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fAcceleration</Name>
@@ -29944,16 +29967,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fAcceleration
-        io: io
-        field: DESC Used internally and by the IOC to set acceleration
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fDeceleration</Name>
@@ -29961,16 +29974,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fDeceleration
-        io: io
-        field: DESC Used internally and by the IOC to set deceleration
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fHomePosition</Name>
@@ -29999,16 +30002,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nMotionAxisID
-        io: i
-        field: DESC Unique ID assigned to each axis in the NC
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bEnableDone</Name>
@@ -30017,18 +30010,6 @@ External Setpoint Generation:
  TRUE if done enabling</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14688</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnableDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if done enabling
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bBusy</Name>
@@ -30036,18 +30017,6 @@ External Setpoint Generation:
         <Comment> TRUE if in the middle of a command</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14696</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBusy
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if in the middle of a command
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bDone</Name>
@@ -30055,18 +30024,6 @@ External Setpoint Generation:
         <Comment> TRUE if we've done a command and it has finished</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if command finished successfully
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bHomed</Name>
@@ -30074,16 +30031,6 @@ External Setpoint Generation:
         <Comment> TRUE if the motor has been homed, or does not need to be homed</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14712</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHomed
-        io: i
-        field: DESC TRUE if the motor has been homed
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bSafetyReady</Name>
@@ -30091,18 +30038,6 @@ External Setpoint Generation:
         <Comment> TRUE if we have safety permission to move</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14720</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bSafetyReady
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if safe to start a move
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bError</Name>
@@ -30206,17 +30141,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
-      <BitSize>25216</BitSize>
-      <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-      <Properties>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>DUT_MotionStage has been renamed to ST_MotionStage</Value>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">I_HigherAuthority</Name>
@@ -31643,17 +31567,6 @@ These features efficiently address the addition, removal, and verification of be
         <Comment> Maximum allowable deviation from fPosition while at the state</Comment>
         <BitSize>64</BitSize>
         <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DELTA
-        io: io
-        field: DRVL 0.0
-        field: DESC Max deviation from position at this state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fVelocity</Name>
@@ -31678,16 +31591,6 @@ These features efficiently address the addition, removal, and verification of be
         <Comment> (optional) Acceleration to use for moves to this state</Comment>
         <BitSize>64</BitSize>
         <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ACCL
-        io: io
-        field: DESC Acceleration to use for moves to this state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fDecel</Name>
@@ -31695,16 +31598,6 @@ These features efficiently address the addition, removal, and verification of be
         <Comment> (optional) Deceleration to use for moves to this state</Comment>
         <BitSize>64</BitSize>
         <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DCCL
-        io: io
-        field: DESC Deceleration to use for moves to this state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bMoveOk</Name>
@@ -31731,18 +31624,6 @@ These features efficiently address the addition, removal, and verification of be
         <Comment> Signifies to FB_PositionStateLock that this state should be immutable</Comment>
         <BitSize>8</BitSize>
         <BitOffs>1096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: LOCKED
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if state is immutable
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bValid</Name>
@@ -31750,18 +31631,6 @@ These features efficiently address the addition, removal, and verification of be
         <Comment> Set this to TRUE when you make your state. This defaults to FALSE so that uninitialized states can never be moved to</Comment>
         <BitSize>8</BitSize>
         <BitOffs>1104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: VALID
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if this is a real state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bUseRawCounts</Name>
@@ -31783,26 +31652,26 @@ These features efficiently address the addition, removal, and verification of be
         <Comment> We give this a state name and it is used to load parameters from the pmps database.</Comment>
         <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_PositionState</Name>
-      <BitSize>3648</BitSize>
-      <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-      <Properties>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>DUT_PositionState has been renamed to ST_PositionState</Value>
-        </Property>
-      </Properties>
+      <Name Namespace="lcls_twincat_motion">E_EpicsInOut</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>UNKNOWN</Text>
+        <Enum>0</Enum>
+        <Comment> UNKNOWN must be in slot 0 or the FB breaks</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+        <Comment> OUT at slot 1 is a convention</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IN</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_E_TcMC_STATES</Name>
@@ -39841,6 +39710,696 @@ These features efficiently address the addition, removal, and verification of be
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_common_components">FB_PositionState_Defaults</Name>
+      <BitSize>1024</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNameDefault</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloDefault</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDeltaDefault</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAccelDefault</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDecelDefault</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>nSetValue</Name>
+        <Type>UINT</Type>
+        <Comment> For internal use only. This holds new goal positions as an integer, else it is 0 if there is no new state move request. It is written to from the user's input enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to acknowledge and clear an error.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Name>
+      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>bArbiterEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> User setting: TRUE to enable the arbiter, FALSE to disable it.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:ARB:ENABLE
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <Comment> User setting: TRUE to enable maintenance mode (Fast fault, free motion), FALSE to disable it.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:MAINT
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>nGetValue</Name>
+        <Type>UINT</Type>
+        <Comment> For internal use only. This holds the current position index as an integer, else it is 0 if we are changing states or not at any particular state.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE when we are in an active state move and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE after a move completes and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE if the most recent move had an error and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> This will be set to an NC error code during an error if one exists or left at 0 otherwise.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMsg</Name>
+        <Type>STRING(80)</Type>
+        <Comment> This will be set to an appropriate error message during an error if one exists or left as an empty string otherwise.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Name>
+      <BitSize>2496</BitSize>
+      <SubItem>
+        <Name>stTransitionDb</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The database entry for the transition state. This should always be present.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:TRANS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatesInputHandler</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>stUserInput</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> The user's inputs from EPICS. This is an IN_OUT variable because we will write values back to this to help us detect when the same value is re-caput</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> The bBusy boolean from the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nStartingState</Name>
+        <Type>UINT</Type>
+        <Comment> The starting state number to seed nCurrGoal with</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The goal index to input to the motion FB. This will be clamped to the range 0..GeneralConstants.MAX_STATES</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecMove</Name>
+        <Type>BOOL</Type>
+        <Comment> The bExecute boolean to input to the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetMove</Name>
+        <Type>BOOL</Type>
+        <Comment> The bReset boolean to input to the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nQueuedGoal</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IDLE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>GOING</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_STOP</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_RawCountConverter</Name>
+      <BitSize>8576</BitSize>
+      <SubItem>
+        <Name>stParameters</Name>
+        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
+        <Comment> Parameters to check against</Comment>
+        <BitSize>8192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCountCheck</Name>
+        <Type>UDINT</Type>
+        <Comment> Optional count to convert to a real position</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosCheck</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional position to convert to encoder counts</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>8320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCountGet</Name>
+        <Type>UDINT</Type>
+        <Comment> If converting position, the number of counts</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosGet</Name>
+        <Type>LREAL</Type>
+        <Comment> If converting counts, the position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>8448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> True during a parameter get/calc</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> True after a successful get/calc</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> True if the calculation errored</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateLock</Name>
+      <BitSize>3840</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCachedPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3776</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternal</Name>
+      <BitSize>12544</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbEncConverter</Name>
+        <Type Namespace="lcls_twincat_motion">FB_RawCountConverter</Type>
+        <BitSize>8576</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLock</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateLock</Type>
+        <BitSize>3840</BitSize>
+        <BitOffs>8704</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Name>
+      <BitSize>564672</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All the motors to apply the standard routines to</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbStateInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> The individual instantiated internal FBs. Must have the same bounds as astPositionState.</Comment>
+        <BitSize>564480</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotors</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>564608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterStates</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>564640</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">E_MotionRequest</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -40417,506 +40976,16 @@ These features efficiently address the addition, removal, and verification of be
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_RawCountConverter</Name>
-      <BitSize>8576</BitSize>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Name>
+      <BitSize>8768</BitSize>
       <SubItem>
-        <Name>stParameters</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
-        <Comment> Parameters to check against</Comment>
-        <BitSize>8192</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountCheck</Name>
-        <Type>UDINT</Type>
-        <Comment> Optional count to convert to a real position</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosCheck</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional position to convert to encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountGet</Name>
-        <Type>UDINT</Type>
-        <Comment> If converting position, the number of counts</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosGet</Name>
-        <Type>LREAL</Type>
-        <Comment> If converting counts, the position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> True during a parameter get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> True after a successful get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if the calculation errored</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateLock</Name>
-      <BitSize>3840</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCachedPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3776</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternal</Name>
-      <BitSize>12544</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbEncConverter</Name>
-        <Type Namespace="lcls_twincat_motion">FB_RawCountConverter</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbLock</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateLock</Type>
-        <BitSize>3840</BitSize>
-        <BitOffs>8704</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
-      <BitSize>253824</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> On rising edge, reset this FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, there is an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error ID</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The error that caused bError to flip TRUE</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>776</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>784</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
           <LBound>1</LBound>
-          <Elements>15</Elements>
+          <Elements>3</Elements>
         </ArrayInfo>
-        <Comment> Pre-allocated array of states</Comment>
-        <BitSize>54720</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-        io: io
-        expand: %.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>setState</Name>
-        <Type>INT</Type>
-        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55552</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>goalState</Name>
-        <Type>INT</Type>
-        <Comment> The current position we are trying to reach, or 0</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55568</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
-        <Comment> The readback position</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55584</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>55600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stUnknown</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>55616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoal</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>59264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
-        <BitSize>2560</BitSize>
-        <BitOffs>62912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>188160</BitSize>
-        <BitOffs>65472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>253632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewGoal</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>253648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerExec</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>253656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>253664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>253696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveRequested</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>253760</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>StateHandler</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionState1D instead</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</Name>
-      <BitSize>19392</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Array of motors to move together</Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Properties>
@@ -40927,12 +40996,13 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>arrStates</Name>
+        <Name>astPositionState</Name>
         <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <ArrayInfo ReferenceTo="true">
           <LBound>1</LBound>
-          <Elements>15</Elements>
+          <Elements>3</Elements>
         </ArrayInfo>
+        <Comment> 1D Position states: the current position to send each axis to</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -40943,13 +41013,11 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bArbiterEnabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
         <BitOffs>96</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -40958,27 +41026,9 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bMaintMode</Name>
+        <Name>bExecute</Name>
         <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MAINT
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bRequestTransition</Name>
-        <Type>BOOL</Type>
+        <Comment> Start all moves on rising edge, stop all moves on falling edge</Comment>
         <BitSize>8</BitSize>
         <BitOffs>112</BitOffs>
         <Properties>
@@ -40989,34 +41039,24 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>setState</Name>
-        <Type>INT</Type>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset any errors</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when a move request is interrupted with a new request</Comment>
         <BitSize>16</BitSize>
         <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fStateBoundaryDeadband</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -41028,40 +41068,102 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>tArbiterTimeout</Name>
-        <Type>TIME</Type>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ALL of the motors are at their goal states</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ANY of this FB's moves are in progress</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ALL motors have completed the last move request from this FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ANY of this FB's moves had an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorCount</Name>
+        <Type>UINT</Type>
+        <Comment> How many FBs are erroring</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nShownError</Name>
+        <Type>DINT</Type>
+        <Comment> Which component is the source of the example/summarized error</Comment>
         <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> One of the error ids</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The error error message matching the ID</Comment>
+        <BitSize>648</BitSize>
         <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveOnArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>288</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>296</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -41070,276 +41172,515 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bForwardAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
+        <Name>afbPositionStateMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> 1D State movers: FBs to move the motors</Comment>
+        <BitSize>7680</BitSize>
+        <BitOffs>960</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bBackwardAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionDb</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <BitSize>2496</BitSize>
-        <BitOffs>352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: TRANS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionBeam</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>2848</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>4608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bTransDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTransReq</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBPTMDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtBPTMDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftMotorExec</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTransDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtDoLateFinish</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonDone</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
         <BitOffs>8640</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>stStateReq</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>8896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>mcPower</Name>
-        <Type Namespace="Tc2_MC2">MC_Power</Type>
-        <BitSize>768</BitSize>
-        <BitOffs>12544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fUpperBound</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>13312</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLowerBound</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>13376</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>13440</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoalState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>13504</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fActPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>17152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fReqPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>17216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInTransition</Name>
+        <Name>bMotorCountError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>17280</BitOffs>
+        <BitOffs>8672</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>stBeamNeeded</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>17312</BitOffs>
+        <Name>nLowerBound</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>8704</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bFwdOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19072</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBwdOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonArbiter</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>19104</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLateFinish</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInternalAuth</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19336</BitOffs>
+        <Name>nUpperBound</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>8736</BitOffs>
       </SubItem>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>DoStateMoves</Name>
       </Action>
       <Action>
-        <Name>HandleBPTM</Name>
+        <Name>CheckCount</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
+        <Name>CombineOutputs</Name>
       </Action>
-      <Action>
-        <Name>ClearAsserts</Name>
-      </Action>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandlePmpsDb</Name>
-      </Action>
-      <Method>
-        <Name>GetBeamFromState</Name>
-        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
-        <ReturnBitSize>1760</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stState</Name>
-          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-          <BitSize>3648</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetStateCode</Name>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetStateStruct</Name>
-        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
-        <ReturnBitSize>3648</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateRead</Name>
+      <BitSize>3968</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to check the state of</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> The allowed states for this motor</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're standing still at a known state, or moving within the bounds of a state to another location in the bounds.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMovingState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're moving to some other state or to another non-state position.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nPositionIndex</Name>
+        <Type>UINT</Type>
+        <Comment> If we're at a known state, this will be the index in the astPositionState array that matches the state. Otherwise, this will be 0, which is below the bounds of the array, so it cannot be confused with a valid output.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentPosition</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> A copy of the details of the current position state, for convenience. This may be a moving state or an unknown state as a placeholder if we are not at a known state.</Comment>
+        <BitSize>3648</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abAtPosition</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> A full description of whether we're at each of our states. This is used in 2D, 3D, etc. to clarify cases where states may overlap in 1D.</Comment>
+        <BitSize>120</BitSize>
+        <BitOffs>3776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>3904</BitOffs>
+      </SubItem>
+      <Properties>
         <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateReadND</Name>
+      <BitSize>12288</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The motors with a combined N-dimensional state</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're standing still at a known state.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMovingState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're moving, there can be no valid state if we are moving.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nPositionIndex</Name>
+        <Type>UINT</Type>
+        <Comment> If we're at a known state, this will be the state index along the enclosed states arrays. Otherwise, it will be zero, which is below the bounds of the states array.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the active motor count was invalid</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abAtPosition</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> A full description of whether we're at each of our states. This is used to clarify cases where states may overlap.</Comment>
+        <BitSize>120</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbPositionStateRead</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateRead</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The individual position state reader function blocks</Comment>
+        <BitSize>11904</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter2</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12240</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>DoStateReads</Name>
+      </Action>
+      <Action>
+        <Name>CombineOutputs</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Name>
+      <BitSize>600960</BitSize>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All position states for all motors, including unused/invalid states.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbInput</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatesInputHandler</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Type>
+        <BitSize>564672</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Type>
+        <BitSize>8768</BitSize>
+        <BitOffs>565248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbRead</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateReadND</Type>
+        <BitSize>12288</BitSize>
+        <BitOffs>574016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMoveGoals</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>10944</BitSize>
+        <BitOffs>586304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInvalidPos</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>597248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotor</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>600896</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -41656,6 +41997,246 @@ These features efficiently address the addition, removal, and verification of be
           <BitSize>16</BitSize>
         </Local>
       </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Name>
+      <BitSize>198656</BitSize>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction. These will not be modified.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The database lookup key for the transition state. This has no corresponding ST_PositionState.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to use for fast faults, etc.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>744</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadNow</Name>
+        <Type>BOOL</Type>
+        <Comment> For debug: set this to TRUE in online mode to read the database immediately.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> The raw lookup results from this FB. Index 0 is the transition beam, the rest of the indices match the state positions.</Comment>
+        <BitSize>39936</BitSize>
+        <BitOffs>1408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstReadDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we've had at least one successful read.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>41344</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be set to TRUE if there was an error reading from the database.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>41352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ffError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>41376</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadPmpsDb</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>109056</BitSize>
+        <BitOffs>66496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftDbBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>175552</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftRead</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>175616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>175680</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotor</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>175712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterState</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>175744</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterState2</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>175776</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sLoopNewKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>175808</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sLoopPrevKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>176456</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>abStateError</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>128</BitSize>
+        <BitOffs>177104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>asLookupKeys</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>10368</BitSize>
+        <BitOffs>177232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>asPrevLookupKeys</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>10368</BitSize>
+        <BitOffs>187600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewKeys</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>197968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sTempBackfill</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>197976</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>SelectLookupKeys</Name>
+      </Action>
+      <Action>
+        <Name>BackfillInfo</Name>
+      </Action>
+      <Action>
+        <Name>ReadDatabase</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -42337,14 +42918,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Name>
-      <BitSize>382720</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</ExtendsType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionBPTM</Name>
+      <BitSize>111808</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Array of motors that will move for this beam transition</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
       <SubItem>
         <Name>fbArbiter</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam states from</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>19392</BitOffs>
+        <BitOffs>64</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42355,8 +42953,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>19424</BitOffs>
+        <BitOffs>96</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42365,46 +42964,37 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>19464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>20112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPmpsDoc</Name>
-        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>stGoalParams</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
+        <Comment> The parameters we want to transition to</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>20768</BitOffs>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransParams</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
+        <Comment> The parameters we want to use during the transition</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42413,24 +43003,52 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stHighBeamThreshold</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>20800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBPOKAutoReset</Name>
+        <Name>bEnable</Name>
         <Type>BOOL</Type>
+        <Comment> Set to TRUE to use the BPTM, FALSE to stop using the BPTM.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>22560</BitOffs>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're at the physical state that matches the goal parameters</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A device name to use in the GUI</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> How long to wait for parameters before timing out</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Value>1000</Value>
         </Default>
         <Properties>
           <Property>
@@ -42440,140 +43058,876 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>arrPMPS</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>39936</BitSize>
-        <BitOffs>22592</BitOffs>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether to fault and move on timeout (TRUE) or to wait (FALSE)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>928</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nBPIndex</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>62528</BitOffs>
+        <Name>bResetBPTMTimeout</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE when it is safe to reset the BPTM timeout fast fault, to reset it early.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>936</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nTransitionAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>62560</BitOffs>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> This becomes TRUE when the motors are allowed to move to their destinations.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>944</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nLastReqAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>62592</BitOffs>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> This becomes TRUE once the full beam transition is done.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbReadPmpsDb</Name>
-        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
-        <BitSize>109056</BitSize>
-        <BitOffs>62656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftDbBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>171712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReadDBExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>171776</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftRead</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>171840</BitOffs>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're using a bad motor count</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
         <Name>bptm</Name>
         <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
         <BitSize>60256</BitSize>
-        <BitOffs>171904</BitOffs>
+        <BitOffs>992</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>ffBeamParamsOk</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>232160</BitOffs>
+        <Name>bDoneMoving</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>61248</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>ffZeroRate</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>257248</BitOffs>
+        <Name>nPrevID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>61280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>61312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInternalAuth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>61344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDoneResetQueued</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>61352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonArbiter</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>61376</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>61600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffBPTMTimeoutAndMove</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25088</BitSize>
-        <BitOffs>282336</BitOffs>
+        <BitOffs>61632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffBPTMError</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25088</BitSize>
-        <BitOffs>307424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffMaint</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>332512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffUnknown</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>357600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFFOxOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>382688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAtSafeState</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>382696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>382704</BitOffs>
+        <BitOffs>86720</BitOffs>
       </SubItem>
       <Action>
-        <Name>HandlePmpsDb</Name>
+        <Name>HandleTimeout</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
+        <Name>SetDoneMoving</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>CheckCount</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
-      </Action>
-      <Action>
-        <Name>HandleBPTM</Name>
+        <Name>RunBPTM</Name>
       </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Name>
+      <BitSize>224</BitSize>
+      <SubItem>
+        <Name>astDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> All states to deactivate: transition + the static position states</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter who made the PMPS assert requests</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Clear asserts on rising edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <Properties>
         <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">E_StatePMPSStatus</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>UNKNOWN</Text>
+        <Enum>0</Enum>
+        <Comment> No other enum state describes it</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TRANSITION</Text>
+        <Enum>1</Enum>
+        <Comment> Moving toward a known state</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AT_STATE</Text>
+        <Enum>2</Enum>
+        <Comment> Within a known state, not trying to leave</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>DISABLED</Text>
+        <Enum>3</Enum>
+        <Comment> PMPS is in some way disabled, either with maint mode or arbiter disable</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Name>
+      <BitSize>26304</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor with a position state.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for this motor.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, do the limits as normal. If FALSE, allow all moves regardless of the limits defined here.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalStateIndex</Name>
+        <Type>UINT</Type>
+        <Comment> The state that the motor is moving to.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <Comment> The overal PMPS FB state</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect to the BPTM</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForwardEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBackwardEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValidGoal</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>mc_power</Name>
+        <Type Namespace="Tc2_MC2">MC_Power</Type>
+        <BitSize>768</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPrevStateIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLowerPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fUpperPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffNoGoal</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>SetEnables</Name>
+      </Action>
+      <Action>
+        <Name>ApplyEnables</Name>
+      </Action>
+      <Action>
+        <Name>GetBounds</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Name>
+      <BitSize>130112</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The motors with a combined N-dimensional state</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether or not to do anything</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalStateIndex</Name>
+        <Type>UINT</Type>
+        <Comment> The state that the motors are moving to, along dimension 2 of the position state array. This may be the same as the current state.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to use for this state mover in the case of fast faults.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE to put motors into maintenance mode. This allows us to freely move the motors at the cost of a fast fault.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>824</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <Comment> The overal PMPS FB state</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect from bptm bTransitionAuthorized</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>848</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abForwardEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>880</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abBackwardEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abValidGoal</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>928</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE if the arrays have mismatched sizing. For this FB, this means the motor won't ever get an enable.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbStateEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The individual state limit function blocks</Comment>
+        <BitSize>78912</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffMaint</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>79872</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffProgrammerError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>104960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>130048</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>DoLimits</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Name>
+      <BitSize>103360</BitSize>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam states from</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to link to these fast faults</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentBeamReq</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> Current requested beam details: either a known state or the transition beam</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're at a known state (doesn't matter which)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTransitionID</Name>
+        <Type>DWORD</Type>
+        <Comment> Lookup ID of the transition beam</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMaxTrips</Name>
+        <Type>UINT</Type>
+        <Comment> Number of consecutive trips before we debounce</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2592</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tTripReset</Name>
+        <Type>TIME</Type>
+        <Comment> Decrease trip count by 1 after this much time has passed</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ffBeamParamsOk</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> If the beam parameters are wrong, it is a fault! This encompasses all unknown arbiter-related errors.</Comment>
+        <BitSize>25088</BitSize>
+        <BitOffs>2656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffZeroRate</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> If we asked for zero rate (NC or SC) then we can cut the beam early. This is somewhat redundant.</Comment>
+        <BitSize>25088</BitSize>
+        <BitOffs>27744</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffUnknown</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Trip the beam for unknown state</Comment>
+        <BitSize>25088</BitSize>
+        <BitOffs>52832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffDebounce</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Trip the beam (no autoreset) if ffBeamParamsOK faults/resets multiple times too quickly.</Comment>
+        <BitSize>25088</BitSize>
+        <BitOffs>77920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTripCount</Name>
+        <Type>UINT</Type>
+        <Comment> Number of consecutive trips so far</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>103008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftTripCount</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <Comment> Increase by 1 whenever there is a fault (rising edge)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>103040</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonTripCount</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Decrease trip count by 1 each timeout</Comment>
+        <BitSize>224</BitSize>
+        <BitOffs>103104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCycle</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE on only the first cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>103328</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -42833,14 +44187,18 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</Name>
-      <BitSize>666112</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase</ExtendsType>
+      <Name Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Name>
+      <BitSize>109696</BitSize>
       <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors associated with the state mover.</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>253824</BitOffs>
+        <BitOffs>32</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42851,8 +44209,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Fast fault output to fault to.</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>253856</BitOffs>
+        <BitOffs>64</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42861,10 +44220,246 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>sPmpsDeviceName</Name>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
         <Type>STRING(80)</Type>
+        <Comment> Identifying name to use in group fast faults</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>253888</BitOffs>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE if the arrays don't have the same bounds. In this FB, that's an automatic fault.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>760</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbEncError</Name>
+        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>83808</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffProgrammerError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>84576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>109664</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>HandleLoops</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Name>
+      <BitSize>658112</BitSize>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All position states for all motors, including unused/invalid states.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>320</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42875,8 +44470,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>sTransitionKey</Name>
         <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>254536</BitOffs>
+        <BitOffs>968</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42885,35 +44481,24 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bArbiterEnabled</Name>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1616</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
         <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>255184</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:ARB:ENABLE
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tArbiterTimeout</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>255200</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
+        <BitOffs>1632</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -42922,114 +44507,231 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bMoveOnArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>255232</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>1664</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
+            <Value>Output</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fStateBoundaryDeadband</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>255296</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
+        <Name>fbMotionReadPMPSDB</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Type>
+        <BitSize>198656</BitSize>
+        <BitOffs>4160</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bBPOKAutoReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>255360</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
+        <Name>fbMotionBPTM</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionBPTM</Type>
+        <BitSize>111808</BitSize>
+        <BitOffs>202816</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>fbStatePMPS</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Type>
-        <BitSize>382720</BitSize>
-        <BitOffs>255424</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: PMPS</Value>
-          </Property>
-        </Properties>
+        <Name>fbMotionClearAsserts</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>314624</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>fbEncErrFFO</Name>
-        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
-        <BitSize>27936</BitSize>
-        <BitOffs>638144</BitOffs>
+        <Name>fbStatePMPSEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Type>
+        <BitSize>130112</BitSize>
+        <BitOffs>314880</BitOffs>
       </SubItem>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>PMPSHandler</Name>
-      </Action>
+      <SubItem>
+        <Name>fbMiscStatesErrorFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Type>
+        <BitSize>103360</BitSize>
+        <BitOffs>444992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPerMotorFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Type>
+        <BitSize>109696</BitSize>
+        <BitOffs>548352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>658048</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
-        </Property>
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_EpicsInOut_INT</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>UNKNOWN</Text>
-        <Enum>0</Enum>
-        <Comment> UNKNOWN must be in slot 0 or the FB breaks</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-        <Comment> OUT at slot 1 is a convention</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>IN</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateInOut_WithPMPS</Name>
-      <BitSize>673536</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</ExtendsType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
+      <BitSize>1506304</BitSize>
       <SubItem>
-        <Name>enumSet</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_EpicsInOut_INT</Type>
-        <Comment> NOTE: Please copy this pragma exactly on your enumSet</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>666112</BitOffs>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to move.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states, including unused/invalid states.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1552</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -43037,45 +44739,46 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           </Property>
           <Property>
             <Name>pytmc</Name>
-            <Value>
-        pv: SET
-        io: io
-    </Value>
+            <Value>pv: STATE</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <Comment> NOTE: Do not pragma these, let it happen in the manager.</Comment>
-        <BitSize>3648</BitSize>
-        <BitOffs>666176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stIn</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <Comment> Information about the IN position</Comment>
-        <BitSize>3648</BitSize>
-        <BitOffs>669824</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumGet</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_EpicsInOut_INT</Type>
-        <Comment> NOTE: Please copy this pragma exactly on your enumGet</Comment>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>673472</BitOffs>
+        <BitOffs>1584</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1600</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>1632</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -43083,33 +44786,164 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           </Property>
           <Property>
             <Name>pytmc</Name>
-            <Value>
-        pv: GET
-        io: i
-    </Value>
+            <Value>pv: STATE</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bInOutInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>673488</BitOffs>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>2400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>4896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
+        <BitSize>600960</BitSize>
+        <BitOffs>7424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPMPSCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
+        <BitSize>658112</BitSize>
+        <BitOffs>608384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>75648</BitSize>
+        <BitOffs>1266496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>164160</BitSize>
+        <BitOffs>1342144</BitOffs>
       </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Name>
+      <BitSize>54912</BitSize>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bCheck</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSave</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHadWrite</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astCache</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>54720</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>54848</BitOffs>
+      </SubItem>
+      <Properties>
         <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D_InOut instead</Value>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">FB_AnalogInput</Name>
-      <BitSize>320</BitSize>
+      <BitSize>448</BitSize>
       <SubItem>
         <Name>iRaw</Name>
         <Type>INT</Type>
@@ -43167,15 +45001,64 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>fResolution</Name>
+        <Type>LREAL</Type>
+        <Comment> Value to scale the end result to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RES
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fOffset</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: OFF
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>fReal</Name>
         <Type>LREAL</Type>
         <Comment> The real value read from the output</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
+        <BitOffs>320</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
             <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: VAL
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -43183,7 +45066,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fScale</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
+        <BitOffs>384</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -43304,8 +45187,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_REF_Laser</Name>
-      <BitSize>1088</BitSize>
+      <Name Namespace="lcls_twincat_common_components">FB_REF_Laser</Name>
+      <BitSize>1216</BitSize>
       <SubItem>
         <Name>bShutdown</Name>
         <Type>BOOL</Type>
@@ -43364,14 +45247,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGetLasPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>320</BitSize>
+        <BitSize>448</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetLasPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogOutput</Type>
         <BitSize>576</BitSize>
-        <BitOffs>512</BitOffs>
+        <BitOffs>640</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -43381,11 +45264,12 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_REF</Name>
-      <BitSize>981568</BitSize>
+      <Name Namespace="lcls_twincat_common_components">FB_REF</Name>
+      <BitSize>1927552</BitSize>
       <SubItem>
         <Name>stYStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Y motor (state select).</Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Properties>
@@ -43396,8 +45280,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -43408,8 +45293,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Properties>
@@ -43420,8 +45306,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stIn</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Name>stOut</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the OUT state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -43432,8 +45319,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Name>stIn</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the IN state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>3776</BitOffs>
         <Properties>
@@ -43444,10 +45332,70 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
+        <Name>eEnumSet</Name>
+        <Type Namespace="lcls_twincat_motion">E_EpicsInOut</Type>
+        <Comment> Set this to a non-unknown value to request a new move.</Comment>
+        <BitSize>16</BitSize>
         <BitOffs>7424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MMS:STATE:SET
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>7440</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>7448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>7456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>7464</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -43458,8 +45406,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>sTransitionKey</Name>
         <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>8072</BitOffs>
+        <BitOffs>8112</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -43468,38 +45417,48 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbYStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>297920</BitSize>
-        <BitOffs>8768</BitOffs>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug).</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8760</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbStates</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInOut_WithPMPS</Type>
-        <BitSize>673536</BitSize>
-        <BitOffs>306688</BitOffs>
+        <Name>eEnumGet</Name>
+        <Type Namespace="lcls_twincat_motion">E_EpicsInOut</Type>
+        <Comment> The current position state as an enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>8768</BitOffs>
         <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: MMS:STATE
-        io: io
+        pv: MMS:STATE:GET
+        io: i
     </Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbLaser</Name>
-        <Type Namespace="lcls2_cc_lib">FB_REF_Laser</Type>
-        <BitSize>1088</BitSize>
-        <BitOffs>980224</BitOffs>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>8800</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: LAS
-        io: io
-    </Value>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -43507,42 +45466,79 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>981312</BitOffs>
+        <BitOffs>11296</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bStatesLock</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>981320</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
+        <Name>fbYStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>297920</BitSize>
+        <BitOffs>11328</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>fVelo</Name>
+        <Name>fbStateDefaults</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_PositionState_Defaults</Type>
+        <BitSize>1024</BitSize>
+        <BitOffs>309248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStates</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
+        <BitSize>1506304</BitSize>
+        <BitOffs>310272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MMS
+        astPositionState.array: 1..2
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>54720</BitSize>
+        <BitOffs>1816576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbArrCheckWrite</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
+        <BitSize>54912</BitSize>
+        <BitOffs>1871296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLaser</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_REF_Laser</Type>
+        <BitSize>1216</BitSize>
+        <BitOffs>1926208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: LAS</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>981376</BitOffs>
+        <BitOffs>1927424</BitOffs>
         <Default>
-          <Value>10</Value>
+          <Value>2</Value>
         </Default>
       </SubItem>
       <SubItem>
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>981440</BitOffs>
+        <BitOffs>1927488</BitOffs>
         <Default>
           <Value>10</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>981504</BitOffs>
-        <Default>
-          <Value>2</Value>
         </Default>
       </SubItem>
       <Properties>
@@ -43553,9 +45549,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">ENUM_PPM_States</Name>
+      <Name Namespace="lcls_twincat_common_components">E_PPM_States</Name>
       <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
+      <BaseType>UINT</BaseType>
       <EnumInfo>
         <Text>Unknown</Text>
         <Enum>0</Enum>
@@ -43576,253 +45572,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Text>YAG2</Text>
         <Enum>4</Enum>
       </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_PositionState_Defaults</Name>
-      <BitSize>320</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_PositionState</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloDefault</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDeltaDefault</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAccelDefault</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDecelDefault</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_PPM_States</Name>
-      <BitSize>681600</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</ExtendsType>
-      <SubItem>
-        <Name>enumSet</Name>
-        <Type Namespace="lcls2_cc_lib">ENUM_PPM_States</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>666112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SET
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>666176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPower</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>669824</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYag1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>673472</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYag2</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>677120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bStatesLock</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>680768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumGet</Name>
-        <Type Namespace="lcls2_cc_lib">ENUM_PPM_States</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>680784</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GET
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateDefaults</Name>
-        <Type Namespace="lcls2_cc_lib">FB_PositionState_Defaults</Type>
-        <BitSize>320</BitSize>
-        <BitOffs>680832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bPPMInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>681152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fInDelta</Name>
-        <Type>LREAL</Type>
-        <Comment> These are the default values
- Set values on states prior to passing in for non-default values</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>681216</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681280</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fInVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681344</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681408</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fAccel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681472</BitOffs>
-        <Default>
-          <Value>200</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutDecel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681536</BitOffs>
-        <Default>
-          <Value>25</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">FB_ThermoCouple</Name>
@@ -44148,8 +45897,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_PPM_PowerMeter</Name>
-      <BitSize>578496</BitSize>
+      <Name Namespace="lcls_twincat_common_components">FB_PPM_PowerMeter</Name>
+      <BitSize>578624</BitSize>
       <SubItem>
         <Name>iVoltageINT</Name>
         <Type>INT</Type>
@@ -44331,26 +46080,26 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGetPMVoltage</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>320</BitSize>
+        <BitSize>448</BitSize>
         <BitOffs>192640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbVoltageBuffer</Name>
         <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <BitSize>128512</BitSize>
-        <BitOffs>192960</BitOffs>
+        <BitOffs>193088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbCalibBaseBuffer</Name>
         <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <BitSize>128512</BitSize>
-        <BitOffs>321472</BitOffs>
+        <BitOffs>321600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbCalibMJBuffer</Name>
         <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
         <BitSize>128512</BitSize>
-        <BitOffs>449984</BitOffs>
+        <BitOffs>450112</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -44360,8 +46109,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_PPM_Gige</Name>
-      <BitSize>1088</BitSize>
+      <Name Namespace="lcls_twincat_common_components">FB_PPM_Gige</Name>
+      <BitSize>1216</BitSize>
       <SubItem>
         <Name>iIlluminatorINT</Name>
         <Type>INT</Type>
@@ -44412,20 +46161,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbGetIllPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>320</BitSize>
+        <BitSize>448</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetIllPercent</Name>
         <Type Namespace="LCLS_General">FB_AnalogOutput</Type>
         <BitSize>576</BitSize>
-        <BitOffs>448</BitOffs>
+        <BitOffs>576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bGigeInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
+        <BitOffs>1152</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -44438,69 +46187,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_L2SI_Flowmeter</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>fRaw</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MA
-        io: input
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fFlowRate</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: FLOW
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_PPM</Name>
-      <BitSize>1575488</BitSize>
+      <Name Namespace="lcls_twincat_common_components">FB_PPM</Name>
+      <BitSize>2514240</BitSize>
       <SubItem>
         <Name>stYStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Y motor (state select).</Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44511,6 +46205,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Properties>
@@ -44522,7 +46230,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the OUT state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -44534,7 +46243,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stPower</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the POWERMETER state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>3776</BitOffs>
         <Properties>
@@ -44546,7 +46256,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stYag1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the YAG1 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>7424</BitOffs>
         <Properties>
@@ -44558,7 +46269,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stYag2</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the YAG2 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>11072</BitOffs>
         <Properties>
@@ -44569,10 +46281,70 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
+        <Name>eEnumSet</Name>
+        <Type Namespace="lcls_twincat_common_components">E_PPM_States</Type>
+        <Comment> Set this to a non-unknown value to request a new move.</Comment>
+        <BitSize>16</BitSize>
         <BitOffs>14720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MMS:STATE:SET
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14736</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14744</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>14760</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44583,8 +46355,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>sTransitionKey</Name>
         <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>15368</BitOffs>
+        <BitOffs>15408</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44593,65 +46366,164 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbYStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>297920</BitSize>
-        <BitOffs>16064</BitOffs>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug).</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbStates</Name>
-        <Type Namespace="lcls2_cc_lib">FB_PPM_States</Type>
-        <BitSize>681600</BitSize>
-        <BitOffs>313984</BitOffs>
+        <Name>fFlowOffset</Name>
+        <Type>LREAL</Type>
+        <Comment> Offset for the flow meter in engineering units</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>16064</BitOffs>
         <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type Namespace="lcls_twincat_common_components">E_PPM_States</Type>
+        <Comment> The current position state as an enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>16128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: MMS:STATE
+        pv: MMS:STATE:GET
         io: i
     </Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbPowerMeter</Name>
-        <Type Namespace="lcls2_cc_lib">FB_PPM_PowerMeter</Type>
-        <BitSize>578496</BitSize>
-        <BitOffs>995584</BitOffs>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>16160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>18656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbYStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>297920</BitSize>
+        <BitOffs>18688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateDefaults</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_PositionState_Defaults</Type>
+        <BitSize>1024</BitSize>
+        <BitOffs>316608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStates</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
+        <BitSize>1506304</BitSize>
+        <BitOffs>317632</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: SPM
+        pv: MMS
+        astPositionState.array: 1..4
     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>54720</BitSize>
+        <BitOffs>1823936</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbArrCheckWrite</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
+        <BitSize>54912</BitSize>
+        <BitOffs>1878656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPowerMeter</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_PPM_PowerMeter</Type>
+        <BitSize>578624</BitSize>
+        <BitOffs>1933568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: SPM</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
         <Name>fbGige</Name>
-        <Type Namespace="lcls2_cc_lib">FB_PPM_Gige</Type>
-        <BitSize>1088</BitSize>
-        <BitOffs>1574080</BitOffs>
+        <Type Namespace="lcls_twincat_common_components">FB_PPM_Gige</Type>
+        <BitSize>1216</BitSize>
+        <BitOffs>2512192</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
-            <Value>
-        pv: CAM
-    </Value>
+            <Value>pv: CAM</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
         <Name>fbFlowMeter</Name>
-        <Type Namespace="lcls2_cc_lib">FB_L2SI_Flowmeter</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1575168</BitOffs>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>2513408</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.iTermBits</Name>
+            <Value>12</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMax</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMin</Name>
+            <Value>0</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fResolution</Name>
+            <Value>0.1</Value>
+          </SubItem>
+        </Default>
         <Properties>
           <Property>
             <Name>pytmc</Name>
-            <Value>
-        pv: SFM
-    </Value>
+            <Value>pv: FWM</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -44659,16 +46531,41 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbYagThermoCouple</Name>
         <Type Namespace="LCLS_General">FB_ThermoCouple</Type>
         <BitSize>192</BitSize>
-        <BitOffs>1575296</BitOffs>
+        <BitOffs>2513856</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
-            <Value>
-        pv: YAG
-        io: input
-    </Value>
+            <Value>pv: YAG</Value>
           </Property>
         </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <Comment> State defaults if not provided</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2514048</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2514112</BitOffs>
+        <Default>
+          <Value>200</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fOutDecel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2514176</BitOffs>
+        <Default>
+          <Value>25</Value>
+        </Default>
       </SubItem>
       <Properties>
         <Property>
@@ -44678,9 +46575,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">ENUM_LIC_States</Name>
+      <Name Namespace="lcls_twincat_common_components">E_LIC_States</Name>
       <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
+      <BaseType>UINT</BaseType>
       <EnumInfo>
         <Text>Unknown</Text>
         <Enum>0</Enum>
@@ -44703,33 +46600,53 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_LIC_States</Name>
-      <BitSize>681600</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</ExtendsType>
+      <Name Namespace="lcls_twincat_common_components">FB_LIC</Name>
+      <BitSize>1933696</BitSize>
       <SubItem>
-        <Name>enumSet</Name>
-        <Type Namespace="lcls2_cc_lib">ENUM_LIC_States</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>666112</BitOffs>
+        <Name>stYStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Y motor (state select).</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
+            <Value>InOut</Value>
           </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SET
-        io: io
-    </Value>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
         <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the OUT state.</Comment>
         <BitSize>3648</BitSize>
-        <BitOffs>666176</BitOffs>
+        <BitOffs>128</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44739,9 +46656,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stMirror1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the MIRROR1 state.</Comment>
         <BitSize>3648</BitSize>
-        <BitOffs>669824</BitOffs>
+        <BitOffs>3776</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44751,9 +46669,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stMirror2</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the MIRROR2 state.</Comment>
         <BitSize>3648</BitSize>
-        <BitOffs>673472</BitOffs>
+        <BitOffs>7424</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44763,9 +46682,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stTarget1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the TARGET1 state.</Comment>
         <BitSize>3648</BitSize>
-        <BitOffs>677120</BitOffs>
+        <BitOffs>11072</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44774,22 +46694,109 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bStatesLock</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>680768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumGet</Name>
-        <Type Namespace="lcls2_cc_lib">ENUM_LIC_States</Type>
+        <Name>eEnumSet</Name>
+        <Type Namespace="lcls_twincat_common_components">E_LIC_States</Type>
+        <Comment> Set this to a non-unknown value to request a new move.</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>680784</BitOffs>
+        <BitOffs>14720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MMS:STATE:SET
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14736</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14744</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>14752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>14760</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>15408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug).</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type Namespace="lcls_twincat_common_components">E_LIC_States</Type>
+        <Comment> The current position state as an enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>16064</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -44798,65 +46805,89 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: GET
+        pv: MMS:STATE:GET
         io: i
     </Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbStateDefaults</Name>
-        <Type Namespace="lcls2_cc_lib">FB_PositionState_Defaults</Type>
-        <BitSize>320</BitSize>
-        <BitOffs>680832</BitOffs>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>16096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>bLICInit</Name>
+        <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>681152</BitOffs>
+        <BitOffs>18592</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>fInDelta</Name>
+        <Name>fbYStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>297920</BitSize>
+        <BitOffs>18624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateDefaults</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_PositionState_Defaults</Type>
+        <BitSize>1024</BitSize>
+        <BitOffs>316544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStates</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
+        <BitSize>1506304</BitSize>
+        <BitOffs>317568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MMS
+        astPositionState.array: 1..4
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>54720</BitSize>
+        <BitOffs>1823872</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbArrCheckWrite</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
+        <BitSize>54912</BitSize>
+        <BitOffs>1878592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
         <Type>LREAL</Type>
+        <Comment> State defaults if not provided</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>681216</BitOffs>
+        <BitOffs>1933504</BitOffs>
         <Default>
           <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681280</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fInVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681344</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>681408</BitOffs>
-        <Default>
-          <Value>1</Value>
         </Default>
       </SubItem>
       <SubItem>
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>681472</BitOffs>
+        <BitOffs>1933568</BitOffs>
         <Default>
           <Value>200</Value>
         </Default>
@@ -44865,7 +46896,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDecel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>681536</BitOffs>
+        <BitOffs>1933632</BitOffs>
         <Default>
           <Value>25</Value>
         </Default>
@@ -44878,148 +46909,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_LIC</Name>
-      <BitSize>995584</BitSize>
-      <SubItem>
-        <Name>stYStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stMirror1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>3776</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stMirror2</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>7424</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTarget1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>11072</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>14720</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>15368</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbYStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>297920</BitSize>
-        <BitOffs>16064</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStates</Name>
-        <Type Namespace="lcls2_cc_lib">FB_LIC_States</Type>
-        <BitSize>681600</BitSize>
-        <BitOffs>313984</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MMS:STATE
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls2_cc_lib">ENUM_WFS_States</Name>
+      <Name Namespace="lcls_twincat_common_components">E_WFS_States</Name>
       <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
+      <BaseType>UINT</BaseType>
       <EnumInfo>
         <Text>Unknown</Text>
         <Enum>0</Enum>
@@ -45048,205 +46940,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Text>TARGET5</Text>
         <Enum>6</Enum>
       </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_WFS_States</Name>
-      <BitSize>688896</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</ExtendsType>
-      <SubItem>
-        <Name>enumSet</Name>
-        <Type Namespace="lcls2_cc_lib">ENUM_WFS_States</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>666112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SET
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>666176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTarget1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>669824</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTarget2</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>673472</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTarget3</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>677120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTarget4</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>680768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTarget5</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>684416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bStatesLock</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>688064</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumGet</Name>
-        <Type Namespace="lcls2_cc_lib">ENUM_WFS_States</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>688080</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GET
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateDefaults</Name>
-        <Type Namespace="lcls2_cc_lib">FB_PositionState_Defaults</Type>
-        <BitSize>320</BitSize>
-        <BitOffs>688128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bWFSInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>688448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fInDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>688512</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>688576</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fInVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>688640</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>688704</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fAccel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>688768</BitOffs>
-        <Default>
-          <Value>200</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fOutDecel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>688832</BitOffs>
-        <Default>
-          <Value>25</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">FB_TempSensor</Name>
@@ -45389,11 +47082,12 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls2_cc_lib">FB_WFS</Name>
-      <BitSize>1308672</BitSize>
+      <Name Namespace="lcls_twincat_common_components">FB_WFS</Name>
+      <BitSize>2239488</BitSize>
       <SubItem>
         <Name>stYStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Y motor (state select).</Comment>
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Properties>
@@ -45405,7 +47099,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stZStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Z motor (focus adjust).</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -45416,8 +47111,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Properties>
@@ -45428,8 +47124,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
         <BitSize>32</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -45441,7 +47138,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stOut</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the OUT state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>192</BitOffs>
         <Properties>
@@ -45453,7 +47151,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stTarget1</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the TARGET1 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>3840</BitOffs>
         <Properties>
@@ -45465,7 +47164,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stTarget2</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the TARGET2 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>7488</BitOffs>
         <Properties>
@@ -45477,7 +47177,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stTarget3</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the TARGET3 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>11136</BitOffs>
         <Properties>
@@ -45489,7 +47190,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stTarget4</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the TARGET4 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>14784</BitOffs>
         <Properties>
@@ -45501,7 +47203,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>stTarget5</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> Settings for the TARGET5 state.</Comment>
         <BitSize>3648</BitSize>
         <BitOffs>18432</BitOffs>
         <Properties>
@@ -45512,10 +47215,70 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
+        <Name>eEnumSet</Name>
+        <Type Namespace="lcls_twincat_common_components">E_WFS_States</Type>
+        <Comment> Set this to a non-unknown value to request a new move.</Comment>
+        <BitSize>16</BitSize>
         <BitOffs>22080</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MMS:STATE:SET
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>22096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>22104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>22112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>22120</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -45526,8 +47289,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>sTransitionKey</Name>
         <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>22728</BitOffs>
+        <BitOffs>22768</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -45536,44 +47300,115 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbYStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>297920</BitSize>
-        <BitOffs>23424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbZStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>297920</BitSize>
-        <BitOffs>321344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStates</Name>
-        <Type Namespace="lcls2_cc_lib">FB_WFS_States</Type>
-        <BitSize>688896</BitSize>
-        <BitOffs>619264</BitOffs>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug).</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>23416</BitOffs>
         <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type Namespace="lcls_twincat_common_components">E_WFS_States</Type>
+        <Comment> The current position state as an enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>23424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: MMS:STATE
+        pv: MMS:STATE:GET
         io: i
     </Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbThermoCouple1</Name>
-        <Type Namespace="LCLS_General">FB_TempSensor</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>1308160</BitOffs>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>23456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>25952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbYStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>297920</BitSize>
+        <BitOffs>25984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbZStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>297920</BitSize>
+        <BitOffs>323904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateDefaults</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_PositionState_Defaults</Type>
+        <BitSize>1024</BitSize>
+        <BitOffs>621824</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStates</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
+        <BitSize>1506304</BitSize>
+        <BitOffs>622848</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: STC:01
-        io: input
+        pv: MMS
+        astPositionState.array: 1..6
     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>54720</BitSize>
+        <BitOffs>2129152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbArrCheckWrite</Name>
+        <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
+        <BitSize>54912</BitSize>
+        <BitOffs>2183872</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbThermoCouple1</Name>
+        <Type Namespace="LCLS_General">FB_TempSensor</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>2238784</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STC:01</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -45581,21 +47416,57 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbThermoCouple2</Name>
         <Type Namespace="LCLS_General">FB_TempSensor</Type>
         <BitSize>256</BitSize>
-        <BitOffs>1308416</BitOffs>
+        <BitOffs>2239040</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
-            <Value>
-        pv: STC:02
-        io: input
-    </Value>
+            <Value>pv: STC:02</Value>
           </Property>
         </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <Comment> State defaults if not provided</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2239296</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2239360</BitOffs>
+        <Default>
+          <Value>200</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fOutDecel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2239424</BitOffs>
+        <Default>
+          <Value>25</Value>
+        </Default>
       </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
+      <BitSize>25216</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>DUT_MotionStage has been renamed to ST_MotionStage</Value>
         </Property>
       </Properties>
     </DataType>
@@ -46784,6 +48655,17 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_PositionState</Name>
+      <BitSize>3648</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>DUT_PositionState has been renamed to ST_PositionState</Value>
         </Property>
       </Properties>
     </DataType>
@@ -48580,6 +50462,1134 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
+      <BitSize>253824</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> On rising edge, reset this FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, there is an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error ID</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The error that caused bError to flip TRUE</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are moving the motor</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>784</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrStates</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Pre-allocated array of states</Comment>
+        <BitSize>54720</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+        io: io
+        expand: %.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>setState</Name>
+        <Type>INT</Type>
+        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55552</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>goalState</Name>
+        <Type>INT</Type>
+        <Comment> The current position we are trying to reach, or 0</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>getState</Name>
+        <Type>INT</Type>
+        <Comment> The readback position</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>55600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stUnknown</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>55616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stGoal</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>59264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
+        <BitSize>2560</BitSize>
+        <BitOffs>62912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>188160</BitSize>
+        <BitOffs>65472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>253632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewGoal</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>253648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerExec</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>253656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>253664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>253696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveRequested</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>253760</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>StateHandler</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionState1D instead</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</Name>
+      <BitSize>19392</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrStates</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterEnabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MAINT
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRequestTransition</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>setState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fStateBoundaryDeadband</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForwardAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBackwardAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionDb</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <BitSize>2496</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TRANS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionBeam</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>2848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>4608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bTransDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTransReq</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBPTMDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtBPTMDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftMotorExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTransDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtDoLateFinish</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>8576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonDone</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>8640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stStateReq</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>8896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>mcPower</Name>
+        <Type Namespace="Tc2_MC2">MC_Power</Type>
+        <BitSize>768</BitSize>
+        <BitOffs>12544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fUpperBound</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>13312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLowerBound</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>13376</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>13440</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stGoalState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>13504</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fActPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>17152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fReqPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>17216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInTransition</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>17280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stBeamNeeded</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>17312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFwdOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBwdOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonArbiter</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>19104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLateFinish</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInternalAuth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19336</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>AssertHere</Name>
+      </Action>
+      <Action>
+        <Name>HandleBPTM</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>ClearAsserts</Name>
+      </Action>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandlePmpsDb</Name>
+      </Action>
+      <Method>
+        <Name>GetBeamFromState</Name>
+        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
+        <ReturnBitSize>1760</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stState</Name>
+          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+          <BitSize>3648</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetStateCode</Name>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetStateStruct</Name>
+        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
+        <ReturnBitSize>3648</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Name>
+      <BitSize>382720</BitSize>
+      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</ExtendsType>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>19392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>19424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPmpsDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>19464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>20112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPmpsDoc</Name>
+        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>20768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stHighBeamThreshold</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>20800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBPOKAutoReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>22560</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrPMPS</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>39936</BitSize>
+        <BitOffs>22592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nBPIndex</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>62528</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTransitionAssertionID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>62560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLastReqAssertionID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>62592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadPmpsDb</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>109056</BitSize>
+        <BitOffs>62656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftDbBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>171712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReadDBExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>171776</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftRead</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>171840</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bptm</Name>
+        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
+        <BitSize>60256</BitSize>
+        <BitOffs>171904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBeamParamsOk</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>232160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffZeroRate</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>257248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBPTMTimeoutAndMove</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>282336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBPTMError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>307424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffMaint</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>332512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffUnknown</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>357600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFFOxOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>382688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAtSafeState</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>382696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>382704</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>HandlePmpsDb</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>AssertHere</Name>
+      </Action>
+      <Action>
+        <Name>ClearAsserts</Name>
+      </Action>
+      <Action>
+        <Name>HandleBPTM</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</Name>
+      <BitSize>666112</BitSize>
+      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase</ExtendsType>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>253824</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>253856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPmpsDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>253888</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>254536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterEnabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>255184</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:ARB:ENABLE
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>255200</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>255232</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fStateBoundaryDeadband</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>255296</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBPOKAutoReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>255360</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbStatePMPS</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Type>
+        <BitSize>382720</BitSize>
+        <BitOffs>255424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: PMPS</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbEncErrFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
+        <BitSize>27936</BitSize>
+        <BitOffs>638144</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>PMPSHandler</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name>ENUM_TM1K4_States</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -49494,2748 +52504,87 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>nSetValue</Name>
-        <Type>UINT</Type>
-        <Comment> For internal use only. This holds new goal positions as an integer, else it is 0 if there is no new state move request. It is written to from the user's input enum.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to acknowledge and clear an error.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Name>
+      <Name>ENUM_ZonePlate_States</Name>
       <BitSize>16</BitSize>
-      <SubItem>
-        <Name>bArbiterEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> User setting: TRUE to enable the arbiter, FALSE to disable it.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:ARB:ENABLE
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMaintMode</Name>
-        <Type>BOOL</Type>
-        <Comment> User setting: TRUE to enable maintenance mode (Fast fault, free motion), FALSE to disable it.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:MAINT
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Name>
-      <BitSize>768</BitSize>
-      <SubItem>
-        <Name>nGetValue</Name>
-        <Type>UINT</Type>
-        <Comment> For internal use only. This holds the current position index as an integer, else it is 0 if we are changing states or not at any particular state.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be TRUE when we are in an active state move and FALSE otherwise.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be TRUE after a move completes and FALSE otherwise.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be TRUE if the most recent move had an error and FALSE otherwise.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> This will be set to an NC error code during an error if one exists or left at 0 otherwise.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMsg</Name>
-        <Type>STRING(80)</Type>
-        <Comment> This will be set to an appropriate error message during an error if one exists or left as an empty string otherwise.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Name>
-      <BitSize>2496</BitSize>
-      <SubItem>
-        <Name>stTransitionDb</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <Comment> The database entry for the transition state. This should always be present.</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:TRANS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StatesInputHandler</Name>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>stUserInput</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
-        <Comment> The user's inputs from EPICS. This is an IN_OUT variable because we will write values back to this to help us detect when the same value is re-caput</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> The bBusy boolean from the motion FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nStartingState</Name>
-        <Type>UINT</Type>
-        <Comment> The starting state number to seed nCurrGoal with</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGoal</Name>
-        <Type>UINT</Type>
-        <Comment> The goal index to input to the motion FB. This will be clamped to the range 0..GeneralConstants.MAX_STATES</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecMove</Name>
-        <Type>BOOL</Type>
-        <Comment> The bExecute boolean to input to the motion FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bResetMove</Name>
-        <Type>BOOL</Type>
-        <Comment> The bReset boolean to input to the motion FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nState</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nQueuedGoal</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IDLE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>GOING</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_STOP</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Name>
-      <BitSize>564672</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All the motors to apply the standard routines to</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbStateInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
-        <ArrayInfo Level="0">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> The individual instantiated internal FBs. Must have the same bounds as astPositionState.</Comment>
-        <BitSize>564480</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterMotors</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>564608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterStates</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>564640</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Name>
-      <BitSize>8768</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Array of motors to move together</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> 1D Position states: the current position to send each axis to</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start all moves on rising edge, stop all moves on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Reset any errors</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
-        <Comment> Define behavior for when a move request is interrupted with a new request</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ALL of the motors are at their goal states</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ANY of this FB's moves are in progress</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ALL motors have completed the last move request from this FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ANY of this FB's moves had an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorCount</Name>
-        <Type>UINT</Type>
-        <Comment> How many FBs are erroring</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nShownError</Name>
-        <Type>DINT</Type>
-        <Comment> Which component is the source of the example/summarized error</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> One of the error ids</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The error error message matching the ID</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbPositionStateMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> 1D State movers: FBs to move the motors</Comment>
-        <BitSize>7680</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>8640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLowerBound</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>8704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nUpperBound</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>8736</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>DoStateMoves</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>CombineOutputs</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateRead</Name>
-      <BitSize>3968</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The motor to check the state of</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> The allowed states for this motor</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bKnownState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're standing still at a known state, or moving within the bounds of a state to another location in the bounds.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMovingState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're moving to some other state or to another non-state position.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nPositionIndex</Name>
-        <Type>UINT</Type>
-        <Comment> If we're at a known state, this will be the index in the astPositionState array that matches the state. Otherwise, this will be 0, which is below the bounds of the array, so it cannot be confused with a valid output.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCurrentPosition</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <Comment> A copy of the details of the current position state, for convenience. This may be a moving state or an unknown state as a placeholder if we are not at a known state.</Comment>
-        <BitSize>3648</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abAtPosition</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> A full description of whether we're at each of our states. This is used in 2D, 3D, etc. to clarify cases where states may overlap in 1D.</Comment>
-        <BitSize>120</BitSize>
-        <BitOffs>3776</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>3904</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateReadND</Name>
-      <BitSize>12288</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The motors with a combined N-dimensional state</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bKnownState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're standing still at a known state.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMovingState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're moving, there can be no valid state if we are moving.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nPositionIndex</Name>
-        <Type>UINT</Type>
-        <Comment> If we're at a known state, this will be the state index along the enclosed states arrays. Otherwise, it will be zero, which is below the bounds of the states array.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the active motor count was invalid</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abAtPosition</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> A full description of whether we're at each of our states. This is used to clarify cases where states may overlap.</Comment>
-        <BitSize>120</BitSize>
-        <BitOffs>152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbPositionStateRead</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateRead</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The individual position state reader function blocks</Comment>
-        <BitSize>11904</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>12224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter2</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>12240</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>DoStateReads</Name>
-      </Action>
-      <Action>
-        <Name>CombineOutputs</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Name>
-      <BitSize>600960</BitSize>
-      <SubItem>
-        <Name>astMotionStageMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionStateMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All position states for all motors, including unused/invalid states.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
-        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
-        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumSet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumGet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGoal</Name>
-        <Type>UINT</Type>
-        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbInput</Name>
-        <Type Namespace="lcls_twincat_motion">FB_StatesInputHandler</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Type>
-        <BitSize>564672</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Type>
-        <BitSize>8768</BitSize>
-        <BitOffs>565248</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbRead</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateReadND</Type>
-        <BitSize>12288</BitSize>
-        <BitOffs>574016</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astMoveGoals</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <BitSize>10944</BitSize>
-        <BitOffs>586304</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stInvalidPos</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>597248</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterMotor</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>600896</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Name>
-      <BitSize>198656</BitSize>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction. These will not be modified.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Hardware output to fault to if there is a problem.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The database lookup key for the transition state. This has no corresponding ST_PositionState.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A name to use for fast faults, etc.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>744</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadNow</Name>
-        <Type>BOOL</Type>
-        <Comment> For debug: set this to TRUE in online mode to read the database immediately.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> The raw lookup results from this FB. Index 0 is the transition beam, the rest of the indices match the state positions.</Comment>
-        <BitSize>39936</BitSize>
-        <BitOffs>1408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstReadDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we've had at least one successful read.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>41344</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be set to TRUE if there was an error reading from the database.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>41352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ffError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>41376</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbReadPmpsDb</Name>
-        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
-        <BitSize>109056</BitSize>
-        <BitOffs>66496</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftDbBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>175552</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftRead</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>175616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>175680</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterMotor</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>175712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterState</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>175744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterState2</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>175776</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sLoopNewKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>175808</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sLoopPrevKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>176456</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>abStateError</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>128</BitSize>
-        <BitOffs>177104</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>asLookupKeys</Name>
-        <Type>STRING(80)</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>10368</BitSize>
-        <BitOffs>177232</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>asPrevLookupKeys</Name>
-        <Type>STRING(80)</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>10368</BitSize>
-        <BitOffs>187600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewKeys</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>197968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sTempBackfill</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>197976</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>SelectLookupKeys</Name>
-      </Action>
-      <Action>
-        <Name>BackfillInfo</Name>
-      </Action>
-      <Action>
-        <Name>ReadDatabase</Name>
-      </Action>
-      <Action>
-        <Name>RunFastFaults</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionBPTM</Name>
-      <BitSize>111808</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Array of motors that will move for this beam transition</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam states from</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stGoalParams</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
-        <Comment> The parameters we want to transition to</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransParams</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
-        <Comment> The parameters we want to use during the transition</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE to use the BPTM, FALSE to stop using the BPTM.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're at the physical state that matches the goal parameters</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A device name to use in the GUI</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tArbiterTimeout</Name>
-        <Type>TIME</Type>
-        <Comment> How long to wait for parameters before timing out</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveOnArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <Comment> Whether to fault and move on timeout (TRUE) or to wait (FALSE)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>928</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bResetBPTMTimeout</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE when it is safe to reset the BPTM timeout fast fault, to reset it early.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment> This becomes TRUE when the motors are allowed to move to their destinations.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>944</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> This becomes TRUE once the full beam transition is done.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>952</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're using a bad motor count</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bptm</Name>
-        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
-        <BitSize>60256</BitSize>
-        <BitOffs>992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bDoneMoving</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>61248</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nPrevID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>61280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>61312</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInternalAuth</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>61344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bDoneResetQueued</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>61352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonArbiter</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>61376</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>61600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffBPTMTimeoutAndMove</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>61632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffBPTMError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>86720</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>HandleTimeout</Name>
-      </Action>
-      <Action>
-        <Name>SetDoneMoving</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>RunBPTM</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Name>
-      <BitSize>224</BitSize>
-      <SubItem>
-        <Name>astDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> All states to deactivate: transition + the static position states</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter who made the PMPS assert requests</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Clear asserts on rising edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">E_StatePMPSStatus</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
+      <BaseType>UINT</BaseType>
       <EnumInfo>
-        <Text>UNKNOWN</Text>
+        <Text>Unknown</Text>
         <Enum>0</Enum>
-        <Comment> No other enum state describes it</Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>TRANSITION</Text>
+        <Text>OUT</Text>
         <Enum>1</Enum>
-        <Comment> Moving toward a known state</Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>AT_STATE</Text>
+        <Text>Yag</Text>
         <Enum>2</Enum>
-        <Comment> Within a known state, not trying to leave</Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>DISABLED</Text>
+        <Text>FZP860_1</Text>
         <Enum>3</Enum>
-        <Comment> PMPS is in some way disabled, either with maint mode or arbiter disable</Comment>
+        <Comment>Ne1</Comment>
       </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Name>
-      <BitSize>26304</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The motor with a position state.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All possible position states for this motor.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Hardware output to fault to if there is a problem.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, do the limits as normal. If FALSE, allow all moves regardless of the limits defined here.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalStateIndex</Name>
-        <Type>UINT</Type>
-        <Comment> The state that the motor is moving to.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eStatePMPSStatus</Name>
-        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
-        <Comment> The overal PMPS FB state</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment> Connect to the BPTM</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> The enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bForwardEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> The forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBackwardEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> The backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValidGoal</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>mc_power</Name>
-        <Type Namespace="Tc2_MC2">MC_Power</Type>
-        <BitSize>768</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nPrevStateIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLowerPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fUpperPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffNoGoal</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>SetEnables</Name>
-      </Action>
-      <Action>
-        <Name>ApplyEnables</Name>
-      </Action>
-      <Action>
-        <Name>GetBounds</Name>
-      </Action>
-      <Action>
-        <Name>RunFastFaults</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Name>
-      <BitSize>130112</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The motors with a combined N-dimensional state</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Hardware output to fault to if there is a problem.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Whether or not to do anything</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalStateIndex</Name>
-        <Type>UINT</Type>
-        <Comment> The state that the motors are moving to, along dimension 2 of the position state array. This may be the same as the current state.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A name to use for this state mover in the case of fast faults.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMaintMode</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE to put motors into maintenance mode. This allows us to freely move the motors at the cost of a fast fault.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>824</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eStatePMPSStatus</Name>
-        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
-        <Comment> The overal PMPS FB state</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment> Connect from bptm bTransitionAuthorized</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abEnabled</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>856</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abForwardEnabled</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>880</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abBackwardEnabled</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>904</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abValidGoal</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>928</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE if the arrays have mismatched sizing. For this FB, this means the motor won't ever get an enable.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>952</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbStateEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The individual state limit function blocks</Comment>
-        <BitSize>78912</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffMaint</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>79872</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffProgrammerError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>104960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>130048</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>DoLimits</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>RunFastFaults</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Name>
-      <BitSize>103360</BitSize>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam states from</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A name to link to these fast faults</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCurrentBeamReq</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> Current requested beam details: either a known state or the transition beam</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bKnownState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're at a known state (doesn't matter which)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>2528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTransitionID</Name>
-        <Type>DWORD</Type>
-        <Comment> Lookup ID of the transition beam</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nMaxTrips</Name>
-        <Type>UINT</Type>
-        <Comment> Number of consecutive trips before we debounce</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2592</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tTripReset</Name>
-        <Type>TIME</Type>
-        <Comment> Decrease trip count by 1 after this much time has passed</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2624</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ffBeamParamsOk</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> If the beam parameters are wrong, it is a fault! This encompasses all unknown arbiter-related errors.</Comment>
-        <BitSize>25088</BitSize>
-        <BitOffs>2656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffZeroRate</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> If we asked for zero rate (NC or SC) then we can cut the beam early. This is somewhat redundant.</Comment>
-        <BitSize>25088</BitSize>
-        <BitOffs>27744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffUnknown</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> Trip the beam for unknown state</Comment>
-        <BitSize>25088</BitSize>
-        <BitOffs>52832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffDebounce</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> Trip the beam (no autoreset) if ffBeamParamsOK faults/resets multiple times too quickly.</Comment>
-        <BitSize>25088</BitSize>
-        <BitOffs>77920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nTripCount</Name>
-        <Type>UINT</Type>
-        <Comment> Number of consecutive trips so far</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>103008</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftTripCount</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <Comment> Increase by 1 whenever there is a fault (rising edge)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>103040</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonTripCount</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Decrease trip count by 1 each timeout</Comment>
-        <BitSize>224</BitSize>
-        <BitOffs>103104</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCycle</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE on only the first cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>103328</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Name>
-      <BitSize>109696</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All motors associated with the state mover.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Fast fault output to fault to.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Identifying name to use in group fast faults</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE if the arrays don't have the same bounds. In this FB, that's an automatic fault.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>760</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbEncError</Name>
-        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <BitSize>83808</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffProgrammerError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>84576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>109664</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>HandleLoops</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Name>
-      <BitSize>658112</BitSize>
-      <SubItem>
-        <Name>astMotionStageMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionStateMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All position states for all motors, including unused/invalid states.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
-        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSEpicsToPlc</Type>
-        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
-        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSPlcToEpics</Type>
-        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam conditions from.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableBeamParams</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnablePositionLimits</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>296</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the transition state in the PMPS database.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>968</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGoal</Name>
-        <Type>UINT</Type>
-        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1616</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadDBNow</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1632</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <Comment> The PMPS database lookup associated with the current position state.</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>1664</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionReadPMPSDB</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Type>
-        <BitSize>198656</BitSize>
-        <BitOffs>4160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionBPTM</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionBPTM</Type>
-        <BitSize>111808</BitSize>
-        <BitOffs>202816</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionClearAsserts</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>314624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStatePMPSEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Type>
-        <BitSize>130112</BitSize>
-        <BitOffs>314880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMiscStatesErrorFFO</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Type>
-        <BitSize>103360</BitSize>
-        <BitOffs>444992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbPerMotorFFO</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Type>
-        <BitSize>109696</BitSize>
-        <BitOffs>548352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eStatePMPSStatus</Name>
-        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>658048</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
+      <EnumInfo>
+        <Text>FZP860_2</Text>
+        <Enum>4</Enum>
+        <Comment>Ne2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP860_3</Text>
+        <Enum>5</Enum>
+        <Comment>Ne3</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_1</Text>
+        <Enum>6</Enum>
+        <Comment>3w1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP750_2</Text>
+        <Enum>7</Enum>
+        <Comment>3w2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_1</Text>
+        <Enum>8</Enum>
+        <Comment>o1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP530_2</Text>
+        <Enum>9</Enum>
+        <Comment>o2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_1</Text>
+        <Enum>10</Enum>
+        <Comment>Ti1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP460_2</Text>
+        <Enum>11</Enum>
+        <Comment>Ti2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_1</Text>
+        <Enum>12</Enum>
+        <Comment>N1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP410_2</Text>
+        <Enum>13</Enum>
+        <Comment>N2</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_1</Text>
+        <Enum>14</Enum>
+        <Comment> C1</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FZP290_2</Text>
+        <Enum>15</Enum>
+        <Comment>C2
+	FZP250_1 := 16    //w1</Comment>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</Name>
@@ -52607,122 +52956,6 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_ZonePlate_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Yag</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_1</Text>
-        <Enum>3</Enum>
-        <Comment>Ne1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_2</Text>
-        <Enum>4</Enum>
-        <Comment>Ne2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP860_3</Text>
-        <Enum>5</Enum>
-        <Comment>Ne3</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_1</Text>
-        <Enum>6</Enum>
-        <Comment>3w1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP750_2</Text>
-        <Enum>7</Enum>
-        <Comment>3w2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_1</Text>
-        <Enum>8</Enum>
-        <Comment>o1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP530_2</Text>
-        <Enum>9</Enum>
-        <Comment>o2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_1</Text>
-        <Enum>10</Enum>
-        <Comment>Ti1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP460_2</Text>
-        <Enum>11</Enum>
-        <Comment>Ti2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_1</Text>
-        <Enum>12</Enum>
-        <Comment>N1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP410_2</Text>
-        <Enum>13</Enum>
-        <Comment>N2</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_1</Text>
-        <Enum>14</Enum>
-        <Comment> C1</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FZP290_2</Text>
-        <Enum>15</Enum>
-        <Comment>C2
-	FZP250_1 := 16    //w1</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
@@ -53276,6 +53509,39 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
@@ -54039,8 +54305,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>84570552</GetCodeOffs>
-        <SetCodeOffs>84570560</SetCodeOffs>
+        <GetCodeOffs>85697216</GetCodeOffs>
+        <SetCodeOffs>85697224</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -55334,31 +55600,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84570120</GetCodeOffs>
+        <GetCodeOffs>85696784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>84570152</GetCodeOffs>
+        <GetCodeOffs>85696816</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84570156</GetCodeOffs>
+        <GetCodeOffs>85696820</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>84570144</GetCodeOffs>
+        <GetCodeOffs>85696808</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>84570164</GetCodeOffs>
+        <GetCodeOffs>85696828</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -58628,6 +58894,44 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -59433,44 +59737,6 @@ Digital outputs</Comment>
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
       </Hides>
     </DataType>
-    <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
-    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{A4C97A60-C95C-4787-A832-16AA681FD195}" TcSmClass="TComPlcObjDef">
@@ -59492,7 +59758,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85524480</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -59503,7 +59769,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639777216</BitOffs>
+            <BitOffs>640357696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641921728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641946944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641954880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641954888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641954896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641954912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641954944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641955008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641955024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641972160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -59516,7 +60121,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640746400</BitOffs>
+            <BitOffs>642270304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59528,7 +60133,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>640767680</BitOffs>
+            <BitOffs>642293632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643857664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643882880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643908096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -59540,7 +60484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641744736</BitOffs>
+            <BitOffs>644206048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59559,7 +60503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937096</BitOffs>
+            <BitOffs>644398408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59571,7 +60515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937104</BitOffs>
+            <BitOffs>644398416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59583,7 +60527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937112</BitOffs>
+            <BitOffs>644398424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59595,7 +60539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937120</BitOffs>
+            <BitOffs>644398432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59608,7 +60552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641937376</BitOffs>
+            <BitOffs>644398688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59621,26 +60565,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642323360</BitOffs>
+            <BitOffs>644784800</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324320</BitOffs>
+            <BitOffs>644785888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -59659,7 +60597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324552</BitOffs>
+            <BitOffs>644786440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -59671,7 +60609,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324560</BitOffs>
+            <BitOffs>644786448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -59683,7 +60621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324568</BitOffs>
+            <BitOffs>644786456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -59695,7 +60633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642324576</BitOffs>
+            <BitOffs>644786464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59707,7 +60645,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>642343232</BitOffs>
+            <BitOffs>644807936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646371968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646379904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646379912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646379920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646379936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646379968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646380032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646380048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646397184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646422400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -59719,7 +60996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643320288</BitOffs>
+            <BitOffs>646720352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59738,7 +61015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512648</BitOffs>
+            <BitOffs>646912712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59750,7 +61027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512656</BitOffs>
+            <BitOffs>646912720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59762,7 +61039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512664</BitOffs>
+            <BitOffs>646912728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59774,7 +61051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512672</BitOffs>
+            <BitOffs>646912736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59787,7 +61064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643512928</BitOffs>
+            <BitOffs>646912992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59800,26 +61077,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643898912</BitOffs>
+            <BitOffs>647299104</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643899872</BitOffs>
+            <BitOffs>647300192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -59838,7 +61109,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900104</BitOffs>
+            <BitOffs>647300744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -59850,7 +61121,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900112</BitOffs>
+            <BitOffs>647300752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -59862,7 +61133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900120</BitOffs>
+            <BitOffs>647300760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -59874,7 +61145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643900128</BitOffs>
+            <BitOffs>647300768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -59886,7 +61157,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643918784</BitOffs>
+            <BitOffs>647322240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648886272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648911488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648936704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -59898,7 +61508,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644895840</BitOffs>
+            <BitOffs>649234656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -59917,7 +61527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088200</BitOffs>
+            <BitOffs>649427016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -59929,7 +61539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088208</BitOffs>
+            <BitOffs>649427024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -59941,7 +61551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088216</BitOffs>
+            <BitOffs>649427032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -59953,7 +61563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088224</BitOffs>
+            <BitOffs>649427040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -59966,7 +61576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645088480</BitOffs>
+            <BitOffs>649427296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -59979,26 +61589,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645474464</BitOffs>
+            <BitOffs>649813408</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475424</BitOffs>
+            <BitOffs>649814496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -60017,7 +61621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475656</BitOffs>
+            <BitOffs>649815048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60029,7 +61633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475664</BitOffs>
+            <BitOffs>649815056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -60041,7 +61645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475672</BitOffs>
+            <BitOffs>649815064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -60053,7 +61657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645475680</BitOffs>
+            <BitOffs>649815072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60065,7 +61669,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645494336</BitOffs>
+            <BitOffs>649836544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651400576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651425792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651451008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651458944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651458952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651458960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651458976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651459008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651459072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651459088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -60077,7 +62020,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646471392</BitOffs>
+            <BitOffs>651748960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60096,7 +62039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663752</BitOffs>
+            <BitOffs>651941320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60108,7 +62051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663760</BitOffs>
+            <BitOffs>651941328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60120,7 +62063,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663768</BitOffs>
+            <BitOffs>651941336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60132,7 +62075,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646663776</BitOffs>
+            <BitOffs>651941344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60145,7 +62088,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646664032</BitOffs>
+            <BitOffs>651941600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60158,26 +62101,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647050016</BitOffs>
+            <BitOffs>652327712</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647050976</BitOffs>
+            <BitOffs>652328800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -60196,7 +62133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051208</BitOffs>
+            <BitOffs>652329352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60208,7 +62145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051216</BitOffs>
+            <BitOffs>652329360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -60220,7 +62157,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051224</BitOffs>
+            <BitOffs>652329368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -60232,7 +62169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647051232</BitOffs>
+            <BitOffs>652329376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60244,7 +62181,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647069888</BitOffs>
+            <BitOffs>652350848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653914880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653940096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653965312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -60256,7 +62532,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648046944</BitOffs>
+            <BitOffs>654263264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -60275,7 +62551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239304</BitOffs>
+            <BitOffs>654455624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -60287,7 +62563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239312</BitOffs>
+            <BitOffs>654455632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -60299,7 +62575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239320</BitOffs>
+            <BitOffs>654455640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -60311,7 +62587,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239328</BitOffs>
+            <BitOffs>654455648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -60324,7 +62600,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648239584</BitOffs>
+            <BitOffs>654455904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -60337,26 +62613,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648625568</BitOffs>
+            <BitOffs>654842016</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.fRaw</Name>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
             <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MA
-        io: input
-    </Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626528</BitOffs>
+            <BitOffs>654843104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -60375,7 +62645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626760</BitOffs>
+            <BitOffs>654843656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -60387,7 +62657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626768</BitOffs>
+            <BitOffs>654843664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -60399,7 +62669,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626776</BitOffs>
+            <BitOffs>654843672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -60411,7 +62681,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648626784</BitOffs>
+            <BitOffs>654843680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60423,7 +62693,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648645952</BitOffs>
+            <BitOffs>654865280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656429312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656454528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656479744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60435,7 +63044,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649651328</BitOffs>
+            <BitOffs>656808448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60447,7 +63056,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649949248</BitOffs>
+            <BitOffs>657106368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658670400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658695616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658720832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -60471,7 +63419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933768</BitOffs>
+            <BitOffs>659018952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -60483,7 +63431,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933776</BitOffs>
+            <BitOffs>659018960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -60495,7 +63443,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933784</BitOffs>
+            <BitOffs>659018968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -60507,7 +63455,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650933792</BitOffs>
+            <BitOffs>659018976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -60531,7 +63479,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934024</BitOffs>
+            <BitOffs>659019208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -60543,7 +63491,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934032</BitOffs>
+            <BitOffs>659019216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -60555,7 +63503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934040</BitOffs>
+            <BitOffs>659019224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -60567,7 +63515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650934048</BitOffs>
+            <BitOffs>659019232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60579,7 +63527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>650961792</BitOffs>
+            <BitOffs>659049728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60591,7 +63539,346 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651259712</BitOffs>
+            <BitOffs>659347648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660911680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660936896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660962112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -60615,7 +63902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244232</BitOffs>
+            <BitOffs>661260232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -60627,7 +63914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244240</BitOffs>
+            <BitOffs>661260240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -60639,7 +63926,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244248</BitOffs>
+            <BitOffs>661260248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -60651,7 +63938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244256</BitOffs>
+            <BitOffs>661260256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -60675,7 +63962,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244488</BitOffs>
+            <BitOffs>661260488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -60687,7 +63974,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244496</BitOffs>
+            <BitOffs>661260496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -60699,7 +63986,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244504</BitOffs>
+            <BitOffs>661260504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -60711,7 +63998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652244512</BitOffs>
+            <BitOffs>661260512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60723,7 +64010,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652250560</BitOffs>
+            <BitOffs>661266752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60735,7 +64022,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652548480</BitOffs>
+            <BitOffs>661564672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60747,7 +64034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652846400</BitOffs>
+            <BitOffs>661862592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60759,7 +64046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653144320</BitOffs>
+            <BitOffs>662160512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -60771,7 +64058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653590016</BitOffs>
+            <BitOffs>662606208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -60787,7 +64074,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653593584</BitOffs>
+            <BitOffs>662609776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -60803,7 +64090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653593592</BitOffs>
+            <BitOffs>662609784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60815,7 +64102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653597184</BitOffs>
+            <BitOffs>662613376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60827,7 +64114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>653895104</BitOffs>
+            <BitOffs>662911296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60839,7 +64126,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654193024</BitOffs>
+            <BitOffs>663209216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60851,7 +64138,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654490944</BitOffs>
+            <BitOffs>663507136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
@@ -60863,7 +64150,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654936640</BitOffs>
+            <BitOffs>663952832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -60876,7 +64163,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655049120</BitOffs>
+            <BitOffs>664065312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -60888,39 +64175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655049128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL1High</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>655049632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL1Low</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>655049640</BitOffs>
+            <BitOffs>664065320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60932,7 +64187,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655082880</BitOffs>
+            <BitOffs>664100480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -60944,7 +64199,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655380800</BitOffs>
+            <BitOffs>664398400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -60968,7 +64223,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372232</BitOffs>
+            <BitOffs>665389832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -60980,7 +64235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372240</BitOffs>
+            <BitOffs>665389840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -60992,7 +64247,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372248</BitOffs>
+            <BitOffs>665389848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -61004,39 +64259,39 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372256</BitOffs>
+            <BitOffs>665389856</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL2High</Name>
+            <Name>PRG_SP1K4.bTL1High</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372784</BitOffs>
+            <BitOffs>665390368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL2Low</Name>
+            <Name>PRG_SP1K4.bTL1Low</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
               </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656372792</BitOffs>
+            <BitOffs>665390376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61048,7 +64303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656398720</BitOffs>
+            <BitOffs>665416320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61060,7 +64315,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656696640</BitOffs>
+            <BitOffs>665714240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -61084,7 +64339,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680776</BitOffs>
+            <BitOffs>666698376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -61096,7 +64351,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680784</BitOffs>
+            <BitOffs>666698384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -61108,7 +64363,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680792</BitOffs>
+            <BitOffs>666698392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -61120,7 +64375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657680800</BitOffs>
+            <BitOffs>666698400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61132,7 +64387,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657686976</BitOffs>
+            <BitOffs>666701504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61144,7 +64399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657984896</BitOffs>
+            <BitOffs>666999424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61156,7 +64411,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658282816</BitOffs>
+            <BitOffs>667297344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61168,7 +64423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658580736</BitOffs>
+            <BitOffs>667595264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61180,7 +64435,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>658878656</BitOffs>
+            <BitOffs>667893184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61192,7 +64447,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659176576</BitOffs>
+            <BitOffs>668191104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61204,7 +64459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659474496</BitOffs>
+            <BitOffs>668489024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61216,7 +64471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659772416</BitOffs>
+            <BitOffs>668786944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61228,7 +64483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660070336</BitOffs>
+            <BitOffs>669084864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61240,7 +64495,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660368256</BitOffs>
+            <BitOffs>669382784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61252,7 +64507,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660666176</BitOffs>
+            <BitOffs>669680704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61264,7 +64519,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660964096</BitOffs>
+            <BitOffs>669978624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -61276,7 +64531,39 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661262016</BitOffs>
+            <BitOffs>670276544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL2High</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 1^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>670571984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL2Low</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL2-EL1124]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>670571992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61288,7 +64575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662825216</BitOffs>
+            <BitOffs>671839808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61297,21 +64584,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833152</BitOffs>
+            <BitOffs>671847744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61320,21 +64597,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833160</BitOffs>
+            <BitOffs>671847752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -61343,21 +64610,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833168</BitOffs>
+            <BitOffs>671847760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61380,7 +64637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833184</BitOffs>
+            <BitOffs>671847776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61393,7 +64650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833216</BitOffs>
+            <BitOffs>671847808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61406,7 +64663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833280</BitOffs>
+            <BitOffs>671847872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61419,7 +64676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662833296</BitOffs>
+            <BitOffs>671847888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61431,7 +64688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662850432</BitOffs>
+            <BitOffs>671865024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61440,21 +64697,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858368</BitOffs>
+            <BitOffs>671872960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61463,21 +64710,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858376</BitOffs>
+            <BitOffs>671872968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -61486,21 +64723,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858384</BitOffs>
+            <BitOffs>671872976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61523,7 +64750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858400</BitOffs>
+            <BitOffs>671872992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61536,7 +64763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858432</BitOffs>
+            <BitOffs>671873024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61549,7 +64776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858496</BitOffs>
+            <BitOffs>671873088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61562,7 +64789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662858512</BitOffs>
+            <BitOffs>671873104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -61574,7 +64801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662875648</BitOffs>
+            <BitOffs>671890240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -61583,21 +64810,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883584</BitOffs>
+            <BitOffs>671898176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -61606,21 +64823,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883592</BitOffs>
+            <BitOffs>671898184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -61629,21 +64836,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883600</BitOffs>
+            <BitOffs>671898192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -61666,7 +64863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883616</BitOffs>
+            <BitOffs>671898208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -61679,7 +64876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883648</BitOffs>
+            <BitOffs>671898240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -61692,7 +64889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883712</BitOffs>
+            <BitOffs>671898304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -61705,7 +64902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662883728</BitOffs>
+            <BitOffs>671898320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -61717,7 +64914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664587264</BitOffs>
+            <BitOffs>673601792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -61726,21 +64923,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595200</BitOffs>
+            <BitOffs>673609728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -61749,21 +64936,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595208</BitOffs>
+            <BitOffs>673609736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -61772,21 +64949,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595216</BitOffs>
+            <BitOffs>673609744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -61809,7 +64976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595232</BitOffs>
+            <BitOffs>673609760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -61822,7 +64989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595264</BitOffs>
+            <BitOffs>673609792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -61835,7 +65002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595328</BitOffs>
+            <BitOffs>673609856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -61848,7 +65015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664595344</BitOffs>
+            <BitOffs>673609872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -61860,7 +65027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664612480</BitOffs>
+            <BitOffs>673627008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -61869,21 +65036,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620416</BitOffs>
+            <BitOffs>673634944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -61892,21 +65049,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620424</BitOffs>
+            <BitOffs>673634952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -61915,21 +65062,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620432</BitOffs>
+            <BitOffs>673634960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -61952,7 +65089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620448</BitOffs>
+            <BitOffs>673634976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -61965,7 +65102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620480</BitOffs>
+            <BitOffs>673635008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -61978,7 +65115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620544</BitOffs>
+            <BitOffs>673635072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -61991,7 +65128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664620560</BitOffs>
+            <BitOffs>673635088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -62003,7 +65140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664637696</BitOffs>
+            <BitOffs>673652224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -62012,21 +65149,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645632</BitOffs>
+            <BitOffs>673660160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -62035,21 +65162,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645640</BitOffs>
+            <BitOffs>673660168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -62058,21 +65175,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645648</BitOffs>
+            <BitOffs>673660176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -62095,7 +65202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645664</BitOffs>
+            <BitOffs>673660192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -62108,7 +65215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645696</BitOffs>
+            <BitOffs>673660224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -62121,7 +65228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645760</BitOffs>
+            <BitOffs>673660288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -62134,7 +65241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664645776</BitOffs>
+            <BitOffs>673660304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -62150,7 +65257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665028320</BitOffs>
+            <BitOffs>674042912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -62171,7 +65278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665031840</BitOffs>
+            <BitOffs>674046432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -62192,7 +65299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665031841</BitOffs>
+            <BitOffs>674046433</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -62204,7 +65311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675230272</BitOffs>
+            <BitOffs>684244800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -62213,21 +65320,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238208</BitOffs>
+            <BitOffs>684252736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -62236,21 +65333,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238216</BitOffs>
+            <BitOffs>684252744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -62259,21 +65346,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238224</BitOffs>
+            <BitOffs>684252752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -62296,7 +65373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238240</BitOffs>
+            <BitOffs>684252768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -62309,7 +65386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238272</BitOffs>
+            <BitOffs>684252800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -62322,7 +65399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238336</BitOffs>
+            <BitOffs>684252864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -62335,7 +65412,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675238352</BitOffs>
+            <BitOffs>684252880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -62347,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675255488</BitOffs>
+            <BitOffs>684270016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -62356,21 +65433,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263424</BitOffs>
+            <BitOffs>684277952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -62379,21 +65446,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263432</BitOffs>
+            <BitOffs>684277960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -62402,21 +65459,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263440</BitOffs>
+            <BitOffs>684277968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -62439,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263456</BitOffs>
+            <BitOffs>684277984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -62452,7 +65499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263488</BitOffs>
+            <BitOffs>684278016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -62465,7 +65512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263552</BitOffs>
+            <BitOffs>684278080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -62478,7 +65525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675263568</BitOffs>
+            <BitOffs>684278096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -62490,7 +65537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675280704</BitOffs>
+            <BitOffs>684295232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -62499,21 +65546,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288640</BitOffs>
+            <BitOffs>684303168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -62522,21 +65559,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288648</BitOffs>
+            <BitOffs>684303176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -62545,21 +65572,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288656</BitOffs>
+            <BitOffs>684303184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -62582,7 +65599,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288672</BitOffs>
+            <BitOffs>684303200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -62595,7 +65612,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288704</BitOffs>
+            <BitOffs>684303232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -62608,7 +65625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288768</BitOffs>
+            <BitOffs>684303296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -62621,7 +65638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675288784</BitOffs>
+            <BitOffs>684303312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -62633,7 +65650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675305920</BitOffs>
+            <BitOffs>684320448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -62642,21 +65659,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313856</BitOffs>
+            <BitOffs>684328384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -62665,21 +65672,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313864</BitOffs>
+            <BitOffs>684328392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -62688,21 +65685,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313872</BitOffs>
+            <BitOffs>684328400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -62725,7 +65712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313888</BitOffs>
+            <BitOffs>684328416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -62738,7 +65725,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313920</BitOffs>
+            <BitOffs>684328448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -62751,7 +65738,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675313984</BitOffs>
+            <BitOffs>684328512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -62764,7 +65751,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675314000</BitOffs>
+            <BitOffs>684328528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -62776,7 +65763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675331136</BitOffs>
+            <BitOffs>684345664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -62785,21 +65772,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339072</BitOffs>
+            <BitOffs>684353600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -62808,21 +65785,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339080</BitOffs>
+            <BitOffs>684353608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -62831,21 +65798,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339088</BitOffs>
+            <BitOffs>684353616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -62868,7 +65825,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339104</BitOffs>
+            <BitOffs>684353632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -62881,7 +65838,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339136</BitOffs>
+            <BitOffs>684353664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -62894,7 +65851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339200</BitOffs>
+            <BitOffs>684353728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -62907,7 +65864,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675339216</BitOffs>
+            <BitOffs>684353744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -62919,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675356352</BitOffs>
+            <BitOffs>684370880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -62928,21 +65885,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364288</BitOffs>
+            <BitOffs>684378816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -62951,21 +65898,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364296</BitOffs>
+            <BitOffs>684378824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -62974,21 +65911,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364304</BitOffs>
+            <BitOffs>684378832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -63011,7 +65938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364320</BitOffs>
+            <BitOffs>684378848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -63024,7 +65951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364352</BitOffs>
+            <BitOffs>684378880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -63037,7 +65964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364416</BitOffs>
+            <BitOffs>684378944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -63050,7 +65977,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675364432</BitOffs>
+            <BitOffs>684378960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -63062,7 +65989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675381568</BitOffs>
+            <BitOffs>684396096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -63071,21 +65998,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389504</BitOffs>
+            <BitOffs>684404032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -63094,21 +66011,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389512</BitOffs>
+            <BitOffs>684404040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -63117,21 +66024,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389520</BitOffs>
+            <BitOffs>684404048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -63154,7 +66051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389536</BitOffs>
+            <BitOffs>684404064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -63167,7 +66064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389568</BitOffs>
+            <BitOffs>684404096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -63180,7 +66077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389632</BitOffs>
+            <BitOffs>684404160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -63193,7 +66090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675389648</BitOffs>
+            <BitOffs>684404176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -63205,7 +66102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675406784</BitOffs>
+            <BitOffs>684421312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -63214,21 +66111,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414720</BitOffs>
+            <BitOffs>684429248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -63237,21 +66124,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414728</BitOffs>
+            <BitOffs>684429256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -63260,21 +66137,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414736</BitOffs>
+            <BitOffs>684429264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -63297,7 +66164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414752</BitOffs>
+            <BitOffs>684429280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -63310,7 +66177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414784</BitOffs>
+            <BitOffs>684429312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -63323,7 +66190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414848</BitOffs>
+            <BitOffs>684429376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -63336,7 +66203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675414864</BitOffs>
+            <BitOffs>684429392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -63348,7 +66215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675432000</BitOffs>
+            <BitOffs>684446528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -63357,21 +66224,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439936</BitOffs>
+            <BitOffs>684454464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -63380,21 +66237,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439944</BitOffs>
+            <BitOffs>684454472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -63403,21 +66250,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439952</BitOffs>
+            <BitOffs>684454480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -63440,7 +66277,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675439968</BitOffs>
+            <BitOffs>684454496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -63453,7 +66290,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675440000</BitOffs>
+            <BitOffs>684454528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -63466,7 +66303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675440064</BitOffs>
+            <BitOffs>684454592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -63479,7 +66316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675440080</BitOffs>
+            <BitOffs>684454608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -63491,7 +66328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675457216</BitOffs>
+            <BitOffs>684471744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -63500,21 +66337,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465152</BitOffs>
+            <BitOffs>684479680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -63523,21 +66350,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465160</BitOffs>
+            <BitOffs>684479688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -63546,21 +66363,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465168</BitOffs>
+            <BitOffs>684479696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -63583,7 +66390,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465184</BitOffs>
+            <BitOffs>684479712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -63596,7 +66403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465216</BitOffs>
+            <BitOffs>684479744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -63609,7 +66416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465280</BitOffs>
+            <BitOffs>684479808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -63622,7 +66429,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675465296</BitOffs>
+            <BitOffs>684479824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -63634,7 +66441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675482432</BitOffs>
+            <BitOffs>684496960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -63643,21 +66450,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490368</BitOffs>
+            <BitOffs>684504896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -63666,21 +66463,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490376</BitOffs>
+            <BitOffs>684504904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -63689,21 +66476,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490384</BitOffs>
+            <BitOffs>684504912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -63726,7 +66503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490400</BitOffs>
+            <BitOffs>684504928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -63739,7 +66516,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490432</BitOffs>
+            <BitOffs>684504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -63752,7 +66529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490496</BitOffs>
+            <BitOffs>684505024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -63765,7 +66542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675490512</BitOffs>
+            <BitOffs>684505040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -63777,7 +66554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675507648</BitOffs>
+            <BitOffs>684522176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -63786,21 +66563,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515584</BitOffs>
+            <BitOffs>684530112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -63809,21 +66576,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515592</BitOffs>
+            <BitOffs>684530120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -63832,21 +66589,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515600</BitOffs>
+            <BitOffs>684530128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -63869,7 +66616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515616</BitOffs>
+            <BitOffs>684530144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -63882,7 +66629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515648</BitOffs>
+            <BitOffs>684530176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -63895,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515712</BitOffs>
+            <BitOffs>684530240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -63908,7 +66655,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675515728</BitOffs>
+            <BitOffs>684530256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -63920,7 +66667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675532864</BitOffs>
+            <BitOffs>684547392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -63929,21 +66676,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540800</BitOffs>
+            <BitOffs>684555328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -63952,21 +66689,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540808</BitOffs>
+            <BitOffs>684555336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -63975,21 +66702,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540816</BitOffs>
+            <BitOffs>684555344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -64012,7 +66729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540832</BitOffs>
+            <BitOffs>684555360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -64025,7 +66742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540864</BitOffs>
+            <BitOffs>684555392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -64038,7 +66755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540928</BitOffs>
+            <BitOffs>684555456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -64051,7 +66768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675540944</BitOffs>
+            <BitOffs>684555472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -64063,7 +66780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675558080</BitOffs>
+            <BitOffs>684572608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -64072,21 +66789,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566016</BitOffs>
+            <BitOffs>684580544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -64095,21 +66802,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566024</BitOffs>
+            <BitOffs>684580552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -64118,21 +66815,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566032</BitOffs>
+            <BitOffs>684580560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -64155,7 +66842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566048</BitOffs>
+            <BitOffs>684580576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -64168,7 +66855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566080</BitOffs>
+            <BitOffs>684580608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -64181,7 +66868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566144</BitOffs>
+            <BitOffs>684580672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -64194,7 +66881,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675566160</BitOffs>
+            <BitOffs>684580688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -64206,7 +66893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675583296</BitOffs>
+            <BitOffs>684597824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -64215,21 +66902,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591232</BitOffs>
+            <BitOffs>684605760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -64238,21 +66915,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591240</BitOffs>
+            <BitOffs>684605768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -64261,21 +66928,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591248</BitOffs>
+            <BitOffs>684605776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -64298,7 +66955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591264</BitOffs>
+            <BitOffs>684605792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -64311,7 +66968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591296</BitOffs>
+            <BitOffs>684605824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -64324,7 +66981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591360</BitOffs>
+            <BitOffs>684605888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -64337,7 +66994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675591376</BitOffs>
+            <BitOffs>684605904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -64349,7 +67006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675608512</BitOffs>
+            <BitOffs>684623040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -64358,21 +67015,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616448</BitOffs>
+            <BitOffs>684630976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -64381,21 +67028,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616456</BitOffs>
+            <BitOffs>684630984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -64404,21 +67041,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616464</BitOffs>
+            <BitOffs>684630992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -64441,7 +67068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616480</BitOffs>
+            <BitOffs>684631008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -64454,7 +67081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616512</BitOffs>
+            <BitOffs>684631040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -64467,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616576</BitOffs>
+            <BitOffs>684631104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -64480,7 +67107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675616592</BitOffs>
+            <BitOffs>684631120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -64492,7 +67119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675633728</BitOffs>
+            <BitOffs>684648256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -64501,21 +67128,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641664</BitOffs>
+            <BitOffs>684656192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -64524,21 +67141,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641672</BitOffs>
+            <BitOffs>684656200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -64547,21 +67154,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641680</BitOffs>
+            <BitOffs>684656208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -64584,7 +67181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641696</BitOffs>
+            <BitOffs>684656224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -64597,7 +67194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641728</BitOffs>
+            <BitOffs>684656256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -64610,7 +67207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641792</BitOffs>
+            <BitOffs>684656320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -64623,7 +67220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675641808</BitOffs>
+            <BitOffs>684656336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -64635,7 +67232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675658944</BitOffs>
+            <BitOffs>684673472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -64644,21 +67241,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666880</BitOffs>
+            <BitOffs>684681408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -64667,21 +67254,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666888</BitOffs>
+            <BitOffs>684681416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -64690,21 +67267,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666896</BitOffs>
+            <BitOffs>684681424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -64727,7 +67294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666912</BitOffs>
+            <BitOffs>684681440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -64740,7 +67307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675666944</BitOffs>
+            <BitOffs>684681472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -64753,7 +67320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675667008</BitOffs>
+            <BitOffs>684681536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -64766,7 +67333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675667024</BitOffs>
+            <BitOffs>684681552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -64778,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675684160</BitOffs>
+            <BitOffs>684698688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -64787,21 +67354,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692096</BitOffs>
+            <BitOffs>684706624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -64810,21 +67367,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692104</BitOffs>
+            <BitOffs>684706632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -64833,21 +67380,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692112</BitOffs>
+            <BitOffs>684706640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -64870,7 +67407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692128</BitOffs>
+            <BitOffs>684706656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -64883,7 +67420,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692160</BitOffs>
+            <BitOffs>684706688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -64896,7 +67433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692224</BitOffs>
+            <BitOffs>684706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -64909,7 +67446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675692240</BitOffs>
+            <BitOffs>684706768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -64921,7 +67458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675709376</BitOffs>
+            <BitOffs>684723904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -64930,21 +67467,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717312</BitOffs>
+            <BitOffs>684731840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -64953,21 +67480,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717320</BitOffs>
+            <BitOffs>684731848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -64976,21 +67493,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717328</BitOffs>
+            <BitOffs>684731856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -65013,7 +67520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717344</BitOffs>
+            <BitOffs>684731872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -65026,7 +67533,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717376</BitOffs>
+            <BitOffs>684731904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -65039,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717440</BitOffs>
+            <BitOffs>684731968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -65052,7 +67559,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675717456</BitOffs>
+            <BitOffs>684731984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -65064,7 +67571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675734592</BitOffs>
+            <BitOffs>684749120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -65073,21 +67580,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742528</BitOffs>
+            <BitOffs>684757056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -65096,21 +67593,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742536</BitOffs>
+            <BitOffs>684757064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -65119,21 +67606,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742544</BitOffs>
+            <BitOffs>684757072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -65156,7 +67633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742560</BitOffs>
+            <BitOffs>684757088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -65169,7 +67646,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742592</BitOffs>
+            <BitOffs>684757120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -65182,7 +67659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742656</BitOffs>
+            <BitOffs>684757184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -65195,7 +67672,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675742672</BitOffs>
+            <BitOffs>684757200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -65207,7 +67684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675759808</BitOffs>
+            <BitOffs>684774336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -65216,21 +67693,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767744</BitOffs>
+            <BitOffs>684782272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -65239,21 +67706,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767752</BitOffs>
+            <BitOffs>684782280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -65262,21 +67719,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767760</BitOffs>
+            <BitOffs>684782288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -65299,7 +67746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767776</BitOffs>
+            <BitOffs>684782304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -65312,7 +67759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767808</BitOffs>
+            <BitOffs>684782336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -65325,7 +67772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767872</BitOffs>
+            <BitOffs>684782400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -65338,7 +67785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675767888</BitOffs>
+            <BitOffs>684782416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -65350,7 +67797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675785024</BitOffs>
+            <BitOffs>684799552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -65359,21 +67806,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792960</BitOffs>
+            <BitOffs>684807488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -65382,21 +67819,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792968</BitOffs>
+            <BitOffs>684807496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -65405,21 +67832,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792976</BitOffs>
+            <BitOffs>684807504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -65442,7 +67859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675792992</BitOffs>
+            <BitOffs>684807520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -65455,7 +67872,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675793024</BitOffs>
+            <BitOffs>684807552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -65468,7 +67885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675793088</BitOffs>
+            <BitOffs>684807616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -65481,7 +67898,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675793104</BitOffs>
+            <BitOffs>684807632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -65493,7 +67910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675810240</BitOffs>
+            <BitOffs>684824768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -65502,21 +67919,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818176</BitOffs>
+            <BitOffs>684832704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -65525,21 +67932,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818184</BitOffs>
+            <BitOffs>684832712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -65548,21 +67945,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818192</BitOffs>
+            <BitOffs>684832720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -65585,7 +67972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818208</BitOffs>
+            <BitOffs>684832736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -65598,7 +67985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818240</BitOffs>
+            <BitOffs>684832768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -65611,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818304</BitOffs>
+            <BitOffs>684832832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -65624,7 +68011,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675818320</BitOffs>
+            <BitOffs>684832848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -65636,7 +68023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675835456</BitOffs>
+            <BitOffs>684849984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -65645,21 +68032,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843392</BitOffs>
+            <BitOffs>684857920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -65668,21 +68045,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843400</BitOffs>
+            <BitOffs>684857928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -65691,21 +68058,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843408</BitOffs>
+            <BitOffs>684857936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -65728,7 +68085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843424</BitOffs>
+            <BitOffs>684857952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -65741,7 +68098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843456</BitOffs>
+            <BitOffs>684857984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -65754,7 +68111,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843520</BitOffs>
+            <BitOffs>684858048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -65767,7 +68124,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675843536</BitOffs>
+            <BitOffs>684858064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -65779,7 +68136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675860672</BitOffs>
+            <BitOffs>684875200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -65788,21 +68145,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868608</BitOffs>
+            <BitOffs>684883136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -65811,21 +68158,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868616</BitOffs>
+            <BitOffs>684883144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -65834,21 +68171,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868624</BitOffs>
+            <BitOffs>684883152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -65871,7 +68198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868640</BitOffs>
+            <BitOffs>684883168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -65884,7 +68211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868672</BitOffs>
+            <BitOffs>684883200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -65897,7 +68224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868736</BitOffs>
+            <BitOffs>684883264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -65910,7 +68237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675868752</BitOffs>
+            <BitOffs>684883280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -65922,7 +68249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675885888</BitOffs>
+            <BitOffs>684900416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -65931,21 +68258,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893824</BitOffs>
+            <BitOffs>684908352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -65954,21 +68271,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893832</BitOffs>
+            <BitOffs>684908360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -65977,21 +68284,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893840</BitOffs>
+            <BitOffs>684908368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -66014,7 +68311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893856</BitOffs>
+            <BitOffs>684908384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -66027,7 +68324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893888</BitOffs>
+            <BitOffs>684908416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -66040,7 +68337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893952</BitOffs>
+            <BitOffs>684908480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -66053,7 +68350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675893968</BitOffs>
+            <BitOffs>684908496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -66065,7 +68362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675911104</BitOffs>
+            <BitOffs>684925632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -66074,21 +68371,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919040</BitOffs>
+            <BitOffs>684933568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -66097,21 +68384,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919048</BitOffs>
+            <BitOffs>684933576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -66120,21 +68397,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919056</BitOffs>
+            <BitOffs>684933584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -66157,7 +68424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919072</BitOffs>
+            <BitOffs>684933600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -66170,7 +68437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919104</BitOffs>
+            <BitOffs>684933632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -66183,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919168</BitOffs>
+            <BitOffs>684933696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -66196,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675919184</BitOffs>
+            <BitOffs>684933712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -66208,7 +68475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675936320</BitOffs>
+            <BitOffs>684950848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -66217,21 +68484,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944256</BitOffs>
+            <BitOffs>684958784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -66240,21 +68497,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944264</BitOffs>
+            <BitOffs>684958792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -66263,21 +68510,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944272</BitOffs>
+            <BitOffs>684958800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -66300,7 +68537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944288</BitOffs>
+            <BitOffs>684958816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -66313,7 +68550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944320</BitOffs>
+            <BitOffs>684958848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -66326,7 +68563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944384</BitOffs>
+            <BitOffs>684958912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -66339,7 +68576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675944400</BitOffs>
+            <BitOffs>684958928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -66351,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675961536</BitOffs>
+            <BitOffs>684976064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -66360,21 +68597,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969472</BitOffs>
+            <BitOffs>684984000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -66383,21 +68610,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969480</BitOffs>
+            <BitOffs>684984008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -66406,21 +68623,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969488</BitOffs>
+            <BitOffs>684984016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -66443,7 +68650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969504</BitOffs>
+            <BitOffs>684984032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -66456,7 +68663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969536</BitOffs>
+            <BitOffs>684984064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -66469,7 +68676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969600</BitOffs>
+            <BitOffs>684984128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -66482,7 +68689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675969616</BitOffs>
+            <BitOffs>684984144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -66494,7 +68701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675986752</BitOffs>
+            <BitOffs>685001280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -66503,21 +68710,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994688</BitOffs>
+            <BitOffs>685009216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -66526,21 +68723,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994696</BitOffs>
+            <BitOffs>685009224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -66549,21 +68736,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994704</BitOffs>
+            <BitOffs>685009232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -66586,7 +68763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994720</BitOffs>
+            <BitOffs>685009248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -66599,7 +68776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994752</BitOffs>
+            <BitOffs>685009280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -66612,7 +68789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994816</BitOffs>
+            <BitOffs>685009344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -66625,7 +68802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675994832</BitOffs>
+            <BitOffs>685009360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -66637,7 +68814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676011968</BitOffs>
+            <BitOffs>685026496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -66646,21 +68823,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019904</BitOffs>
+            <BitOffs>685034432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -66669,21 +68836,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019912</BitOffs>
+            <BitOffs>685034440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -66692,21 +68849,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019920</BitOffs>
+            <BitOffs>685034448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -66729,7 +68876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019936</BitOffs>
+            <BitOffs>685034464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -66742,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676019968</BitOffs>
+            <BitOffs>685034496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -66755,7 +68902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676020032</BitOffs>
+            <BitOffs>685034560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -66768,7 +68915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676020048</BitOffs>
+            <BitOffs>685034576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -66780,7 +68927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676037184</BitOffs>
+            <BitOffs>685051712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -66789,21 +68936,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045120</BitOffs>
+            <BitOffs>685059648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -66812,21 +68949,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045128</BitOffs>
+            <BitOffs>685059656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -66835,21 +68962,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045136</BitOffs>
+            <BitOffs>685059664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -66872,7 +68989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045152</BitOffs>
+            <BitOffs>685059680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -66885,7 +69002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045184</BitOffs>
+            <BitOffs>685059712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -66898,7 +69015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045248</BitOffs>
+            <BitOffs>685059776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -66911,7 +69028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676045264</BitOffs>
+            <BitOffs>685059792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -66923,7 +69040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676062400</BitOffs>
+            <BitOffs>685076928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -66932,21 +69049,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070336</BitOffs>
+            <BitOffs>685084864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -66955,21 +69062,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070344</BitOffs>
+            <BitOffs>685084872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -66978,21 +69075,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070352</BitOffs>
+            <BitOffs>685084880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -67015,7 +69102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070368</BitOffs>
+            <BitOffs>685084896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -67028,7 +69115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070400</BitOffs>
+            <BitOffs>685084928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -67041,7 +69128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070464</BitOffs>
+            <BitOffs>685084992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -67054,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676070480</BitOffs>
+            <BitOffs>685085008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -67066,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676087616</BitOffs>
+            <BitOffs>685102144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -67075,21 +69162,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095552</BitOffs>
+            <BitOffs>685110080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -67098,21 +69175,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095560</BitOffs>
+            <BitOffs>685110088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -67121,21 +69188,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095568</BitOffs>
+            <BitOffs>685110096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -67158,7 +69215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095584</BitOffs>
+            <BitOffs>685110112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -67171,7 +69228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095616</BitOffs>
+            <BitOffs>685110144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -67184,7 +69241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095680</BitOffs>
+            <BitOffs>685110208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -67197,7 +69254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676095696</BitOffs>
+            <BitOffs>685110224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -67209,7 +69266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676112832</BitOffs>
+            <BitOffs>685127360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -67218,21 +69275,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120768</BitOffs>
+            <BitOffs>685135296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -67241,21 +69288,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120776</BitOffs>
+            <BitOffs>685135304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -67264,21 +69301,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120784</BitOffs>
+            <BitOffs>685135312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -67301,7 +69328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120800</BitOffs>
+            <BitOffs>685135328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -67314,7 +69341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120832</BitOffs>
+            <BitOffs>685135360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -67327,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120896</BitOffs>
+            <BitOffs>685135424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -67340,7 +69367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676120912</BitOffs>
+            <BitOffs>685135440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -67352,7 +69379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676138048</BitOffs>
+            <BitOffs>685152576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -67361,21 +69388,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676145984</BitOffs>
+            <BitOffs>685160512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -67384,21 +69401,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676145992</BitOffs>
+            <BitOffs>685160520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -67407,21 +69414,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146000</BitOffs>
+            <BitOffs>685160528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -67444,7 +69441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146016</BitOffs>
+            <BitOffs>685160544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -67457,7 +69454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146048</BitOffs>
+            <BitOffs>685160576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -67470,7 +69467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146112</BitOffs>
+            <BitOffs>685160640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -67483,7 +69480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676146128</BitOffs>
+            <BitOffs>685160656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -67495,7 +69492,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676163264</BitOffs>
+            <BitOffs>685177792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -67504,21 +69501,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171200</BitOffs>
+            <BitOffs>685185728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -67527,21 +69514,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171208</BitOffs>
+            <BitOffs>685185736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -67550,21 +69527,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171216</BitOffs>
+            <BitOffs>685185744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -67587,7 +69554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171232</BitOffs>
+            <BitOffs>685185760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -67600,7 +69567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171264</BitOffs>
+            <BitOffs>685185792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -67613,7 +69580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171328</BitOffs>
+            <BitOffs>685185856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -67626,7 +69593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676171344</BitOffs>
+            <BitOffs>685185872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -67638,7 +69605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676188480</BitOffs>
+            <BitOffs>685203008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -67647,21 +69614,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196416</BitOffs>
+            <BitOffs>685210944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -67670,21 +69627,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196424</BitOffs>
+            <BitOffs>685210952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -67693,21 +69640,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196432</BitOffs>
+            <BitOffs>685210960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -67730,7 +69667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196448</BitOffs>
+            <BitOffs>685210976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -67743,7 +69680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196480</BitOffs>
+            <BitOffs>685211008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -67756,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196544</BitOffs>
+            <BitOffs>685211072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -67769,7 +69706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676196560</BitOffs>
+            <BitOffs>685211088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -67781,7 +69718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676213696</BitOffs>
+            <BitOffs>685228224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -67790,21 +69727,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221632</BitOffs>
+            <BitOffs>685236160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -67813,21 +69740,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221640</BitOffs>
+            <BitOffs>685236168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -67836,21 +69753,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221648</BitOffs>
+            <BitOffs>685236176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -67873,7 +69780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221664</BitOffs>
+            <BitOffs>685236192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -67886,7 +69793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221696</BitOffs>
+            <BitOffs>685236224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -67899,7 +69806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221760</BitOffs>
+            <BitOffs>685236288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -67912,7 +69819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676221776</BitOffs>
+            <BitOffs>685236304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -67924,7 +69831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676238912</BitOffs>
+            <BitOffs>685253440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -67933,21 +69840,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246848</BitOffs>
+            <BitOffs>685261376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -67956,21 +69853,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246856</BitOffs>
+            <BitOffs>685261384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -67979,21 +69866,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246864</BitOffs>
+            <BitOffs>685261392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -68016,7 +69893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246880</BitOffs>
+            <BitOffs>685261408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -68029,7 +69906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246912</BitOffs>
+            <BitOffs>685261440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -68042,7 +69919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246976</BitOffs>
+            <BitOffs>685261504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -68055,7 +69932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676246992</BitOffs>
+            <BitOffs>685261520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -68067,7 +69944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676264128</BitOffs>
+            <BitOffs>685278656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -68076,21 +69953,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272064</BitOffs>
+            <BitOffs>685286592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -68099,21 +69966,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272072</BitOffs>
+            <BitOffs>685286600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -68122,21 +69979,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272080</BitOffs>
+            <BitOffs>685286608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -68159,7 +70006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272096</BitOffs>
+            <BitOffs>685286624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -68172,7 +70019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272128</BitOffs>
+            <BitOffs>685286656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -68185,7 +70032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272192</BitOffs>
+            <BitOffs>685286720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -68198,7 +70045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676272208</BitOffs>
+            <BitOffs>685286736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -68210,7 +70057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676289344</BitOffs>
+            <BitOffs>685303872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -68219,21 +70066,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297280</BitOffs>
+            <BitOffs>685311808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -68242,21 +70079,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297288</BitOffs>
+            <BitOffs>685311816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -68265,21 +70092,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297296</BitOffs>
+            <BitOffs>685311824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -68302,7 +70119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297312</BitOffs>
+            <BitOffs>685311840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -68315,7 +70132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297344</BitOffs>
+            <BitOffs>685311872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -68328,7 +70145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297408</BitOffs>
+            <BitOffs>685311936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -68341,7 +70158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676297424</BitOffs>
+            <BitOffs>685311952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -68353,7 +70170,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676314560</BitOffs>
+            <BitOffs>685329088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -68362,21 +70179,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322496</BitOffs>
+            <BitOffs>685337024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -68385,21 +70192,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322504</BitOffs>
+            <BitOffs>685337032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -68408,21 +70205,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322512</BitOffs>
+            <BitOffs>685337040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -68445,7 +70232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322528</BitOffs>
+            <BitOffs>685337056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -68458,7 +70245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322560</BitOffs>
+            <BitOffs>685337088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -68471,7 +70258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322624</BitOffs>
+            <BitOffs>685337152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -68484,14 +70271,14 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676322640</BitOffs>
+            <BitOffs>685337168</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85524480</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -68502,7 +70289,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639776192</BitOffs>
+            <BitOffs>640356672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641920704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641929688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641945920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641954904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641971136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>641980120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -68514,7 +70376,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640746304</BitOffs>
+            <BitOffs>642270208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -68526,7 +70388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640746320</BitOffs>
+            <BitOffs>642270224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -68539,7 +70401,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640747136</BitOffs>
+            <BitOffs>642271168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68551,7 +70413,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>640766656</BitOffs>
+            <BitOffs>642292608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643856640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643865624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643881856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643890840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643907072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>643916056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -68563,7 +70500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642323232</BitOffs>
+            <BitOffs>644784672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -68583,7 +70520,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642323248</BitOffs>
+            <BitOffs>644784688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68596,7 +70533,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642324096</BitOffs>
+            <BitOffs>644785664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68608,7 +70545,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>642342208</BitOffs>
+            <BitOffs>644806912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646370944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646379928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646396160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646405144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646421376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>646430360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -68620,7 +70632,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643898784</BitOffs>
+            <BitOffs>647298976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -68640,7 +70652,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643898800</BitOffs>
+            <BitOffs>647298992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68653,7 +70665,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643899648</BitOffs>
+            <BitOffs>647299968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68665,7 +70677,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643917760</BitOffs>
+            <BitOffs>647321216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648885248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648894232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648910464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648919448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648935680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>648944664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -68677,7 +70764,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645474336</BitOffs>
+            <BitOffs>649813280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -68697,7 +70784,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645474352</BitOffs>
+            <BitOffs>649813296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68710,7 +70797,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645475200</BitOffs>
+            <BitOffs>649814272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68722,7 +70809,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645493312</BitOffs>
+            <BitOffs>649835520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651399552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651408536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651424768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651433752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651449984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>651458968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -68734,7 +70896,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647049888</BitOffs>
+            <BitOffs>652327584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -68754,7 +70916,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647049904</BitOffs>
+            <BitOffs>652327600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68767,7 +70929,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647050752</BitOffs>
+            <BitOffs>652328576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68779,7 +70941,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647068864</BitOffs>
+            <BitOffs>652349824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653913856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653922840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653939072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653948056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653964288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>653973272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -68791,7 +71028,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648625440</BitOffs>
+            <BitOffs>654841888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -68811,7 +71048,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648625456</BitOffs>
+            <BitOffs>654841904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -68824,7 +71061,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648626304</BitOffs>
+            <BitOffs>654842880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68836,7 +71073,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648644928</BitOffs>
+            <BitOffs>654864256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656428288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656437272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656453504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656462488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656478720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>656487704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68848,7 +71160,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649650304</BitOffs>
+            <BitOffs>656807424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68860,7 +71172,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649948224</BitOffs>
+            <BitOffs>657105344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658669376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658678360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658694592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658703576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658719808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>658728792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68872,7 +71259,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>650960768</BitOffs>
+            <BitOffs>659048704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68884,7 +71271,82 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651258688</BitOffs>
+            <BitOffs>659346624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660910656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660919640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660935872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660944856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660961088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>660970072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68896,7 +71358,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652249536</BitOffs>
+            <BitOffs>661265728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68908,7 +71370,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652547456</BitOffs>
+            <BitOffs>661563648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68920,7 +71382,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652845376</BitOffs>
+            <BitOffs>661861568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68932,7 +71394,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653143296</BitOffs>
+            <BitOffs>662159488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -68944,7 +71406,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653589920</BitOffs>
+            <BitOffs>662606112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68956,7 +71418,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653596160</BitOffs>
+            <BitOffs>662612352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68968,7 +71430,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>653894080</BitOffs>
+            <BitOffs>662910272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68980,7 +71442,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654192000</BitOffs>
+            <BitOffs>663208192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -68992,7 +71454,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654489920</BitOffs>
+            <BitOffs>663506112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -69004,7 +71466,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654936544</BitOffs>
+            <BitOffs>663952736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -69016,7 +71478,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655049136</BitOffs>
+            <BitOffs>664065328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -69028,7 +71490,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655049144</BitOffs>
+            <BitOffs>664065336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69040,7 +71502,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655081856</BitOffs>
+            <BitOffs>664099456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69052,7 +71514,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655379776</BitOffs>
+            <BitOffs>664397376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69064,7 +71526,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656397696</BitOffs>
+            <BitOffs>665415296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69076,7 +71538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656695616</BitOffs>
+            <BitOffs>665713216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69088,7 +71550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657685952</BitOffs>
+            <BitOffs>666700480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69100,7 +71562,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657983872</BitOffs>
+            <BitOffs>666998400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69112,7 +71574,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658281792</BitOffs>
+            <BitOffs>667296320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69124,7 +71586,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658579712</BitOffs>
+            <BitOffs>667594240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69136,7 +71598,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>658877632</BitOffs>
+            <BitOffs>667892160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69148,7 +71610,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659175552</BitOffs>
+            <BitOffs>668190080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69160,7 +71622,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659473472</BitOffs>
+            <BitOffs>668488000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69172,7 +71634,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659771392</BitOffs>
+            <BitOffs>668785920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69184,7 +71646,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660069312</BitOffs>
+            <BitOffs>669083840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69196,7 +71658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660367232</BitOffs>
+            <BitOffs>669381760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69208,7 +71670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660665152</BitOffs>
+            <BitOffs>669679680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69220,7 +71682,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660963072</BitOffs>
+            <BitOffs>669977600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -69232,7 +71694,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661260992</BitOffs>
+            <BitOffs>670275520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -69244,7 +71706,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662824192</BitOffs>
+            <BitOffs>671838784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -69253,21 +71715,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662833176</BitOffs>
+            <BitOffs>671847768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -69279,7 +71731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662849408</BitOffs>
+            <BitOffs>671864000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -69288,21 +71740,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662858392</BitOffs>
+            <BitOffs>671872984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -69314,7 +71756,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662874624</BitOffs>
+            <BitOffs>671889216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -69323,21 +71765,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662883608</BitOffs>
+            <BitOffs>671898200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -69349,7 +71781,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664586240</BitOffs>
+            <BitOffs>673600768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -69358,21 +71790,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664595224</BitOffs>
+            <BitOffs>673609752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -69384,7 +71806,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664611456</BitOffs>
+            <BitOffs>673625984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -69393,21 +71815,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664620440</BitOffs>
+            <BitOffs>673634968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -69419,7 +71831,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664636672</BitOffs>
+            <BitOffs>673651200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -69428,21 +71840,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664645656</BitOffs>
+            <BitOffs>673660184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -69461,7 +71863,26 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665027512</BitOffs>
+            <BitOffs>673840568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>674042080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -69477,7 +71898,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665030080</BitOffs>
+            <BitOffs>674044672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -69497,7 +71918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671935560</BitOffs>
+            <BitOffs>680950152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -69517,26 +71938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673582472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[PMPS_PRE]^IO Outputs^bST4K4_OUT</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675229120</BitOffs>
+            <BitOffs>682597064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -69548,7 +71950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675229248</BitOffs>
+            <BitOffs>684243776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -69557,21 +71959,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675238232</BitOffs>
+            <BitOffs>684252760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -69583,7 +71975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675254464</BitOffs>
+            <BitOffs>684268992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -69592,21 +71984,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675263448</BitOffs>
+            <BitOffs>684277976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -69618,7 +72000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675279680</BitOffs>
+            <BitOffs>684294208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -69627,21 +72009,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675288664</BitOffs>
+            <BitOffs>684303192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -69653,7 +72025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675304896</BitOffs>
+            <BitOffs>684319424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -69662,21 +72034,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675313880</BitOffs>
+            <BitOffs>684328408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -69688,7 +72050,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675330112</BitOffs>
+            <BitOffs>684344640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -69697,21 +72059,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675339096</BitOffs>
+            <BitOffs>684353624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -69723,7 +72075,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675355328</BitOffs>
+            <BitOffs>684369856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -69732,21 +72084,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675364312</BitOffs>
+            <BitOffs>684378840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -69758,7 +72100,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675380544</BitOffs>
+            <BitOffs>684395072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -69767,21 +72109,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675389528</BitOffs>
+            <BitOffs>684404056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -69793,7 +72125,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675405760</BitOffs>
+            <BitOffs>684420288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -69802,21 +72134,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675414744</BitOffs>
+            <BitOffs>684429272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -69828,7 +72150,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675430976</BitOffs>
+            <BitOffs>684445504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -69837,21 +72159,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675439960</BitOffs>
+            <BitOffs>684454488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -69863,7 +72175,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675456192</BitOffs>
+            <BitOffs>684470720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -69872,21 +72184,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675465176</BitOffs>
+            <BitOffs>684479704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -69898,7 +72200,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675481408</BitOffs>
+            <BitOffs>684495936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -69907,21 +72209,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675490392</BitOffs>
+            <BitOffs>684504920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -69933,7 +72225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675506624</BitOffs>
+            <BitOffs>684521152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -69942,21 +72234,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675515608</BitOffs>
+            <BitOffs>684530136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -69968,7 +72250,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675531840</BitOffs>
+            <BitOffs>684546368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -69977,21 +72259,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675540824</BitOffs>
+            <BitOffs>684555352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -70003,7 +72275,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675557056</BitOffs>
+            <BitOffs>684571584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -70012,21 +72284,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675566040</BitOffs>
+            <BitOffs>684580568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -70038,7 +72300,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675582272</BitOffs>
+            <BitOffs>684596800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -70047,21 +72309,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675591256</BitOffs>
+            <BitOffs>684605784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -70073,7 +72325,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675607488</BitOffs>
+            <BitOffs>684622016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -70082,21 +72334,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675616472</BitOffs>
+            <BitOffs>684631000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -70108,7 +72350,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675632704</BitOffs>
+            <BitOffs>684647232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -70117,21 +72359,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675641688</BitOffs>
+            <BitOffs>684656216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -70143,7 +72375,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675657920</BitOffs>
+            <BitOffs>684672448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -70152,21 +72384,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675666904</BitOffs>
+            <BitOffs>684681432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -70178,7 +72400,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675683136</BitOffs>
+            <BitOffs>684697664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -70187,21 +72409,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675692120</BitOffs>
+            <BitOffs>684706648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -70213,7 +72425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675708352</BitOffs>
+            <BitOffs>684722880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -70222,21 +72434,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675717336</BitOffs>
+            <BitOffs>684731864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -70248,7 +72450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675733568</BitOffs>
+            <BitOffs>684748096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -70257,21 +72459,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675742552</BitOffs>
+            <BitOffs>684757080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -70283,7 +72475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675758784</BitOffs>
+            <BitOffs>684773312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -70292,21 +72484,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675767768</BitOffs>
+            <BitOffs>684782296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -70318,7 +72500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675784000</BitOffs>
+            <BitOffs>684798528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -70327,21 +72509,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675792984</BitOffs>
+            <BitOffs>684807512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -70353,7 +72525,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675809216</BitOffs>
+            <BitOffs>684823744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -70362,21 +72534,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675818200</BitOffs>
+            <BitOffs>684832728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -70388,7 +72550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675834432</BitOffs>
+            <BitOffs>684848960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -70397,21 +72559,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675843416</BitOffs>
+            <BitOffs>684857944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -70423,7 +72575,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675859648</BitOffs>
+            <BitOffs>684874176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -70432,21 +72584,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675868632</BitOffs>
+            <BitOffs>684883160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -70458,7 +72600,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675884864</BitOffs>
+            <BitOffs>684899392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -70467,21 +72609,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675893848</BitOffs>
+            <BitOffs>684908376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -70493,7 +72625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675910080</BitOffs>
+            <BitOffs>684924608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -70502,21 +72634,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675919064</BitOffs>
+            <BitOffs>684933592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -70528,7 +72650,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675935296</BitOffs>
+            <BitOffs>684949824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -70537,21 +72659,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675944280</BitOffs>
+            <BitOffs>684958808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -70563,7 +72675,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675960512</BitOffs>
+            <BitOffs>684975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -70572,21 +72684,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675969496</BitOffs>
+            <BitOffs>684984024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -70598,7 +72700,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675985728</BitOffs>
+            <BitOffs>685000256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -70607,21 +72709,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675994712</BitOffs>
+            <BitOffs>685009240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -70633,7 +72725,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676010944</BitOffs>
+            <BitOffs>685025472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -70642,21 +72734,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676019928</BitOffs>
+            <BitOffs>685034456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -70668,7 +72750,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676036160</BitOffs>
+            <BitOffs>685050688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -70677,21 +72759,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676045144</BitOffs>
+            <BitOffs>685059672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -70703,7 +72775,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676061376</BitOffs>
+            <BitOffs>685075904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -70712,21 +72784,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676070360</BitOffs>
+            <BitOffs>685084888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -70738,7 +72800,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676086592</BitOffs>
+            <BitOffs>685101120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -70747,21 +72809,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676095576</BitOffs>
+            <BitOffs>685110104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -70773,7 +72825,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676111808</BitOffs>
+            <BitOffs>685126336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -70782,21 +72834,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676120792</BitOffs>
+            <BitOffs>685135320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -70808,7 +72850,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676137024</BitOffs>
+            <BitOffs>685151552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -70817,21 +72859,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676146008</BitOffs>
+            <BitOffs>685160536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -70843,7 +72875,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676162240</BitOffs>
+            <BitOffs>685176768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -70852,21 +72884,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676171224</BitOffs>
+            <BitOffs>685185752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -70878,7 +72900,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676187456</BitOffs>
+            <BitOffs>685201984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -70887,21 +72909,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676196440</BitOffs>
+            <BitOffs>685210968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -70913,7 +72925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676212672</BitOffs>
+            <BitOffs>685227200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -70922,21 +72934,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676221656</BitOffs>
+            <BitOffs>685236184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -70948,7 +72950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676237888</BitOffs>
+            <BitOffs>685252416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -70957,21 +72959,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676246872</BitOffs>
+            <BitOffs>685261400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -70983,7 +72975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676263104</BitOffs>
+            <BitOffs>685277632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -70992,21 +72984,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676272088</BitOffs>
+            <BitOffs>685286616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -71018,7 +73000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676288320</BitOffs>
+            <BitOffs>685302848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -71027,21 +73009,11 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676297304</BitOffs>
+            <BitOffs>685311832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -71053,7 +73025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676313536</BitOffs>
+            <BitOffs>685328064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -71062,28 +73034,18 @@ Digital outputs</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676322520</BitOffs>
+            <BitOffs>685337048</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85524480</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -77334,7 +79296,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
             <BitSize>621827200</BitSize>
-            <BaseType Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
+            <BaseType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -77346,7 +79308,7 @@ Digital outputs</Comment>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
             <Comment> Pointer to current test suite being called </Comment>
             <BitSize>32</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -77410,7 +79372,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
             <BitSize>32000</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>1000</Elements>
@@ -77452,7 +79414,7 @@ Digital outputs</Comment>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
             <Comment> Buffered ADS message queue for output to the error list </Comment>
             <BitSize>8320864</BitSize>
-            <BaseType Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
+            <BaseType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -77608,9 +79570,80 @@ Digital outputs</Comment>
             <BitOffs>639714560</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>639714848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>639714856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <BitOffs>639714864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL2K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>639714872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Physics.fbScatteringFactors</Name>
+            <BitSize>575872</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>639714880</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
-            <BitSize>981568</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_REF</BaseType>
+            <BitSize>1927552</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_REF</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77625,12 +79658,22 @@ Digital outputs</Comment>
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
               </Property>
             </Properties>
-            <BitOffs>639765952</BitOffs>
+            <BitOffs>640343872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>642272416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
-            <BitSize>1575488</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
+            <BitSize>2514240</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77654,7 +79697,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw := TIIB[IM2K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>640749120</BitOffs>
+            <BitOffs>642272448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fStartupVelo</Name>
@@ -77663,12 +79706,12 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>642324608</BitOffs>
+            <BitOffs>644786688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
-            <BitSize>1575488</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
+            <BitSize>2514240</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77692,7 +79735,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>642324672</BitOffs>
+            <BitOffs>644786752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fStartupVelo</Name>
@@ -77701,12 +79744,12 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>643900160</BitOffs>
+            <BitOffs>647300992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
-            <BitSize>1575488</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
+            <BitSize>2514240</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77730,7 +79773,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM4K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>643900224</BitOffs>
+            <BitOffs>647301056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fStartupVelo</Name>
@@ -77739,12 +79782,12 @@ Digital outputs</Comment>
             <Default>
               <Value>15</Value>
             </Default>
-            <BitOffs>645475712</BitOffs>
+            <BitOffs>649815296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
-            <BitSize>1575488</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
+            <BitSize>2514240</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77768,7 +79811,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM5K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>645475776</BitOffs>
+            <BitOffs>649815360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fStartupVelo</Name>
@@ -77777,12 +79820,12 @@ Digital outputs</Comment>
             <Default>
               <Value>12</Value>
             </Default>
-            <BitOffs>647051264</BitOffs>
+            <BitOffs>652329600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
-            <BitSize>1575488</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_PPM</BaseType>
+            <BitSize>2514240</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77806,7 +79849,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM6K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>647051328</BitOffs>
+            <BitOffs>652329664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fStartupVelo</Name>
@@ -77815,72 +79858,12 @@ Digital outputs</Comment>
             <Default>
               <Value>13</Value>
             </Default>
-            <BitOffs>648626816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>648627360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <BitOffs>648627368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <BitOffs>648627376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL2K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>648627384</BitOffs>
+            <BitOffs>654843904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
-            <BitSize>995584</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_LIC</BaseType>
+            <BitSize>1933696</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_LIC</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77890,28 +79873,18 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>648627392</BitOffs>
+            <BitOffs>654844160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>649622976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>649625376</BitOffs>
+            <BitOffs>656777856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
-            <BitSize>1308672</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_WFS</BaseType>
+            <BitSize>2239488</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_WFS</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77932,13 +79905,13 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649625408</BitOffs>
+            <BitOffs>656779968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>650934080</BitOffs>
+            <BitOffs>659019456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -77948,12 +79921,12 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>650935840</BitOffs>
+            <BitOffs>659021216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
-            <BitSize>1308672</BitSize>
-            <BaseType Namespace="lcls2_cc_lib">FB_WFS</BaseType>
+            <BitSize>2239488</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">FB_WFS</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -77974,13 +79947,13 @@ Digital outputs</Comment>
                               .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>650935872</BitOffs>
+            <BitOffs>659021248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stSiBP</Name>
             <BitSize>1760</BitSize>
             <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <BitOffs>652244544</BitOffs>
+            <BitOffs>661260736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -77990,7 +79963,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>652246944</BitOffs>
+            <BitOffs>661263136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -78005,7 +79978,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>652246976</BitOffs>
+            <BitOffs>661263168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -78016,7 +79989,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>653590144</BitOffs>
+            <BitOffs>662606336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -78026,7 +79999,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>653593216</BitOffs>
+            <BitOffs>662609408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bTest</Name>
@@ -78035,13 +80008,13 @@ Digital outputs</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>653593568</BitOffs>
+            <BitOffs>662609760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>653593576</BitOffs>
+            <BitOffs>662609768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -78056,7 +80029,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>653593600</BitOffs>
+            <BitOffs>662609792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -78067,7 +80040,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>654936768</BitOffs>
+            <BitOffs>663952960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
@@ -78077,7 +80050,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939840</BitOffs>
+            <BitOffs>663956032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -78087,7 +80060,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939872</BitOffs>
+            <BitOffs>663956064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -78097,7 +80070,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939904</BitOffs>
+            <BitOffs>663956096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -78107,7 +80080,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>654939936</BitOffs>
+            <BitOffs>663956128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -78126,13 +80099,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>654940224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL1HighCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>655049648</BitOffs>
+            <BitOffs>663956416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -78154,13 +80121,13 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>655049664</BitOffs>
+            <BitOffs>664067264</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.nTL1LowCycles</Name>
+            <Name>PRG_SP1K4.nTL1HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>656372768</BitOffs>
+            <BitOffs>665390384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -78182,97 +80149,103 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>656372800</BitOffs>
+            <BitOffs>665390400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657684480</BitOffs>
+            <BitOffs>666699008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>657982400</BitOffs>
+            <BitOffs>666996928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658280320</BitOffs>
+            <BitOffs>667294848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658578240</BitOffs>
+            <BitOffs>667592768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>658876160</BitOffs>
+            <BitOffs>667890688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659174080</BitOffs>
+            <BitOffs>668188608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659472000</BitOffs>
+            <BitOffs>668486528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>659769920</BitOffs>
+            <BitOffs>668784448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660067840</BitOffs>
+            <BitOffs>669082368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660365760</BitOffs>
+            <BitOffs>669380288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660663680</BitOffs>
+            <BitOffs>669678208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>660961600</BitOffs>
+            <BitOffs>669976128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>661259520</BitOffs>
+            <BitOffs>670274048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL1LowCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>670571968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>661557440</BitOffs>
+            <BitOffs>670572000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>661557456</BitOffs>
+            <BitOffs>670572016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -78281,7 +80254,7 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>661557472</BitOffs>
+            <BitOffs>670572032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -78290,29 +80263,14 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>661557488</BitOffs>
+            <BitOffs>670572048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>661557496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.fbZPStates</Name>
-            <Comment>/ZP states start</Comment>
-            <BitSize>1506432</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>661557504</BitOffs>
+            <BitOffs>670572056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -78327,7 +80285,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063936</BitOffs>
+            <BitOffs>670572064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -78342,43 +80300,28 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063952</BitOffs>
+            <BitOffs>670572080</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.att_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Name>PRG_SP1K4.fbZPStates</Name>
+            <Comment>/ZP states start</Comment>
+            <BitSize>1506432</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: SP1K4:ATT:STATE:SET
-        io: io
+        pv: SP1K4:FZP
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663063968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>663063984</BitOffs>
+            <BitOffs>670572096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>663064000</BitOffs>
+            <BitOffs>672078528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -78402,7 +80345,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>663151808</BitOffs>
+            <BitOffs>672166336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -78412,7 +80355,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663155456</BitOffs>
+            <BitOffs>672169984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -78422,7 +80365,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663210176</BitOffs>
+            <BitOffs>672224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -78432,7 +80375,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>663264896</BitOffs>
+            <BitOffs>672279424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -78447,13 +80390,61 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663319616</BitOffs>
+            <BitOffs>672334144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673840512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673840528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>673840544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>673840552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>673840560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>664825984</BitOffs>
+            <BitOffs>673840576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -78477,7 +80468,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>664913792</BitOffs>
+            <BitOffs>673928384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -78487,7 +80478,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>664917440</BitOffs>
+            <BitOffs>673932032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -78497,43 +80488,36 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>664972160</BitOffs>
+            <BitOffs>673986752</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>665027488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>665027496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>665027504</BitOffs>
+            <Name>GVL_TcGVL.ePF1K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>674042096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>665027520</BitOffs>
+            <BitOffs>674042112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>665165888</BitOffs>
+            <BitOffs>674180480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>665196736</BitOffs>
+            <BitOffs>674211328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -78552,7 +80536,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>670988352</BitOffs>
+            <BitOffs>680002944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -78571,7 +80555,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671461824</BitOffs>
+            <BitOffs>680476416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -78601,7 +80585,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>671935296</BitOffs>
+            <BitOffs>680949888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -78631,67 +80615,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673582208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675229136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675229144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675229152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>675229168</BitOffs>
+            <BitOffs>682596800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -78720,7 +80644,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675229184</BitOffs>
+            <BitOffs>684243712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -78732,7 +80656,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675254400</BitOffs>
+            <BitOffs>684268928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -78743,7 +80667,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675279616</BitOffs>
+            <BitOffs>684294144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -78754,7 +80678,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675304832</BitOffs>
+            <BitOffs>684319360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -78765,7 +80689,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675330048</BitOffs>
+            <BitOffs>684344576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -78776,7 +80700,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675355264</BitOffs>
+            <BitOffs>684369792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -78787,7 +80711,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675380480</BitOffs>
+            <BitOffs>684395008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -78798,7 +80722,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675405696</BitOffs>
+            <BitOffs>684420224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -78827,7 +80751,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675430912</BitOffs>
+            <BitOffs>684445440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -78855,7 +80779,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675456128</BitOffs>
+            <BitOffs>684470656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -78882,7 +80806,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675481344</BitOffs>
+            <BitOffs>684495872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -78909,7 +80833,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675506560</BitOffs>
+            <BitOffs>684521088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -78936,7 +80860,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675531776</BitOffs>
+            <BitOffs>684546304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -78948,7 +80872,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675556992</BitOffs>
+            <BitOffs>684571520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -78977,7 +80901,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675582208</BitOffs>
+            <BitOffs>684596736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -79006,7 +80930,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675607424</BitOffs>
+            <BitOffs>684621952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -79035,7 +80959,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675632640</BitOffs>
+            <BitOffs>684647168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -79064,7 +80988,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675657856</BitOffs>
+            <BitOffs>684672384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -79089,7 +81013,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675683072</BitOffs>
+            <BitOffs>684697600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -79118,7 +81042,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675708288</BitOffs>
+            <BitOffs>684722816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -79147,7 +81071,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675733504</BitOffs>
+            <BitOffs>684748032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -79172,7 +81096,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675758720</BitOffs>
+            <BitOffs>684773248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -79200,7 +81124,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675783936</BitOffs>
+            <BitOffs>684798464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -79227,7 +81151,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675809152</BitOffs>
+            <BitOffs>684823680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -79254,7 +81178,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675834368</BitOffs>
+            <BitOffs>684848896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -79281,7 +81205,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675859584</BitOffs>
+            <BitOffs>684874112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -79310,7 +81234,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675884800</BitOffs>
+            <BitOffs>684899328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -79339,7 +81263,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675910016</BitOffs>
+            <BitOffs>684924544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -79364,7 +81288,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675935232</BitOffs>
+            <BitOffs>684949760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -79393,7 +81317,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675960448</BitOffs>
+            <BitOffs>684974976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -79418,7 +81342,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>675985664</BitOffs>
+            <BitOffs>685000192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -79455,7 +81379,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676010880</BitOffs>
+            <BitOffs>685025408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -79500,7 +81424,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676036096</BitOffs>
+            <BitOffs>685050624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -79541,7 +81465,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676061312</BitOffs>
+            <BitOffs>685075840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -79582,7 +81506,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676086528</BitOffs>
+            <BitOffs>685101056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -79623,7 +81547,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676111744</BitOffs>
+            <BitOffs>685126272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -79664,7 +81588,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676136960</BitOffs>
+            <BitOffs>685151488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -79705,7 +81629,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676162176</BitOffs>
+            <BitOffs>685176704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -79746,7 +81670,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676187392</BitOffs>
+            <BitOffs>685201920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -79787,7 +81711,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676212608</BitOffs>
+            <BitOffs>685227136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -79823,7 +81747,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676237824</BitOffs>
+            <BitOffs>685252352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -79859,7 +81783,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676263040</BitOffs>
+            <BitOffs>685277568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -79895,7 +81819,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676288256</BitOffs>
+            <BitOffs>685302784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -79940,7 +81864,48 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676313472</BitOffs>
+            <BitOffs>685328000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcGVL.ePF2K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -79970,7 +81935,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338688</BitOffs>
+            <BitOffs>685353248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -80000,7 +81965,37 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338752</BitOffs>
+            <BitOffs>685353312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685353392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -80014,7 +82009,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338816</BitOffs>
+            <BitOffs>685353408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -80028,7 +82023,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338848</BitOffs>
+            <BitOffs>685353440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -80042,7 +82037,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338880</BitOffs>
+            <BitOffs>685353472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -80056,7 +82051,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676338912</BitOffs>
+            <BitOffs>685353504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -80070,7 +82065,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676340960</BitOffs>
+            <BitOffs>685355552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -80088,7 +82083,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676340992</BitOffs>
+            <BitOffs>685355584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -80102,7 +82097,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342016</BitOffs>
+            <BitOffs>685356608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -80123,7 +82118,30 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676342048</BitOffs>
+            <BitOffs>685356640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685399968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -80192,7 +82210,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355424</BitOffs>
+            <BitOffs>685408992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -80261,7 +82279,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355552</BitOffs>
+            <BitOffs>685409120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -80330,7 +82348,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355680</BitOffs>
+            <BitOffs>685409248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -80399,7 +82417,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355808</BitOffs>
+            <BitOffs>685409376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -80468,7 +82486,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676355936</BitOffs>
+            <BitOffs>685409504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -80537,37 +82555,14 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>676356064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>676386400</BitOffs>
+            <BitOffs>685409632</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>85524480</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -80622,6 +82617,9 @@ Digital outputs</Comment>
       <Deployment/>
       <EventClasses>
         <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
+        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -80636,9 +82634,6 @@ Digital outputs</Comment>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
-        <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -80647,15 +82642,15 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-18T12:08:19</Value>
+          <Value>2023-08-28T15:53:14</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>856064</Value>
+          <Value>1069056</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>84131840</Value>
+          <Value>85258240</Value>
         </Property>
       </Properties>
     </Module>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -82646,7 +82646,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-09-06T09:56:11</Value>
+          <Value>2023-09-06T10:07:28</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{92FA8D93-60CA-5735-A4C9-15F0C8DAF7B8}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CA8C4562-F4F0-D1F7-4A88-D27C5261EE31}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -1437,9 +1437,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-      </Method>
-      <Method>
         <Name>ExtendName</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -1495,19 +1492,7 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Name>Clear</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1554,6 +1539,21 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>32</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1773,7 +1773,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1974,9 +1974,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2137,6 +2134,9 @@
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -4066,6 +4066,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -4547,69 +4610,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4640,15 +4640,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -4933,12 +4933,91 @@
         <BitOffs>8224288</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -4987,53 +5066,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5221,44 +5253,12 @@
         </Properties>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -5569,6 +5569,14 @@
         <BitOffs>4240224</BitOffs>
       </SubItem>
       <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5608,46 +5616,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5814,7 +5782,39 @@
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6158,6 +6158,105 @@
         <BitOffs>12687680</BitOffs>
       </SubItem>
       <Method>
+        <Name>AssertArrayEquals_DINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6403,18 +6502,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6569,115 +6668,6 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6813,21 +6803,6 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7202,11 +7177,26 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>128</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7220,8 +7210,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7285,6 +7275,16 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7299,42 +7299,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7371,6 +7335,210 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>7840</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7577,11 +7745,17 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7590,6 +7764,16 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -7842,37 +8026,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertEquals_REAL</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -7941,34 +8094,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LTIME</Name>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8133,340 +8270,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>7840</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -8566,6 +8369,204 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Parameter>
           <Name>Condition</Name>
@@ -8596,11 +8597,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -8614,8 +8615,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9122,19 +9123,19 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>128</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9182,6 +9183,37 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9294,93 +9326,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -9480,11 +9425,41 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9498,8 +9473,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9510,12 +9485,6 @@
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9582,6 +9551,37 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -12965,6 +12965,14 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13017,6 +13025,20 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13030,25 +13052,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13073,9 +13085,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13095,22 +13104,36 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13137,20 +13160,6 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13194,21 +13203,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13260,35 +13254,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>ResetDocument</Name>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13301,20 +13267,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
+        <Name>AddRawObject</Name>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -13324,11 +13279,21 @@
             </Property>
           </Properties>
         </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13337,6 +13302,21 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13360,7 +13340,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
+        <Name>AddKeyDateTime</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13371,6 +13351,11 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13383,10 +13368,25 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>AddReal</Name>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13705,22 +13705,11 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13779,41 +13768,14 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>7680</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -13851,14 +13813,52 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>7680</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14126,22 +14126,12 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14228,19 +14218,14 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14284,32 +14269,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14332,16 +14291,6 @@
         <Parameter>
           <Name>reserve</Name>
           <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14377,34 +14326,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14444,6 +14382,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14459,7 +14407,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14469,8 +14417,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14535,16 +14483,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14581,7 +14519,59 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14591,8 +14581,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14611,9 +14601,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14626,6 +14616,16 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14636,13 +14636,18 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14714,36 +14719,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14754,24 +14729,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -14822,9 +14792,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14832,7 +14802,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -14930,7 +14900,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14939,15 +14909,9 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14968,21 +14932,6 @@
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15027,6 +14976,38 @@
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15062,39 +15043,44 @@
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15128,34 +15114,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15218,9 +15179,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15228,7 +15189,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15237,26 +15208,9 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15288,9 +15242,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15390,14 +15344,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15480,58 +15426,16 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
@@ -15586,6 +15490,42 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15612,12 +15552,22 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15706,9 +15656,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15726,7 +15676,22 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -15758,17 +15723,28 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15783,9 +15759,134 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -15823,7 +15924,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15833,108 +15934,7 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18237,18 +18237,19 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18264,19 +18265,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -18460,88 +18460,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type RpcDirection="in">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -18597,6 +18515,88 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -18795,6 +18795,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Parameter>
           <Name>Name</Name>
@@ -18813,22 +18816,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
         <ReturnType RpcDirection="out">UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -18844,9 +18831,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -18867,10 +18865,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -19230,6 +19230,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -19241,14 +19246,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -19264,9 +19261,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -19303,14 +19300,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -19595,35 +19595,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640288</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19671,9 +19688,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19870,47 +19905,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -20056,37 +20056,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480224</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20094,9 +20064,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -20283,7 +20251,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20843,18 +20843,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -21585,6 +21585,666 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -21889,514 +22549,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -22940,6 +23092,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23429,50 +23596,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -23537,42 +23678,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -23581,22 +23698,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -23604,124 +23706,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -23992,18 +23976,34 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -24376,6 +24376,32 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>WriteLog</Name>
         <Parameter>
           <Name>MsgCtrlMask</Name>
@@ -24409,32 +24435,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -30211,37 +30211,6 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -30286,6 +30255,37 @@ External Setpoint Generation:
 	</Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -30901,28 +30901,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -31183,33 +31183,29 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>391872</BitOffs>
       </SubItem>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
+        <Name>RemoveRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81600</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31333,6 +31329,31 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -31372,40 +31393,19 @@ These features efficiently address the addition, removal, and verification of be
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81600</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -42863,13 +42863,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -42890,7 +42890,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -49687,19 +49687,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Motion</Name>
-      </Action>
-      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_CalculatePositions</Name>
+        <Name>ACT_Motion</Name>
       </Action>
       <Action>
         <Name>ACT_BLOCK</Name>
+      </Action>
+      <Action>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -50449,10 +50449,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Properties>
         <Property>
@@ -50731,10 +50731,10 @@ Digital outputs</Comment>
         <BitOffs>253760</BitOffs>
       </SubItem>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Properties>
         <Property>
@@ -51122,13 +51122,13 @@ Digital outputs</Comment>
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -51401,10 +51401,10 @@ Digital outputs</Comment>
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -54742,47 +54742,6 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -54830,6 +54789,21 @@ Digital outputs</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
@@ -54932,19 +54906,45 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -55651,6 +55651,30 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -55697,30 +55721,6 @@ Digital outputs</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -55856,9 +55856,9 @@ Digital outputs</Comment>
         <BitOffs>64</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -55872,29 +55872,27 @@ Digital outputs</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -55975,45 +55973,6 @@ Digital outputs</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -56147,6 +56106,47 @@ Digital outputs</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -56842,46 +56842,12 @@ Digital outputs</Comment>
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>32</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -57008,6 +56974,40 @@ Digital outputs</Comment>
               <Value>__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -59758,7 +59758,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86835200</ByteSize>
+          <ByteSize>86769664</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -70278,7 +70278,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86835200</ByteSize>
+          <ByteSize>86769664</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -73045,7 +73045,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86835200</ByteSize>
+          <ByteSize>86769664</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -82562,7 +82562,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86835200</ByteSize>
+          <ByteSize>86769664</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -82642,15 +82642,15 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-28T15:53:14</Value>
+          <Value>2023-08-28T16:46:27</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1069056</Value>
+          <Value>991232</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>85258240</Value>
+          <Value>85180416</Value>
         </Property>
       </Properties>
     </Module>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CA8C4562-F4F0-D1F7-4A88-D27C5261EE31}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{20F1ABBE-454A-D8D7-FD93-9D844EEFED26}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -1437,6 +1437,9 @@
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+      </Method>
+      <Method>
         <Name>ExtendName</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -1492,7 +1495,19 @@
         </Local>
       </Method>
       <Method>
-        <Name>Clear</Name>
+        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1539,21 +1554,6 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>32</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1773,7 +1773,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1974,6 +1974,9 @@
         </Local>
       </Method>
       <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2134,9 +2137,6 @@
             </Property>
           </Properties>
         </Local>
-      </Method>
-      <Method>
-        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -4066,69 +4066,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -4610,6 +4547,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4640,15 +4640,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetFailed</Name>
-      </Method>
-      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -4933,91 +4933,12 @@
         <BitOffs>8224288</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>96</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -5066,6 +4987,53 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5253,12 +5221,44 @@
         </Properties>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>96</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -5569,14 +5569,6 @@
         <BitOffs>4240224</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5616,6 +5608,46 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5782,39 +5814,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6158,105 +6158,6 @@
         <BitOffs>12687680</BitOffs>
       </SubItem>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6502,18 +6403,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_UINT</Name>
+        <Name>AssertEquals_STRING</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6668,6 +6569,115 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6803,6 +6813,21 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7177,26 +7202,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>128</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
+        <Name>AssertArrayEquals_DINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7210,8 +7220,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -7275,16 +7285,6 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7299,6 +7299,42 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7335,210 +7371,6 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>7840</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7745,17 +7577,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertTrue</Name>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7764,16 +7590,6 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -8026,6 +7842,37 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertEquals_REAL</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -8094,18 +7941,34 @@
         </Local>
       </Method>
       <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>AssertEquals_LTIME</Name>
         <Parameter>
-          <Name>TestName</Name>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8270,6 +8133,340 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>7840</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UDINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -8369,204 +8566,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_STRING</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertFalse</Name>
         <Parameter>
           <Name>Condition</Name>
@@ -8597,11 +8596,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
+        <Name>AssertArrayEquals_LINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -8615,8 +8614,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9123,19 +9122,19 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>128</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9183,37 +9182,6 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LTIME</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9326,6 +9294,93 @@
         </Local>
       </Method>
       <Method>
+        <Name>FindTestSuiteInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -9425,41 +9480,11 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_LREAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9473,8 +9498,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>32</BitSize>
           <Properties>
             <Property>
@@ -9485,6 +9510,12 @@
               <Value>1</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9551,37 +9582,6 @@
           <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -12965,14 +12965,6 @@
         </Default>
       </SubItem>
       <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13025,20 +13017,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13052,15 +13030,25 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13085,6 +13073,9 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>ResetDocument</Name>
+      </Method>
+      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13104,36 +13095,22 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>StartObject</Name>
       </Method>
       <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13160,6 +13137,20 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13203,6 +13194,21 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13254,7 +13260,35 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
+        <Name>CopyDocument</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13267,9 +13301,20 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddRawObject</Name>
+        <Name>AddFileTime</Name>
         <Parameter>
-          <Name>rawJson</Name>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -13279,21 +13324,11 @@
             </Property>
           </Properties>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13302,21 +13337,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13340,7 +13360,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyDateTime</Name>
+        <Name>AddKeyNull</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13351,11 +13371,6 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13368,25 +13383,10 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>AddReal</Name>
         <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13705,11 +13705,22 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>Execute</Name>
-      </Action>
-      <Action>
         <Name>EvaluateOutput</Name>
       </Action>
+      <Action>
+        <Name>Execute</Name>
+      </Action>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
+      </Method>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13768,51 +13779,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
-        <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>7680</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IdxCheckIn</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>OK</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Reset</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stFF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>7680</BitSize>
-        </Local>
-        <Local>
-          <Name>BeamPermitted</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Register</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13850,15 +13816,49 @@
         </Properties>
       </Method>
       <Method>
-        <Name>EvaluateVetos</Name>
+        <Name>IdxCheckIn</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>OK</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Reset</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stFF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>7680</BitSize>
+        </Local>
+        <Local>
+          <Name>BeamPermitted</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
         <Properties>
           <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
+            <Name>no_check</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
+        <Parameter>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>7680</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -14126,12 +14126,22 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14218,14 +14228,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name>PushbackFileTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14269,6 +14284,32 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14291,6 +14332,16 @@
         <Parameter>
           <Name>reserve</Name>
           <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14326,23 +14377,34 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>PushbackUintValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ParseDocument</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14382,16 +14444,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14407,7 +14459,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
+        <Name>PushbackBoolValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14417,8 +14469,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14483,6 +14535,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14519,59 +14581,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddJsonMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint</Name>
+        <Name>PushbackUint64Value</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14581,8 +14591,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14601,9 +14611,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14616,16 +14626,6 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14636,18 +14636,13 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14719,6 +14714,36 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>SetDcTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetArray</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14729,19 +14754,24 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetStringLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -14792,9 +14822,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsBase64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14802,7 +14832,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
+        <Name>IsTrue</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -14900,7 +14930,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetArray</Name>
+        <Name>AddObjectMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14909,9 +14939,15 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14932,6 +14968,21 @@
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14976,38 +15027,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15043,32 +15062,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsHexBinary</Name>
+        <Name>Swap</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -15076,11 +15070,31 @@
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsHexBinary</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15114,9 +15128,34 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15179,9 +15218,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15189,17 +15228,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackFileTimeValue</Name>
+        <Name>AddJsonMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15208,9 +15237,26 @@
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -15242,9 +15288,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15344,6 +15390,14 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15426,16 +15480,58 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
+        <Name>SetUint</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>dp</Name>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
@@ -15490,42 +15586,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackBoolValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -15552,22 +15612,12 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15656,9 +15706,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15676,22 +15726,7 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
+          <Name>value</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>32</BitSize>
           <Properties>
@@ -15723,28 +15758,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArrayValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -15759,134 +15783,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackDoubleValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
+        <Name>GetDocument</Name>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -15924,7 +15823,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
+        <Name>PushbackDoubleValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -15934,7 +15833,108 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>length</Name>
           <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -17625,7 +17625,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Name>
       <BitSize>8</BitSize>
       <BaseType>BYTE</BaseType>
       <EnumInfo>
@@ -17804,7 +17804,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Name>
       <BitSize>6192</BitSize>
       <SubItem>
         <Name>TestName</Name>
@@ -17838,7 +17838,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>FailureType</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
         <BitSize>8</BitSize>
         <BitOffs>6160</BitOffs>
       </SubItem>
@@ -17850,7 +17850,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Name>
       <BitSize>621296</BitSize>
       <SubItem>
         <Name>Name</Name>
@@ -17880,7 +17880,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestCaseResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -17890,7 +17890,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Name>
       <BitSize>621296064</BitSize>
       <SubItem>
         <Name>NumberOfTestSuites</Name>
@@ -17922,7 +17922,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestSuiteResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -17933,7 +17933,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -17943,7 +17943,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestSuiteResults</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
     </DataType>
@@ -17963,13 +17963,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Name>
       <Comment> This function block holds results of the complete test run, i.e. results for all test suites </Comment>
       <BitSize>621296256</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Implements>
       <SubItem>
         <Name>TestSuiteResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Type>
         <Comment> Test results </Comment>
         <BitSize>621296064</BitSize>
         <BitOffs>64</BitOffs>
@@ -18012,7 +18012,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestSuiteResults</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Properties>
@@ -18023,7 +18023,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -18046,17 +18046,17 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Name>
       <Comment>
     This function block reports the results from the tests using the built-in ADSLOGSTR functionality
     provided by the Tc2_System library. This sends the result using ADS, which is consumed by the "Error List"
     of Visual Studio (which can print Errors, Warnings and Messages).
 </Comment>
       <BitSize>224</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
@@ -18090,7 +18090,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>TcUnitTestResults</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
@@ -18182,7 +18182,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BaseType PointerTo="1">BYTE</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Name>
       <Comment>
     This functionblock can open, close, read, write and delete files on the local filesystem
 </Comment>
@@ -18237,6 +18237,33 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>Open</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Delete</Name>
+        <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a forward slash (/) </Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Write</Name>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -18253,33 +18280,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
-      <Method>
-        <Name>Delete</Name>
-        <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a forward slash (/) </Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Open</Name>
-        <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -18288,7 +18288,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Name>
       <BitSize>8</BitSize>
       <BaseType>BYTE</BaseType>
       <EnumInfo>
@@ -18309,7 +18309,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Name>
       <Comment>
     This functionblock acts as a stream buffer for use with FB_XmlControl
 </Comment>
@@ -18354,7 +18354,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Parameter>
           <Name>XmlError</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -18460,6 +18460,88 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Copy</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -18486,7 +18568,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Parameter>
           <Name>XmlError</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -18516,88 +18598,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>32</BitSize>
         </Local>
       </Method>
-      <Method>
-        <Name>Clear</Name>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type RpcDirection="in">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -18606,7 +18606,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Name>
       <Comment>
     Organizes parsing and composing of XML data. Data can be treated as STRING or char array.
     Buffer size of file can be set via GVL_Param_TcUnit (xUnitBufferSize)
@@ -18614,13 +18614,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>5696</BitSize>
       <SubItem>
         <Name>XmlBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>32</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TagListBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>160</BitOffs>
       </SubItem>
@@ -18632,7 +18632,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TagListSeekBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>2336</BitOffs>
       </SubItem>
@@ -18644,7 +18644,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TagBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>3136</BitOffs>
       </SubItem>
@@ -18795,9 +18795,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ToStartBuffer</Name>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Parameter>
           <Name>Name</Name>
@@ -18816,6 +18813,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
         <ReturnType RpcDirection="out">UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -18831,20 +18844,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Parameter>
-          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -18865,12 +18867,10 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>ClearBuffer</Name>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
       </Method>
       <Properties>
         <Property>
@@ -18880,15 +18880,15 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Name>
       <Comment>
     Publishes test results into an xUnit compatible Xml file
 </Comment>
       <BitSize>530304</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
         <Comment> Dependancy Injection via FB_Init</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
@@ -18905,13 +18905,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>File</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Type>
         <BitSize>96</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Xml</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Type>
         <BitSize>5696</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
@@ -18955,7 +18955,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>UnitTestResults</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
@@ -18997,7 +18997,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</Name>
       <Comment>
     This function block is responsible for holding track of the tests and executing them.
 </Comment>
@@ -19014,14 +19014,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Type>
         <Comment> Test result information </Comment>
         <BitSize>621296256</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsTestResultLogger</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Type>
         <Comment> Prints the results to ADS so that Visual Studio can display the results.
        This test result formatter can be replaced with something else than ADS </Comment>
         <BitSize>224</BitSize>
@@ -19034,7 +19034,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestResultLogger</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
         <BitSize>32</BitSize>
         <BitOffs>621296544</BitOffs>
       </SubItem>
@@ -19048,7 +19048,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>xUnitXmlPublisher</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Type>
         <Comment> Publishes a xUnit compatible XML file </Comment>
         <BitSize>530304</BitSize>
         <BitOffs>621296608</BitOffs>
@@ -19060,7 +19060,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>XmlTestResultPublisher</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
         <BitSize>32</BitSize>
         <BitOffs>621826912</BitOffs>
       </SubItem>
@@ -19161,7 +19161,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
 </Comment>
@@ -19216,23 +19216,18 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertionType</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
         <Comment> Assertion type for the first assertion in this test</Comment>
         <BitSize>8</BitSize>
         <BitOffs>4184</BitOffs>
       </SubItem>
       <Method>
         <Name>GetAssertionType</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFailed</Name>
-      </Method>
-      <Method>
-        <Name>GetTestOrder</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetName</Name>
@@ -19248,6 +19243,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetTestOrder</Name>
         <Parameter>
           <Name>OrderNumber</Name>
@@ -19261,9 +19264,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -19290,7 +19293,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetAssertionType</Name>
         <Parameter>
           <Name>AssertType</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
           <BitSize>8</BitSize>
         </Parameter>
       </Method>
@@ -19300,17 +19303,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
+        <Name>GetTestOrder</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -19335,7 +19335,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Name>
       <BitSize>4096</BitSize>
       <SubItem>
         <Name>boolExpectedOrActual</Name>
@@ -19477,17 +19477,17 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Name>
       <BitSize>12288</BitSize>
       <SubItem>
         <Name>Expected</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>4096</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Actual</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>4096</BitSize>
         <BitOffs>4096</BitOffs>
       </SubItem>
@@ -19505,11 +19505,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Name>
       <BitSize>12352</BitSize>
       <SubItem>
         <Name>AssertResult</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
         <BitSize>12288</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -19529,7 +19529,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which asserts that have been made. The reason we need to
     keep track of these is because if the user does the same assert twice (because of running a test suite over several
@@ -19543,7 +19543,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>24640320</BitSize>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19571,7 +19571,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertResultInstances</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19595,52 +19595,35 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640288</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19688,27 +19671,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
+        <Name>GetDetectionCountThisCycle</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -19905,12 +19870,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -19920,7 +19920,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Name>
       <BitSize>4224</BitSize>
       <SubItem>
         <Name>ExpectedsSize</Name>
@@ -19964,11 +19964,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
       <BitSize>4256</BitSize>
       <SubItem>
         <Name>AssertArrayResult</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
         <BitSize>4224</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -19988,7 +19988,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which array-asserts that have been made.
     The reason we need to keep track of these is because if the user does the same assert twice
@@ -20004,7 +20004,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>8480256</BitSize>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -20032,7 +20032,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertArrayResultInstances</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -20056,7 +20056,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480224</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20064,7 +20094,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -20251,39 +20283,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -20331,7 +20331,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -20359,7 +20359,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
       <Comment>
     This function block is responsible for making sure that the asserted test instance path and test message are not
     loo long. The total printed message can not be more than 253 characters long.
@@ -20457,14 +20457,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Name>
       <Comment>
     This function block is responsible for printing the results of the assertions using the built-in
     ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
     is consumed by the error list of Visual Studio.
 </Comment>
       <BitSize>64</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Implements>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -20489,7 +20489,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Local>
           <Name>AdjustAssertFailureMessageToMax253CharLength</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
           <BitSize>11584</BitSize>
         </Local>
         <Local>
@@ -20526,7 +20526,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</Name>
       <Comment> This function block is responsible for holding the internal state of the test suite.
    Every test suite can have one or more tests, and every test can do one or more asserts.
    It's also responsible for providing all the assert-methods for asserting different data types.
@@ -20568,7 +20568,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>Tests</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_Test</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -20602,19 +20602,19 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Type>
         <BitSize>24640320</BitSize>
         <BitOffs>431040</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
         <BitSize>8480256</BitSize>
         <BitOffs>25071360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsAssertMessageFormatter</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Type>
         <Comment> Prints the failed asserts to ADS so that Visual Studio can display the assert message.
        This assert formatter can be replaced with something else than ADS </Comment>
         <BitSize>64</BitSize>
@@ -20622,7 +20622,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertMessageFormatter</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Type>
         <BitSize>32</BitSize>
         <BitOffs>33551680</BitOffs>
       </SubItem>
@@ -20843,18 +20843,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -20931,7 +20931,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestByPosition</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_Test</ReturnType>
         <ReturnBitSize>4192</ReturnBitSize>
         <Parameter>
           <Name>Position</Name>
@@ -21585,666 +21585,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertFalse</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>AssertEquals</Name>
         <Parameter>
           <Name>Expected</Name>
@@ -22549,6 +21889,514 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>AssertFalse</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LWORD</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -23092,21 +22940,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFinished</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23596,24 +23429,50 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AssertEquals_DWORD</Name>
         <Parameter>
-          <Name>TestName</Name>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -23678,18 +23537,42 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertArray2dEquals_REAL</Name>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -23698,7 +23581,22 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -23706,6 +23604,124 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -23976,34 +23992,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LWORD</Name>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
           <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
+        </Parameter>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -24286,7 +24286,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Name>
       <BitSize>4128</BitSize>
       <SubItem>
         <Name>MsgCtrlMask</Name>
@@ -24314,7 +24314,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
       <Comment> This function block is responsible for making sure that the ADSLOGSTR-messages to the ADS-router are transmitted
    cyclically and not in a burst. The reason this is necessary is because that if too many messages are sent at the
    same time some get lost and are never printed to the error list output
@@ -24376,32 +24376,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>WriteLog</Name>
         <Parameter>
           <Name>MsgCtrlMask</Name>
@@ -24432,9 +24406,35 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Local>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -30211,6 +30211,37 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -30255,37 +30286,6 @@ External Setpoint Generation:
 	</Value>
           </Property>
         </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -30901,28 +30901,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Properties>
         <Property>
@@ -31183,29 +31183,33 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>391872</BitOffs>
       </SubItem>
       <Method>
-        <Name>RemoveRequest</Name>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqId</Name>
+          <Name>nReqID</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>81600</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31329,31 +31333,6 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
-        <Name>CheckRequestInPool</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AddRequest</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -31393,19 +31372,40 @@ These features efficiently address the addition, removal, and verification of be
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEntryCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
+        <Name>RemoveRequest</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqId</Name>
+          <Type>DWORD</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>81600</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
         </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CheckRequestInPool</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -42863,13 +42863,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
-      </Action>
-      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
+      </Action>
+      <Action>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -42890,7 +42890,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>AssertFinalBP</Name>
+        <Name>DeauthorizeTransition</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -49687,19 +49687,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
+        <Name>ACT_Motion</Name>
+      </Action>
+      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_Motion</Name>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_BLOCK</Name>
-      </Action>
-      <Action>
-        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -50449,10 +50449,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Properties>
         <Property>
@@ -50731,10 +50731,10 @@ Digital outputs</Comment>
         <BitOffs>253760</BitOffs>
       </SubItem>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Properties>
         <Property>
@@ -51122,13 +51122,13 @@ Digital outputs</Comment>
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -51401,10 +51401,10 @@ Digital outputs</Comment>
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -54742,6 +54742,47 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
+        <Name>TcQueryInterface</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -54789,21 +54830,6 @@ Digital outputs</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>Execute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
@@ -54906,45 +54932,19 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
+        <Name>Execute</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -55651,30 +55651,6 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -55721,6 +55697,30 @@ Digital outputs</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -55856,9 +55856,9 @@ Digital outputs</Comment>
         <BitOffs>64</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>GetJsonFromSymbol</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -55872,27 +55872,29 @@ Digital outputs</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -55973,6 +55975,45 @@ Digital outputs</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -56106,47 +56147,6 @@ Digital outputs</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
-          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -56842,12 +56842,46 @@ Digital outputs</Comment>
         </Parameter>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>32</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -56974,40 +57008,6 @@ Digital outputs</Comment>
               <Value>__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="15">__getLogToVisualStudio</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -58894,44 +58894,6 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
-    </DataType>
-    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -59737,6 +59699,44 @@ Digital outputs</Comment>
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
       </Hides>
     </DataType>
+    <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{A4C97A60-C95C-4787-A832-16AA681FD195}" TcSmClass="TComPlcObjDef">
@@ -59758,7 +59758,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86769664</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -65311,7 +65311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684244800</BitOffs>
+            <BitOffs>684244864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -65324,7 +65324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252736</BitOffs>
+            <BitOffs>684252800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -65337,7 +65337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252744</BitOffs>
+            <BitOffs>684252808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -65350,7 +65350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252752</BitOffs>
+            <BitOffs>684252816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -65373,7 +65373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252768</BitOffs>
+            <BitOffs>684252832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -65386,7 +65386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252800</BitOffs>
+            <BitOffs>684252864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -65399,7 +65399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252864</BitOffs>
+            <BitOffs>684252928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -65412,7 +65412,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252880</BitOffs>
+            <BitOffs>684252944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -65424,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684270016</BitOffs>
+            <BitOffs>684270080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -65437,7 +65437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684277952</BitOffs>
+            <BitOffs>684278016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -65450,7 +65450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684277960</BitOffs>
+            <BitOffs>684278024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -65463,7 +65463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684277968</BitOffs>
+            <BitOffs>684278032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -65486,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684277984</BitOffs>
+            <BitOffs>684278048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -65499,7 +65499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278016</BitOffs>
+            <BitOffs>684278080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -65512,7 +65512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278080</BitOffs>
+            <BitOffs>684278144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -65525,7 +65525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278096</BitOffs>
+            <BitOffs>684278160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -65537,7 +65537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684295232</BitOffs>
+            <BitOffs>684295296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -65550,7 +65550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303168</BitOffs>
+            <BitOffs>684303232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -65563,7 +65563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303176</BitOffs>
+            <BitOffs>684303240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -65576,7 +65576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303184</BitOffs>
+            <BitOffs>684303248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -65599,7 +65599,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303200</BitOffs>
+            <BitOffs>684303264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -65612,7 +65612,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303232</BitOffs>
+            <BitOffs>684303296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -65625,7 +65625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303296</BitOffs>
+            <BitOffs>684303360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -65638,7 +65638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303312</BitOffs>
+            <BitOffs>684303376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -65650,7 +65650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684320448</BitOffs>
+            <BitOffs>684320512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -65663,7 +65663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328384</BitOffs>
+            <BitOffs>684328448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -65676,7 +65676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328392</BitOffs>
+            <BitOffs>684328456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -65689,7 +65689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328400</BitOffs>
+            <BitOffs>684328464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -65712,7 +65712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328416</BitOffs>
+            <BitOffs>684328480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -65725,7 +65725,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328448</BitOffs>
+            <BitOffs>684328512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -65738,7 +65738,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328512</BitOffs>
+            <BitOffs>684328576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -65751,7 +65751,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328528</BitOffs>
+            <BitOffs>684328592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -65763,7 +65763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684345664</BitOffs>
+            <BitOffs>684345728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -65776,7 +65776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353600</BitOffs>
+            <BitOffs>684353664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -65789,7 +65789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353608</BitOffs>
+            <BitOffs>684353672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -65802,7 +65802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353616</BitOffs>
+            <BitOffs>684353680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -65825,7 +65825,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353632</BitOffs>
+            <BitOffs>684353696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -65838,7 +65838,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353664</BitOffs>
+            <BitOffs>684353728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -65851,7 +65851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353728</BitOffs>
+            <BitOffs>684353792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -65864,7 +65864,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353744</BitOffs>
+            <BitOffs>684353808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -65876,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684370880</BitOffs>
+            <BitOffs>684370944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -65889,7 +65889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378816</BitOffs>
+            <BitOffs>684378880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -65902,7 +65902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378824</BitOffs>
+            <BitOffs>684378888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -65915,7 +65915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378832</BitOffs>
+            <BitOffs>684378896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -65938,7 +65938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378848</BitOffs>
+            <BitOffs>684378912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -65951,7 +65951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378880</BitOffs>
+            <BitOffs>684378944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -65964,7 +65964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378944</BitOffs>
+            <BitOffs>684379008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -65977,7 +65977,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378960</BitOffs>
+            <BitOffs>684379024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -65989,7 +65989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684396096</BitOffs>
+            <BitOffs>684396160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -66002,7 +66002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404032</BitOffs>
+            <BitOffs>684404096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -66015,7 +66015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404040</BitOffs>
+            <BitOffs>684404104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -66028,7 +66028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404048</BitOffs>
+            <BitOffs>684404112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -66051,7 +66051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404064</BitOffs>
+            <BitOffs>684404128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -66064,7 +66064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404096</BitOffs>
+            <BitOffs>684404160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -66077,7 +66077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404160</BitOffs>
+            <BitOffs>684404224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -66090,7 +66090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404176</BitOffs>
+            <BitOffs>684404240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -66102,7 +66102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684421312</BitOffs>
+            <BitOffs>684421376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -66115,7 +66115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429248</BitOffs>
+            <BitOffs>684429312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -66128,7 +66128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429256</BitOffs>
+            <BitOffs>684429320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -66141,7 +66141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429264</BitOffs>
+            <BitOffs>684429328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -66164,7 +66164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429280</BitOffs>
+            <BitOffs>684429344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -66177,7 +66177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429312</BitOffs>
+            <BitOffs>684429376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -66190,7 +66190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429376</BitOffs>
+            <BitOffs>684429440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -66203,7 +66203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429392</BitOffs>
+            <BitOffs>684429456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -66215,7 +66215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684446528</BitOffs>
+            <BitOffs>684446592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -66228,7 +66228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454464</BitOffs>
+            <BitOffs>684454528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -66241,7 +66241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454472</BitOffs>
+            <BitOffs>684454536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -66254,7 +66254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454480</BitOffs>
+            <BitOffs>684454544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -66277,7 +66277,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454496</BitOffs>
+            <BitOffs>684454560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -66290,7 +66290,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454528</BitOffs>
+            <BitOffs>684454592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -66303,7 +66303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454592</BitOffs>
+            <BitOffs>684454656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -66316,7 +66316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454608</BitOffs>
+            <BitOffs>684454672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -66328,7 +66328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684471744</BitOffs>
+            <BitOffs>684471808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -66341,7 +66341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479680</BitOffs>
+            <BitOffs>684479744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -66354,7 +66354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479688</BitOffs>
+            <BitOffs>684479752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -66367,7 +66367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479696</BitOffs>
+            <BitOffs>684479760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -66390,7 +66390,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479712</BitOffs>
+            <BitOffs>684479776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -66403,7 +66403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479744</BitOffs>
+            <BitOffs>684479808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -66416,7 +66416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479808</BitOffs>
+            <BitOffs>684479872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -66429,7 +66429,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479824</BitOffs>
+            <BitOffs>684479888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -66441,7 +66441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684496960</BitOffs>
+            <BitOffs>684497024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -66454,7 +66454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504896</BitOffs>
+            <BitOffs>684504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -66467,7 +66467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504904</BitOffs>
+            <BitOffs>684504968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -66480,7 +66480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504912</BitOffs>
+            <BitOffs>684504976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -66503,7 +66503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504928</BitOffs>
+            <BitOffs>684504992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -66516,7 +66516,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504960</BitOffs>
+            <BitOffs>684505024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -66529,7 +66529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505024</BitOffs>
+            <BitOffs>684505088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -66542,7 +66542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505040</BitOffs>
+            <BitOffs>684505104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -66554,7 +66554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684522176</BitOffs>
+            <BitOffs>684522240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -66567,7 +66567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530112</BitOffs>
+            <BitOffs>684530176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -66580,7 +66580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530120</BitOffs>
+            <BitOffs>684530184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -66593,7 +66593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530128</BitOffs>
+            <BitOffs>684530192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -66616,7 +66616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530144</BitOffs>
+            <BitOffs>684530208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -66629,7 +66629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530176</BitOffs>
+            <BitOffs>684530240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -66642,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530240</BitOffs>
+            <BitOffs>684530304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -66655,7 +66655,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530256</BitOffs>
+            <BitOffs>684530320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -66667,7 +66667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684547392</BitOffs>
+            <BitOffs>684547456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -66680,7 +66680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555328</BitOffs>
+            <BitOffs>684555392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -66693,7 +66693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555336</BitOffs>
+            <BitOffs>684555400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -66706,7 +66706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555344</BitOffs>
+            <BitOffs>684555408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -66729,7 +66729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555360</BitOffs>
+            <BitOffs>684555424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -66742,7 +66742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555392</BitOffs>
+            <BitOffs>684555456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -66755,7 +66755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555456</BitOffs>
+            <BitOffs>684555520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -66768,7 +66768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555472</BitOffs>
+            <BitOffs>684555536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -66780,7 +66780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684572608</BitOffs>
+            <BitOffs>684572672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -66793,7 +66793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580544</BitOffs>
+            <BitOffs>684580608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -66806,7 +66806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580552</BitOffs>
+            <BitOffs>684580616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -66819,7 +66819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580560</BitOffs>
+            <BitOffs>684580624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -66842,7 +66842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580576</BitOffs>
+            <BitOffs>684580640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -66855,7 +66855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580608</BitOffs>
+            <BitOffs>684580672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -66868,7 +66868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580672</BitOffs>
+            <BitOffs>684580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -66881,7 +66881,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580688</BitOffs>
+            <BitOffs>684580752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -66893,7 +66893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684597824</BitOffs>
+            <BitOffs>684597888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -66906,7 +66906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605760</BitOffs>
+            <BitOffs>684605824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -66919,7 +66919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605768</BitOffs>
+            <BitOffs>684605832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -66932,7 +66932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605776</BitOffs>
+            <BitOffs>684605840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -66955,7 +66955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605792</BitOffs>
+            <BitOffs>684605856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -66968,7 +66968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605824</BitOffs>
+            <BitOffs>684605888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -66981,7 +66981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605888</BitOffs>
+            <BitOffs>684605952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -66994,7 +66994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605904</BitOffs>
+            <BitOffs>684605968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -67006,7 +67006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684623040</BitOffs>
+            <BitOffs>684623104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -67019,7 +67019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684630976</BitOffs>
+            <BitOffs>684631040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -67032,7 +67032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684630984</BitOffs>
+            <BitOffs>684631048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -67045,7 +67045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684630992</BitOffs>
+            <BitOffs>684631056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -67068,7 +67068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631008</BitOffs>
+            <BitOffs>684631072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -67081,7 +67081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631040</BitOffs>
+            <BitOffs>684631104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -67094,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631104</BitOffs>
+            <BitOffs>684631168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -67107,7 +67107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631120</BitOffs>
+            <BitOffs>684631184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -67119,7 +67119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684648256</BitOffs>
+            <BitOffs>684648320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -67132,7 +67132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656192</BitOffs>
+            <BitOffs>684656256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -67145,7 +67145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656200</BitOffs>
+            <BitOffs>684656264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -67158,7 +67158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656208</BitOffs>
+            <BitOffs>684656272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -67181,7 +67181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656224</BitOffs>
+            <BitOffs>684656288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -67194,7 +67194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656256</BitOffs>
+            <BitOffs>684656320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -67207,7 +67207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656320</BitOffs>
+            <BitOffs>684656384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -67220,7 +67220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656336</BitOffs>
+            <BitOffs>684656400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -67232,7 +67232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684673472</BitOffs>
+            <BitOffs>684673536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -67245,7 +67245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681408</BitOffs>
+            <BitOffs>684681472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -67258,7 +67258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681416</BitOffs>
+            <BitOffs>684681480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -67271,7 +67271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681424</BitOffs>
+            <BitOffs>684681488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -67294,7 +67294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681440</BitOffs>
+            <BitOffs>684681504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -67307,7 +67307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681472</BitOffs>
+            <BitOffs>684681536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -67320,7 +67320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681536</BitOffs>
+            <BitOffs>684681600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -67333,7 +67333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681552</BitOffs>
+            <BitOffs>684681616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -67345,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684698688</BitOffs>
+            <BitOffs>684698752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -67358,7 +67358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706624</BitOffs>
+            <BitOffs>684706688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -67371,7 +67371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706632</BitOffs>
+            <BitOffs>684706696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -67384,7 +67384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706640</BitOffs>
+            <BitOffs>684706704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -67407,7 +67407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706656</BitOffs>
+            <BitOffs>684706720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -67420,7 +67420,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706688</BitOffs>
+            <BitOffs>684706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -67433,7 +67433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706752</BitOffs>
+            <BitOffs>684706816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -67446,7 +67446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706768</BitOffs>
+            <BitOffs>684706832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -67458,7 +67458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684723904</BitOffs>
+            <BitOffs>684723968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -67471,7 +67471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731840</BitOffs>
+            <BitOffs>684731904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -67484,7 +67484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731848</BitOffs>
+            <BitOffs>684731912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -67497,7 +67497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731856</BitOffs>
+            <BitOffs>684731920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -67520,7 +67520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731872</BitOffs>
+            <BitOffs>684731936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -67533,7 +67533,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731904</BitOffs>
+            <BitOffs>684731968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -67546,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731968</BitOffs>
+            <BitOffs>684732032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -67559,7 +67559,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731984</BitOffs>
+            <BitOffs>684732048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -67571,7 +67571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684749120</BitOffs>
+            <BitOffs>684749184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -67584,7 +67584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757056</BitOffs>
+            <BitOffs>684757120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -67597,7 +67597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757064</BitOffs>
+            <BitOffs>684757128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -67610,7 +67610,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757072</BitOffs>
+            <BitOffs>684757136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -67633,7 +67633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757088</BitOffs>
+            <BitOffs>684757152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -67646,7 +67646,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757120</BitOffs>
+            <BitOffs>684757184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -67659,7 +67659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757184</BitOffs>
+            <BitOffs>684757248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -67672,7 +67672,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757200</BitOffs>
+            <BitOffs>684757264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -67684,7 +67684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684774336</BitOffs>
+            <BitOffs>684774400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -67697,7 +67697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782272</BitOffs>
+            <BitOffs>684782336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -67710,7 +67710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782280</BitOffs>
+            <BitOffs>684782344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -67723,7 +67723,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782288</BitOffs>
+            <BitOffs>684782352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -67746,7 +67746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782304</BitOffs>
+            <BitOffs>684782368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -67759,7 +67759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782336</BitOffs>
+            <BitOffs>684782400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -67772,7 +67772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782400</BitOffs>
+            <BitOffs>684782464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -67785,7 +67785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782416</BitOffs>
+            <BitOffs>684782480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -67797,7 +67797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684799552</BitOffs>
+            <BitOffs>684799616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -67810,7 +67810,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807488</BitOffs>
+            <BitOffs>684807552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -67823,7 +67823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807496</BitOffs>
+            <BitOffs>684807560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -67836,7 +67836,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807504</BitOffs>
+            <BitOffs>684807568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -67859,7 +67859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807520</BitOffs>
+            <BitOffs>684807584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -67872,7 +67872,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807552</BitOffs>
+            <BitOffs>684807616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -67885,7 +67885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807616</BitOffs>
+            <BitOffs>684807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -67898,7 +67898,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807632</BitOffs>
+            <BitOffs>684807696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -67910,7 +67910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684824768</BitOffs>
+            <BitOffs>684824832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -67923,7 +67923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832704</BitOffs>
+            <BitOffs>684832768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -67936,7 +67936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832712</BitOffs>
+            <BitOffs>684832776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -67949,7 +67949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832720</BitOffs>
+            <BitOffs>684832784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -67972,7 +67972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832736</BitOffs>
+            <BitOffs>684832800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -67985,7 +67985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832768</BitOffs>
+            <BitOffs>684832832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -67998,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832832</BitOffs>
+            <BitOffs>684832896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -68011,7 +68011,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832848</BitOffs>
+            <BitOffs>684832912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -68023,7 +68023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684849984</BitOffs>
+            <BitOffs>684850048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -68036,7 +68036,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857920</BitOffs>
+            <BitOffs>684857984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -68049,7 +68049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857928</BitOffs>
+            <BitOffs>684857992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -68062,7 +68062,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857936</BitOffs>
+            <BitOffs>684858000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -68085,7 +68085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857952</BitOffs>
+            <BitOffs>684858016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -68098,7 +68098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857984</BitOffs>
+            <BitOffs>684858048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -68111,7 +68111,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858048</BitOffs>
+            <BitOffs>684858112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -68124,7 +68124,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858064</BitOffs>
+            <BitOffs>684858128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -68136,7 +68136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684875200</BitOffs>
+            <BitOffs>684875264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -68149,7 +68149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883136</BitOffs>
+            <BitOffs>684883200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -68162,7 +68162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883144</BitOffs>
+            <BitOffs>684883208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -68175,7 +68175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883152</BitOffs>
+            <BitOffs>684883216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -68198,7 +68198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883168</BitOffs>
+            <BitOffs>684883232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -68211,7 +68211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883200</BitOffs>
+            <BitOffs>684883264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -68224,7 +68224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883264</BitOffs>
+            <BitOffs>684883328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -68237,7 +68237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883280</BitOffs>
+            <BitOffs>684883344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -68249,7 +68249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684900416</BitOffs>
+            <BitOffs>684900480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -68262,7 +68262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908352</BitOffs>
+            <BitOffs>684908416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -68275,7 +68275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908360</BitOffs>
+            <BitOffs>684908424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -68288,7 +68288,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908368</BitOffs>
+            <BitOffs>684908432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -68311,7 +68311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908384</BitOffs>
+            <BitOffs>684908448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -68324,7 +68324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908416</BitOffs>
+            <BitOffs>684908480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -68337,7 +68337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908480</BitOffs>
+            <BitOffs>684908544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -68350,7 +68350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908496</BitOffs>
+            <BitOffs>684908560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -68362,7 +68362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684925632</BitOffs>
+            <BitOffs>684925696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -68375,7 +68375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933568</BitOffs>
+            <BitOffs>684933632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -68388,7 +68388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933576</BitOffs>
+            <BitOffs>684933640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -68401,7 +68401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933584</BitOffs>
+            <BitOffs>684933648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -68424,7 +68424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933600</BitOffs>
+            <BitOffs>684933664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -68437,7 +68437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933632</BitOffs>
+            <BitOffs>684933696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -68450,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933696</BitOffs>
+            <BitOffs>684933760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -68463,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933712</BitOffs>
+            <BitOffs>684933776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -68475,7 +68475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684950848</BitOffs>
+            <BitOffs>684950912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -68488,7 +68488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958784</BitOffs>
+            <BitOffs>684958848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -68501,7 +68501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958792</BitOffs>
+            <BitOffs>684958856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -68514,7 +68514,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958800</BitOffs>
+            <BitOffs>684958864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -68537,7 +68537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958816</BitOffs>
+            <BitOffs>684958880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -68550,7 +68550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958848</BitOffs>
+            <BitOffs>684958912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -68563,7 +68563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958912</BitOffs>
+            <BitOffs>684958976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -68576,7 +68576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958928</BitOffs>
+            <BitOffs>684958992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -68588,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684976064</BitOffs>
+            <BitOffs>684976128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -68601,7 +68601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984000</BitOffs>
+            <BitOffs>684984064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -68614,7 +68614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984008</BitOffs>
+            <BitOffs>684984072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -68627,7 +68627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984016</BitOffs>
+            <BitOffs>684984080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -68650,7 +68650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984032</BitOffs>
+            <BitOffs>684984096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -68663,7 +68663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984064</BitOffs>
+            <BitOffs>684984128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -68676,7 +68676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984128</BitOffs>
+            <BitOffs>684984192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -68689,7 +68689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984144</BitOffs>
+            <BitOffs>684984208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -68701,7 +68701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685001280</BitOffs>
+            <BitOffs>685001344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -68714,7 +68714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009216</BitOffs>
+            <BitOffs>685009280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -68727,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009224</BitOffs>
+            <BitOffs>685009288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -68740,7 +68740,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009232</BitOffs>
+            <BitOffs>685009296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -68763,7 +68763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009248</BitOffs>
+            <BitOffs>685009312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -68776,7 +68776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009280</BitOffs>
+            <BitOffs>685009344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -68789,7 +68789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009344</BitOffs>
+            <BitOffs>685009408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -68802,7 +68802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009360</BitOffs>
+            <BitOffs>685009424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -68814,7 +68814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685026496</BitOffs>
+            <BitOffs>685026560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -68827,7 +68827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034432</BitOffs>
+            <BitOffs>685034496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -68840,7 +68840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034440</BitOffs>
+            <BitOffs>685034504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -68853,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034448</BitOffs>
+            <BitOffs>685034512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -68876,7 +68876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034464</BitOffs>
+            <BitOffs>685034528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -68889,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034496</BitOffs>
+            <BitOffs>685034560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -68902,7 +68902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034560</BitOffs>
+            <BitOffs>685034624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -68915,7 +68915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034576</BitOffs>
+            <BitOffs>685034640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -68927,7 +68927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685051712</BitOffs>
+            <BitOffs>685051776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -68940,7 +68940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059648</BitOffs>
+            <BitOffs>685059712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -68953,7 +68953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059656</BitOffs>
+            <BitOffs>685059720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -68966,7 +68966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059664</BitOffs>
+            <BitOffs>685059728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -68989,7 +68989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059680</BitOffs>
+            <BitOffs>685059744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -69002,7 +69002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059712</BitOffs>
+            <BitOffs>685059776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -69015,7 +69015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059776</BitOffs>
+            <BitOffs>685059840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -69028,7 +69028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059792</BitOffs>
+            <BitOffs>685059856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -69040,7 +69040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685076928</BitOffs>
+            <BitOffs>685076992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -69053,7 +69053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084864</BitOffs>
+            <BitOffs>685084928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -69066,7 +69066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084872</BitOffs>
+            <BitOffs>685084936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -69079,7 +69079,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084880</BitOffs>
+            <BitOffs>685084944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -69102,7 +69102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084896</BitOffs>
+            <BitOffs>685084960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -69115,7 +69115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084928</BitOffs>
+            <BitOffs>685084992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -69128,7 +69128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084992</BitOffs>
+            <BitOffs>685085056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -69141,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085008</BitOffs>
+            <BitOffs>685085072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -69153,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685102144</BitOffs>
+            <BitOffs>685102208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -69166,7 +69166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110080</BitOffs>
+            <BitOffs>685110144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -69179,7 +69179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110088</BitOffs>
+            <BitOffs>685110152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -69192,7 +69192,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110096</BitOffs>
+            <BitOffs>685110160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -69215,7 +69215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110112</BitOffs>
+            <BitOffs>685110176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -69228,7 +69228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110144</BitOffs>
+            <BitOffs>685110208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -69241,7 +69241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110208</BitOffs>
+            <BitOffs>685110272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -69254,7 +69254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110224</BitOffs>
+            <BitOffs>685110288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -69266,7 +69266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685127360</BitOffs>
+            <BitOffs>685127424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -69279,7 +69279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135296</BitOffs>
+            <BitOffs>685135360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -69292,7 +69292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135304</BitOffs>
+            <BitOffs>685135368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -69305,7 +69305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135312</BitOffs>
+            <BitOffs>685135376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -69328,7 +69328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135328</BitOffs>
+            <BitOffs>685135392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -69341,7 +69341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135360</BitOffs>
+            <BitOffs>685135424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -69354,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135424</BitOffs>
+            <BitOffs>685135488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -69367,7 +69367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135440</BitOffs>
+            <BitOffs>685135504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -69379,7 +69379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685152576</BitOffs>
+            <BitOffs>685152640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -69392,7 +69392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160512</BitOffs>
+            <BitOffs>685160576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -69405,7 +69405,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160520</BitOffs>
+            <BitOffs>685160584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -69418,7 +69418,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160528</BitOffs>
+            <BitOffs>685160592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -69441,7 +69441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160544</BitOffs>
+            <BitOffs>685160608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -69454,7 +69454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160576</BitOffs>
+            <BitOffs>685160640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -69467,7 +69467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160640</BitOffs>
+            <BitOffs>685160704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -69480,7 +69480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160656</BitOffs>
+            <BitOffs>685160720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -69492,7 +69492,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685177792</BitOffs>
+            <BitOffs>685177856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -69505,7 +69505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185728</BitOffs>
+            <BitOffs>685185792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -69518,7 +69518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185736</BitOffs>
+            <BitOffs>685185800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -69531,7 +69531,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185744</BitOffs>
+            <BitOffs>685185808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -69554,7 +69554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185760</BitOffs>
+            <BitOffs>685185824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -69567,7 +69567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185792</BitOffs>
+            <BitOffs>685185856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -69580,7 +69580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185856</BitOffs>
+            <BitOffs>685185920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -69593,7 +69593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185872</BitOffs>
+            <BitOffs>685185936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -69605,7 +69605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685203008</BitOffs>
+            <BitOffs>685203072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -69618,7 +69618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685210944</BitOffs>
+            <BitOffs>685211008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -69631,7 +69631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685210952</BitOffs>
+            <BitOffs>685211016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -69644,7 +69644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685210960</BitOffs>
+            <BitOffs>685211024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -69667,7 +69667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685210976</BitOffs>
+            <BitOffs>685211040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -69680,7 +69680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211008</BitOffs>
+            <BitOffs>685211072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -69693,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211072</BitOffs>
+            <BitOffs>685211136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -69706,7 +69706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211088</BitOffs>
+            <BitOffs>685211152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -69718,7 +69718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685228224</BitOffs>
+            <BitOffs>685228288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -69731,7 +69731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236160</BitOffs>
+            <BitOffs>685236224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -69744,7 +69744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236168</BitOffs>
+            <BitOffs>685236232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -69757,7 +69757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236176</BitOffs>
+            <BitOffs>685236240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -69780,7 +69780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236192</BitOffs>
+            <BitOffs>685236256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -69793,7 +69793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236224</BitOffs>
+            <BitOffs>685236288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -69806,7 +69806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236288</BitOffs>
+            <BitOffs>685236352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -69819,7 +69819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236304</BitOffs>
+            <BitOffs>685236368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -69831,7 +69831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685253440</BitOffs>
+            <BitOffs>685253504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -69844,7 +69844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261376</BitOffs>
+            <BitOffs>685261440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -69857,7 +69857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261384</BitOffs>
+            <BitOffs>685261448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -69870,7 +69870,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261392</BitOffs>
+            <BitOffs>685261456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -69893,7 +69893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261408</BitOffs>
+            <BitOffs>685261472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -69906,7 +69906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261440</BitOffs>
+            <BitOffs>685261504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -69919,7 +69919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261504</BitOffs>
+            <BitOffs>685261568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -69932,7 +69932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261520</BitOffs>
+            <BitOffs>685261584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -69944,7 +69944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685278656</BitOffs>
+            <BitOffs>685278720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -69957,7 +69957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286592</BitOffs>
+            <BitOffs>685286656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -69970,7 +69970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286600</BitOffs>
+            <BitOffs>685286664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -69983,7 +69983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286608</BitOffs>
+            <BitOffs>685286672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -70006,7 +70006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286624</BitOffs>
+            <BitOffs>685286688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -70019,7 +70019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286656</BitOffs>
+            <BitOffs>685286720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -70032,7 +70032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286720</BitOffs>
+            <BitOffs>685286784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -70045,7 +70045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286736</BitOffs>
+            <BitOffs>685286800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -70057,7 +70057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685303872</BitOffs>
+            <BitOffs>685303936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -70070,7 +70070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311808</BitOffs>
+            <BitOffs>685311872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -70083,7 +70083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311816</BitOffs>
+            <BitOffs>685311880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -70096,7 +70096,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311824</BitOffs>
+            <BitOffs>685311888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -70119,7 +70119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311840</BitOffs>
+            <BitOffs>685311904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -70132,7 +70132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311872</BitOffs>
+            <BitOffs>685311936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -70145,7 +70145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311936</BitOffs>
+            <BitOffs>685312000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -70158,7 +70158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311952</BitOffs>
+            <BitOffs>685312016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -70170,7 +70170,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685329088</BitOffs>
+            <BitOffs>685329152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -70183,7 +70183,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337024</BitOffs>
+            <BitOffs>685337088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -70196,7 +70196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337032</BitOffs>
+            <BitOffs>685337096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -70209,7 +70209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337040</BitOffs>
+            <BitOffs>685337104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -70232,7 +70232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337056</BitOffs>
+            <BitOffs>685337120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -70245,7 +70245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337088</BitOffs>
+            <BitOffs>685337152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -70258,7 +70258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337152</BitOffs>
+            <BitOffs>685337216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -70271,14 +70271,14 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337168</BitOffs>
+            <BitOffs>685337232</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86769664</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -71950,7 +71950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684243776</BitOffs>
+            <BitOffs>684243840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -71963,7 +71963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684252760</BitOffs>
+            <BitOffs>684252824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -71975,7 +71975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684268992</BitOffs>
+            <BitOffs>684269056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -71988,7 +71988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684277976</BitOffs>
+            <BitOffs>684278040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -72000,7 +72000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684294208</BitOffs>
+            <BitOffs>684294272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -72013,7 +72013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684303192</BitOffs>
+            <BitOffs>684303256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -72025,7 +72025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684319424</BitOffs>
+            <BitOffs>684319488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -72038,7 +72038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684328408</BitOffs>
+            <BitOffs>684328472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -72050,7 +72050,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684344640</BitOffs>
+            <BitOffs>684344704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -72063,7 +72063,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684353624</BitOffs>
+            <BitOffs>684353688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -72075,7 +72075,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684369856</BitOffs>
+            <BitOffs>684369920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -72088,7 +72088,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684378840</BitOffs>
+            <BitOffs>684378904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -72100,7 +72100,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684395072</BitOffs>
+            <BitOffs>684395136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -72113,7 +72113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684404056</BitOffs>
+            <BitOffs>684404120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -72125,7 +72125,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684420288</BitOffs>
+            <BitOffs>684420352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -72138,7 +72138,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684429272</BitOffs>
+            <BitOffs>684429336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -72150,7 +72150,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684445504</BitOffs>
+            <BitOffs>684445568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -72163,7 +72163,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684454488</BitOffs>
+            <BitOffs>684454552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -72175,7 +72175,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684470720</BitOffs>
+            <BitOffs>684470784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -72188,7 +72188,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684479704</BitOffs>
+            <BitOffs>684479768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -72200,7 +72200,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684495936</BitOffs>
+            <BitOffs>684496000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -72213,7 +72213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684504920</BitOffs>
+            <BitOffs>684504984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -72225,7 +72225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684521152</BitOffs>
+            <BitOffs>684521216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -72238,7 +72238,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684530136</BitOffs>
+            <BitOffs>684530200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -72250,7 +72250,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684546368</BitOffs>
+            <BitOffs>684546432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -72263,7 +72263,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684555352</BitOffs>
+            <BitOffs>684555416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -72275,7 +72275,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684571584</BitOffs>
+            <BitOffs>684571648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -72288,7 +72288,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684580568</BitOffs>
+            <BitOffs>684580632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -72300,7 +72300,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684596800</BitOffs>
+            <BitOffs>684596864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -72313,7 +72313,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684605784</BitOffs>
+            <BitOffs>684605848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -72325,7 +72325,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684622016</BitOffs>
+            <BitOffs>684622080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -72338,7 +72338,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684631000</BitOffs>
+            <BitOffs>684631064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -72350,7 +72350,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684647232</BitOffs>
+            <BitOffs>684647296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -72363,7 +72363,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684656216</BitOffs>
+            <BitOffs>684656280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -72375,7 +72375,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684672448</BitOffs>
+            <BitOffs>684672512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -72388,7 +72388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684681432</BitOffs>
+            <BitOffs>684681496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -72400,7 +72400,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684697664</BitOffs>
+            <BitOffs>684697728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -72413,7 +72413,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684706648</BitOffs>
+            <BitOffs>684706712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -72425,7 +72425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684722880</BitOffs>
+            <BitOffs>684722944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -72438,7 +72438,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684731864</BitOffs>
+            <BitOffs>684731928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -72450,7 +72450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684748096</BitOffs>
+            <BitOffs>684748160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -72463,7 +72463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684757080</BitOffs>
+            <BitOffs>684757144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -72475,7 +72475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684773312</BitOffs>
+            <BitOffs>684773376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -72488,7 +72488,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684782296</BitOffs>
+            <BitOffs>684782360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -72500,7 +72500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684798528</BitOffs>
+            <BitOffs>684798592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -72513,7 +72513,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684807512</BitOffs>
+            <BitOffs>684807576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -72525,7 +72525,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684823744</BitOffs>
+            <BitOffs>684823808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -72538,7 +72538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684832728</BitOffs>
+            <BitOffs>684832792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -72550,7 +72550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684848960</BitOffs>
+            <BitOffs>684849024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -72563,7 +72563,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684857944</BitOffs>
+            <BitOffs>684858008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -72575,7 +72575,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684874176</BitOffs>
+            <BitOffs>684874240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -72588,7 +72588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684883160</BitOffs>
+            <BitOffs>684883224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -72600,7 +72600,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684899392</BitOffs>
+            <BitOffs>684899456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -72613,7 +72613,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684908376</BitOffs>
+            <BitOffs>684908440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -72625,7 +72625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684924608</BitOffs>
+            <BitOffs>684924672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -72638,7 +72638,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684933592</BitOffs>
+            <BitOffs>684933656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -72650,7 +72650,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684949824</BitOffs>
+            <BitOffs>684949888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -72663,7 +72663,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684958808</BitOffs>
+            <BitOffs>684958872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -72675,7 +72675,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684975040</BitOffs>
+            <BitOffs>684975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -72688,7 +72688,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684984024</BitOffs>
+            <BitOffs>684984088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -72700,7 +72700,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685000256</BitOffs>
+            <BitOffs>685000320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -72713,7 +72713,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685009240</BitOffs>
+            <BitOffs>685009304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -72725,7 +72725,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685025472</BitOffs>
+            <BitOffs>685025536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -72738,7 +72738,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685034456</BitOffs>
+            <BitOffs>685034520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -72750,7 +72750,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685050688</BitOffs>
+            <BitOffs>685050752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -72763,7 +72763,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685059672</BitOffs>
+            <BitOffs>685059736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -72775,7 +72775,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685075904</BitOffs>
+            <BitOffs>685075968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -72788,7 +72788,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685084888</BitOffs>
+            <BitOffs>685084952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -72800,7 +72800,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685101120</BitOffs>
+            <BitOffs>685101184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -72813,7 +72813,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685110104</BitOffs>
+            <BitOffs>685110168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -72825,7 +72825,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685126336</BitOffs>
+            <BitOffs>685126400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -72838,7 +72838,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685135320</BitOffs>
+            <BitOffs>685135384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -72850,7 +72850,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685151552</BitOffs>
+            <BitOffs>685151616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -72863,7 +72863,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685160536</BitOffs>
+            <BitOffs>685160600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -72875,7 +72875,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685176768</BitOffs>
+            <BitOffs>685176832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -72888,7 +72888,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685185752</BitOffs>
+            <BitOffs>685185816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -72900,7 +72900,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685201984</BitOffs>
+            <BitOffs>685202048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -72913,7 +72913,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685210968</BitOffs>
+            <BitOffs>685211032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -72925,7 +72925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685227200</BitOffs>
+            <BitOffs>685227264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -72938,7 +72938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685236184</BitOffs>
+            <BitOffs>685236248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -72950,7 +72950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685252416</BitOffs>
+            <BitOffs>685252480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -72963,7 +72963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685261400</BitOffs>
+            <BitOffs>685261464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -72975,7 +72975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685277632</BitOffs>
+            <BitOffs>685277696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -72988,7 +72988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685286616</BitOffs>
+            <BitOffs>685286680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -73000,7 +73000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685302848</BitOffs>
+            <BitOffs>685302912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -73013,7 +73013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685311832</BitOffs>
+            <BitOffs>685311896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -73025,7 +73025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685328064</BitOffs>
+            <BitOffs>685328128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -73038,14 +73038,14 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685337048</BitOffs>
+            <BitOffs>685337112</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86769664</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -79296,7 +79296,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
             <BitSize>621827200</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -79308,7 +79308,7 @@ Digital outputs</Comment>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
             <Comment> Pointer to current test suite being called </Comment>
             <BitSize>32</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -79372,7 +79372,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
             <BitSize>32000</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>1000</Elements>
@@ -79414,7 +79414,7 @@ Digital outputs</Comment>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
             <Comment> Buffered ADS message queue for output to the error list </Comment>
             <BitSize>8320864</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -79732,7 +79732,8 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bError 				:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Error;
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
-                              .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value</Value>
+                              .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
             <BitOffs>644786752</BitOffs>
@@ -80618,6 +80619,77 @@ Digital outputs</Comment>
             <BitOffs>682596800</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>GVL_TcGVL.ePF2K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243760</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>Main.M1</Name>
             <Comment> AL1K4-L2SI: 1 Axis</Comment>
             <BitSize>25216</BitSize>
@@ -80644,7 +80716,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243712</BitOffs>
+            <BitOffs>684243776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -80656,7 +80728,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684268928</BitOffs>
+            <BitOffs>684268992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -80667,7 +80739,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684294144</BitOffs>
+            <BitOffs>684294208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -80678,7 +80750,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684319360</BitOffs>
+            <BitOffs>684319424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -80689,7 +80761,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684344576</BitOffs>
+            <BitOffs>684344640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -80700,7 +80772,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684369792</BitOffs>
+            <BitOffs>684369856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -80711,7 +80783,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684395008</BitOffs>
+            <BitOffs>684395072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -80722,7 +80794,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684420224</BitOffs>
+            <BitOffs>684420288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -80751,7 +80823,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684445440</BitOffs>
+            <BitOffs>684445504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -80779,7 +80851,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684470656</BitOffs>
+            <BitOffs>684470720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -80806,7 +80878,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684495872</BitOffs>
+            <BitOffs>684495936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -80833,7 +80905,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684521088</BitOffs>
+            <BitOffs>684521152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -80860,7 +80932,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684546304</BitOffs>
+            <BitOffs>684546368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -80872,7 +80944,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684571520</BitOffs>
+            <BitOffs>684571584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -80901,7 +80973,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684596736</BitOffs>
+            <BitOffs>684596800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -80930,7 +81002,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684621952</BitOffs>
+            <BitOffs>684622016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -80959,7 +81031,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684647168</BitOffs>
+            <BitOffs>684647232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -80988,7 +81060,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684672384</BitOffs>
+            <BitOffs>684672448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -81013,7 +81085,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684697600</BitOffs>
+            <BitOffs>684697664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -81042,7 +81114,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684722816</BitOffs>
+            <BitOffs>684722880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -81071,7 +81143,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684748032</BitOffs>
+            <BitOffs>684748096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -81096,7 +81168,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684773248</BitOffs>
+            <BitOffs>684773312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -81124,7 +81196,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684798464</BitOffs>
+            <BitOffs>684798528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -81151,7 +81223,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684823680</BitOffs>
+            <BitOffs>684823744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -81178,7 +81250,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684848896</BitOffs>
+            <BitOffs>684848960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -81205,7 +81277,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684874112</BitOffs>
+            <BitOffs>684874176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -81234,7 +81306,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684899328</BitOffs>
+            <BitOffs>684899392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -81263,7 +81335,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684924544</BitOffs>
+            <BitOffs>684924608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -81288,7 +81360,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684949760</BitOffs>
+            <BitOffs>684949824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -81317,7 +81389,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684974976</BitOffs>
+            <BitOffs>684975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -81342,7 +81414,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685000192</BitOffs>
+            <BitOffs>685000256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -81379,7 +81451,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685025408</BitOffs>
+            <BitOffs>685025472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -81424,7 +81496,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685050624</BitOffs>
+            <BitOffs>685050688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -81465,7 +81537,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685075840</BitOffs>
+            <BitOffs>685075904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -81506,7 +81578,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685101056</BitOffs>
+            <BitOffs>685101120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -81547,7 +81619,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685126272</BitOffs>
+            <BitOffs>685126336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -81588,7 +81660,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685151488</BitOffs>
+            <BitOffs>685151552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -81629,7 +81701,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685176704</BitOffs>
+            <BitOffs>685176768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -81670,7 +81742,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685201920</BitOffs>
+            <BitOffs>685201984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -81711,7 +81783,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685227136</BitOffs>
+            <BitOffs>685227200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -81747,7 +81819,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685252352</BitOffs>
+            <BitOffs>685252416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -81783,7 +81855,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685277568</BitOffs>
+            <BitOffs>685277632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -81819,7 +81891,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685302784</BitOffs>
+            <BitOffs>685302848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -81864,48 +81936,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685328000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcGVL.ePF2K4State</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353240</BitOffs>
+            <BitOffs>685328064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -81935,7 +81966,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353248</BitOffs>
+            <BitOffs>685353280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -81965,37 +81996,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685353392</BitOffs>
+            <BitOffs>685353344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -82121,29 +82122,6 @@ Digital outputs</Comment>
             <BitOffs>685356640</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>685399968</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
             <Comment> 11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31</Comment>
             <BitSize>128</BitSize>
@@ -82210,7 +82188,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685408992</BitOffs>
+            <BitOffs>685370016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -82279,7 +82257,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409120</BitOffs>
+            <BitOffs>685370144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -82348,7 +82326,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409248</BitOffs>
+            <BitOffs>685370272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -82417,7 +82395,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409376</BitOffs>
+            <BitOffs>685370400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -82486,7 +82464,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409504</BitOffs>
+            <BitOffs>685370528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -82555,14 +82533,37 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685409632</BitOffs>
+            <BitOffs>685370656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>685400992</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86769664</ByteSize>
+          <ByteSize>86835200</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -82617,9 +82618,6 @@ Digital outputs</Comment>
       <Deployment/>
       <EventClasses>
         <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
-        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -82634,6 +82632,9 @@ Digital outputs</Comment>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
+        <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -82642,15 +82643,15 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-08-28T16:46:27</Value>
+          <Value>2023-08-29T13:19:11</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>991232</Value>
+          <Value>1069056</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>85180416</Value>
+          <Value>85258240</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
WFS-PPM PMPS deployed
Because when I work on WFS-PPM-PMPS branch, I did not fetch the most recent in master which includes Nick recent flow sensor codes. So I try to merge WFS-PPM-PMPS branch and upstream master and manually choose. However it only merge part of his code. Only IM3K4 flow sensor is here. So I need to manually put the others code into WFS-PPM-PMPS branch. This branch is running in PLC.
I plan to push again after I adding other flow sensor codes.
8-29:
I push all flow sensor code in IM4K4-Im6K4;
I also ad bmoveOk for every common component
<!--- Describe your changes in detail -->
Add WFS-PPM PMPS. If WFS any target in, PPM YAG can take any beam. Otherwise, 
PPM YAG will work as normal PMPS state
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
TMO scientists ask for it and give them freedom during the beam time.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in TMO GUI. While PF1K4 IN, IM5K4 and take 100% beam. While PF1K4 OUT, IM4K4 YAG take 10% beam as normal PMPS device.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
https://jira.slac.stanford.edu/browse/ECS-3735

<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
