### PR TITLE
Common component flow sensor

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -12488,9 +12488,6 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^Main.M15.bBrakeRelease" VarB="Channel 1^Output" AutoLink="true"/>
 				<Link VarA="PlcTask Outputs^PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
 			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM3K4-PPM (EK1100)^IM3K4-EL3052-E5">
-				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
-			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM3K4-PPM (EK1100)^IM3K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
@@ -12519,6 +12516,7 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Outputs^PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower" VarB="Channel 2^Output" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL3052-E5">
+				<Link VarA="PlcTask Inputs^PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 1(EK1100)^PLC Junction 5 (EK1122)^IM4K4-PPM (EK1100)^IM4K4-EL3062-E6">

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
@@ -18,7 +18,7 @@ VAR
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value;
-                              .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value'}
+                              .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value'} //IM3K4 and IM4K4 share the same flow meter
     fbIM3K4: FB_PPM;
     fStartupVelo: LREAL := 12;
 END_VAR
@@ -63,6 +63,7 @@ fbIM3K4(
     bEnableMotion := TRUE,
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
+    fFlowOffset := 0.4
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -75,7 +75,7 @@ fbIM5K4(
     bEnableMotion := TRUE,
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
-    fFlowOffset := 0.8,
+    fFlowOffset := 0.9,
 
 );]]></ST>
     </Implementation>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -77,7 +77,7 @@ fbIM6K4(
     bEnableMotion := TRUE,
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
-    fFlowOffset := 0.6,
+    fFlowOffset := 0.7,
 );]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
@@ -15,6 +15,8 @@ VAR
                               .fbThermoCouple2.bUnderrange 	:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Underrange;
                               .fbThermoCouple2.bOverrange 	:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Overrange;
                               .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value'}
+
+
     fbPF1K4: FB_WFS;
 
     stSiBP: ST_BeamParams := PMPS_GVL.cstFullBeam;
@@ -74,7 +76,7 @@ fbPF1K4(
     bEnableBeamParams := TRUE,
     bEnablePositionLimits := TRUE,
     eEnumGet => GVL_TcGVL.ePF1K4State,
-);
+    );
 ]]></ST>
     </Implementation>
   </POU>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{0F12739F-5C25-5C7A-BE7F-347F55021D9C}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FD26F0E3-7FD4-D910-8FE6-7B468AC7A2AD}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -79710,6 +79710,7 @@ Digital outputs</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
+            <Comment>IM3K4 and IM4K4 share the same flow meter</Comment>
             <BitSize>2514240</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
@@ -79733,7 +79734,7 @@ Digital outputs</Comment>
                               .fbYagThermoCouple.bUnderrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Underrange;
                               .fbYagThermoCouple.bOverrange 			:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Status^Overrange;
                               .fbYagThermoCouple.iRaw 					:= TIIB[IM3K4-EL3314-E4]^TC Inputs Channel 2^Value;
-                              .fbFlowMeter.iRaw                         := TIIB[IM3K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
+                              .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
             <BitOffs>644786752</BitOffs>
@@ -82646,7 +82647,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-09-06T10:07:28</Value>
+          <Value>2023-09-11T12:06:57</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Need to update all PPM flow meters to match the sensors reading on the wall
<!--- Describe your changes in detail -->
IM3K4 look at IM4K4 flow meter because ME connects the same cooling tube between IM3K4 and IM4K4
update IM4K4, IM5K4, IM6K4 offset to match the sensor readings on the wall
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Per scientists request
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Yes, I checked the new reading from the GUI and looks that the GUI reading from all PPM are very close to the sensor readings on the wall
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

https://jira.slac.stanford.edu/browse/ECS-3739
https://jira.slac.stanford.edu/browse/ECS-3740
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
