### PR TITLE
fixing PF1K4-target1-value modify from epics level

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -4950,10 +4950,6 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -5297,11 +5293,11 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
+					<Name>PRG_SP1K4.bHallInput2</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K4.bTL1Low</Name>
+					<Name>PRG_SP1K4.bTL1High</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -6054,6 +6050,10 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1Low</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K4.bTL2High</Name>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_AL1K4_L2SI.TcPOU
@@ -10,22 +10,29 @@ VAR
     {attribute 'TcLinkTo' := '.fbLaser.iLaserINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 1^Analog output;
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output'}
     fbAL1K4: FB_REF;
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
 
-fbAL1K4.stOut.fPosition := -33.5; // Upper limit
+//fbAL1K4.stOut.fPosition := -33.5; // Upper limit
 fbAL1K4.stOut.bUseRawCounts := FALSE;
 fbAL1K4.stOut.bValid := TRUE;
 fbAL1K4.stOut.bMoveOk := TRUE;
 fbAL1K4.stOut.stPMPS.sPmpsState := 'AL1K4:L2SI-OUT';
 
-fbAL1K4.stIn.fPosition := -75; // Current position at time of edit
+//fbAL1K4.stIn.fPosition := -75; // Current position at time of edit
 fbAL1K4.stIn.bUseRawCounts := FALSE;
 fbAL1K4.stIn.bValid := TRUE;
 fbAL1K4.stIn.bMoveOk := TRUE;
 fbAL1K4.stIn.stPMPS.sPmpsState := 'AL1K4:L2SI-IN';
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbAL1K4.stOut.fPosition := -33.5;
+   fbAL1K4.stIn.fPosition := -75;
+END_IF
 
 fbAL1K4(
     stYStage := Main.M1,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM2K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM2K4_PPM.TcPOU
@@ -20,38 +20,48 @@ VAR
                               .fbYagThermoCouple.iRaw := TIIB[IM2K4-EL3314-E4]^TC Inputs Channel 2^Value'}
     fbIM2K4: FB_PPM;
     fStartupVelo: LREAL := 13;
-
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
-fbIM2K4.stOut.fPosition := -8.59;
+//fbIM2K4.stOut.fPosition := -8.59;
 fbIM2K4.stOut.fVelocity := fStartupVelo;
 fbIM2K4.stOut.bUseRawCounts := FALSE;
 fbIM2K4.stOut.bValid := TRUE;
 fbIM2K4.stOut.bMoveOk := TRUE;
 fbIM2K4.stOut.stPMPS.sPmpsState := 'IM2K4:PPM-OUT';
 
-fbIM2K4.stPower.fPosition := -47.69;
+//fbIM2K4.stPower.fPosition := -47.69;
 fbIM2K4.stPower.fVelocity := fStartupVelo;
 fbIM2K4.stPower.bUseRawCounts := FALSE;
 fbIM2K4.stPower.bValid := TRUE;
 fbIM2K4.stPower.bMoveOk := TRUE;
 fbIM2K4.stPower.stPMPS.sPmpsState := 'IM2K4:PPM-POWERMETER';
 
-fbIM2K4.stYag1.fPosition := -71.69;
+//fbIM2K4.stYag1.fPosition := -71.69;
 fbIM2K4.stYag1.fVelocity := fStartupVelo;
 fbIM2K4.stYag1.bUseRawCounts := FALSE;
 fbIM2K4.stYag1.bValid := TRUE;
 fbIM2K4.stYag1.bMoveOk := TRUE;
 fbIM2K4.stYag1.stPMPS.sPmpsState := 'IM2K4:PPM-YAG1';
 
-fbIM2K4.stYag2.fPosition := -97.70;
+//fbIM2K4.stYag2.fPosition := -97.70;
 fbIM2K4.stYag2.fVelocity := fStartupVelo;
 fbIM2K4.stYag2.bUseRawCounts := FALSE;
 fbIM2K4.stYag2.bValid := TRUE;
 fbIM2K4.stYag2.bMoveOk := TRUE;
 fbIM2K4.stYag2.stPMPS.sPmpsState := 'IM2K4:PPM-YAG2';
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbIM2K4.stOut.fPosition := -8.59;
+   fbIM2K4.stPower.fPosition := -47.69;
+   fbIM2K4.stYag1.fPosition := -71.69;
+   fbIM2K4.stYag2.fPosition := -97.70;
+
+END_IF
+
 
 fbIM2K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM3K4_PPM.TcPOU
@@ -21,38 +21,47 @@ VAR
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value'} //IM3K4 and IM4K4 share the same flow meter
     fbIM3K4: FB_PPM;
     fStartupVelo: LREAL := 12;
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
 
-fbIM3K4.stOut.fPosition := -5.82;
+//fbIM3K4.stOut.fPosition := -5.82;
 fbIM3K4.stOut.fVelocity := fStartupVelo;
 fbIM3K4.stOut.bUseRawCounts := FALSE;
 fbIM3K4.stOut.bValid := TRUE;
 fbIM3K4.stOut.bMoveOk := TRUE;
 fbIM3K4.stOut.stPMPS.sPmpsState := 'IM3K4:PPM-OUT';
 
-fbIM3K4.stPower.fPosition := -44.92;
+//fbIM3K4.stPower.fPosition := -44.92;
 fbIM3K4.stPower.fVelocity := fStartupVelo;
 fbIM3K4.stPower.bUseRawCounts := FALSE;
 fbIM3K4.stPower.bValid := TRUE;
 fbIM3K4.stPower.bMoveOk := TRUE;
 fbIM3K4.stPower.stPMPS.sPmpsState := 'IM3K4:PPM-POWERMETER';
 
-fbIM3K4.stYag1.fPosition := -68.92;
+//fbIM3K4.stYag1.fPosition := -68.92;
 fbIM3K4.stYag1.fVelocity := fStartupVelo;
 fbIM3K4.stYag1.bUseRawCounts := FALSE;
 fbIM3K4.stYag1.bValid := TRUE;
 fbIM3K4.stYag1.bMoveOk := TRUE;
 fbIM3K4.stYag1.stPMPS.sPmpsState := 'IM3K4:PPM-YAG1';
 
-fbIM3K4.stYag2.fPosition := -94.93;
+//fbIM3K4.stYag2.fPosition := -94.93;
 fbIM3K4.stYag2.fVelocity := fStartupVelo;
 fbIM3K4.stYag2.bUseRawCounts := FALSE;
 fbIM3K4.stYag2.bValid := TRUE;
 fbIM3K4.stYag2.bMoveOk := TRUE;
 fbIM3K4.stYag2.stPMPS.sPmpsState := 'IM3K4:PPM-YAG2';
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbIM3K4.stOut.fPosition := -5.82;
+   fbIM3K4.stPower.fPosition := -44.92;
+   fbIM3K4.stYag1.fPosition := -68.92;
+   fbIM3K4.stYag2.fPosition := -94.93;
+END_IF
 
 fbIM3K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM4K4_PPM.TcPOU
@@ -21,32 +21,33 @@ VAR
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM4K4: FB_PPM;
     fStartupVelo: LREAL := 15;
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
-fbIM4K4.stOut.fPosition := -9.29;
+//fbIM4K4.stOut.fPosition := -9.29;
 fbIM4K4.stOut.fVelocity := fStartupVelo;
 fbIM4K4.stOut.bUseRawCounts := FALSE;
 fbIM4K4.stOut.bValid := TRUE;
 fbIM4K4.stOut.bMoveOk := TRUE;
 fbIM4K4.stOut.stPMPS.sPmpsState := 'IM4K4:PPM-OUT';
 
-fbIM4K4.stPower.fPosition := -48.39;
+//fbIM4K4.stPower.fPosition := -48.39;
 fbIM4K4.stPower.fVelocity := fStartupVelo;
 fbIM4K4.stPower.bUseRawCounts := FALSE;
 fbIM4K4.stPower.bValid := TRUE;
 fbIM4K4.stPower.bMoveOk := TRUE;
 fbIM4K4.stPower.stPMPS.sPmpsState := 'IM4K4:PPM-POWERMETER';
 
-fbIM4K4.stYag1.fPosition := -72.39;
+//fbIM4K4.stYag1.fPosition := -72.39;
 fbIM4K4.stYag1.fVelocity := fStartupVelo;
 fbIM4K4.stYag1.bUseRawCounts := FALSE;
 fbIM4K4.stYag1.bValid := TRUE;
 fbIM4K4.stYag1.bMoveOk := TRUE;
 fbIM4K4.stYag1.stPMPS.sPmpsState := 'IM4K4:PPM-YAG1';
 
-fbIM4K4.stYag2.fPosition := -98.4;
+//fbIM4K4.stYag2.fPosition := -98.4;
 fbIM4K4.stYag2.fVelocity := fStartupVelo;
 fbIM4K4.stYag2.bUseRawCounts := FALSE;
 fbIM4K4.stYag2.bValid := TRUE;
@@ -58,6 +59,16 @@ IF Main.M16.fVelocity > 1 AND Main.M16.fVelocity <> 15 AND Main.M16.bExecute THE
     Main.M16.nErrorId := 16#4221;
     Main.M16.sCustomErrorMessage := 'Unsafe velocity, try 1 or 15.';
 END_IF
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbIM4K4.stOut.fPosition := -9.29;
+   fbIM4K4.stPower.fPosition := -48.39;
+   fbIM4K4.stYag1.fPosition := -72.39;
+   fbIM4K4.stYag2.fPosition := -98.4;
+END_IF
+
+
 
 fbIM4K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -21,34 +21,34 @@ VAR
                               .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM5K4: FB_PPM;
     fStartupVelo: LREAL := 12;
-
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
 
-fbIM5K4.stOut.fPosition := -5.13;
+//fbIM5K4.stOut.fPosition := -5.13;
 fbIM5K4.stOut.fVelocity := fStartupVelo;
 fbIM5K4.stOut.bUseRawCounts := FALSE;
 fbIM5K4.stOut.bValid := TRUE;
 fbIM5K4.stOut.bMoveOk := TRUE;
 fbIM5K4.stOut.stPMPS.sPmpsState := 'IM5K4:PPM-OUT';
 
-fbIM5K4.stPower.fPosition := -44.23;
+//fbIM5K4.stPower.fPosition := -44.23;
 fbIM5K4.stPower.fVelocity := fStartupVelo;
 fbIM5K4.stPower.bUseRawCounts := FALSE;
 fbIM5K4.stPower.bValid := TRUE;
 fbIM5K4.stPower.bMoveOk := TRUE;
 fbIM5K4.stPower.stPMPS.sPmpsState := 'IM5K4:PPM-POWERMETER';
 
-fbIM5K4.stYag1.fPosition := -68.23;
+//fbIM5K4.stYag1.fPosition := -68.23;
 fbIM5K4.stYag1.fVelocity := fStartupVelo;
 fbIM5K4.stYag1.bUseRawCounts := FALSE;
 fbIM5K4.stYag1.bMoveOk := TRUE;
 fbIM5K4.stYag1.bValid := TRUE;
 
 
-fbIM5K4.stYag2.fPosition := -94.24;
+//fbIM5K4.stYag2.fPosition := -94.24;
 fbIM5K4.stYag2.fVelocity := fStartupVelo;
 fbIM5K4.stYag2.bUseRawCounts := FALSE;
 fbIM5K4.stYag2.bMoveOk := TRUE;
@@ -65,6 +65,14 @@ ELSE
     fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1';
     fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2';
 END_CASE
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbIM5K4.stOut.fPosition := -5.13;
+   fbIM5K4.stPower.fPosition := -44.23;
+   fbIM5K4.stYag1.fPosition := -68.23;
+   fbIM5K4.stYag2.fPosition := -94.24;
+END_IF
 
 fbIM5K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM6K4_PPM.TcPOU
@@ -21,32 +21,33 @@ VAR
                               .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value'}
     fbIM6K4: FB_PPM;
     fStartupVelo: LREAL := 13;
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
-fbIM6K4.stOut.fPosition := -7.4;
+//fbIM6K4.stOut.fPosition := -7.4;
 fbIM6K4.stOut.fVelocity := fStartupVelo;
 fbIM6K4.stOut.bUseRawCounts := FALSE;
 fbIM6K4.stOut.bValid := TRUE;
 fbIM6K4.stOut.bMoveOk := TRUE;
 fbIM6K4.stOut.stPMPS.sPmpsState := 'IM6K4:PPM-OUT';
 
-fbIM6K4.stPower.fPosition := -46.5;
+//fbIM6K4.stPower.fPosition := -46.5;
 fbIM6K4.stPower.fVelocity := fStartupVelo;
 fbIM6K4.stPower.bUseRawCounts := FALSE;
 fbIM6K4.stPower.bValid := TRUE;
 fbIM6K4.stPower.bMoveOk := TRUE;
 fbIM6K4.stPower.stPMPS.sPmpsState := 'IM6K4:PPM-POWERMETER';
 
-fbIM6K4.stYag1.fPosition := -70.5;
+//fbIM6K4.stYag1.fPosition := -70.5;
 fbIM6K4.stYag1.fVelocity := fStartupVelo;
 fbIM6K4.stYag1.bUseRawCounts := FALSE;
 fbIM6K4.stYag1.bValid := TRUE;
 fbIM6K4.stYag1.bMoveOk := TRUE;
 
 
-fbIM6K4.stYag2.fPosition := -96.51;
+//fbIM6K4.stYag2.fPosition := -96.51;
 fbIM6K4.stYag2.fVelocity := fStartupVelo;
 fbIM6K4.stYag2.bUseRawCounts := FALSE;
 fbIM6K4.stYag2.bValid := TRUE;
@@ -64,8 +65,13 @@ ELSE
     fbIM6K4.stYag2.stPMPS.sPmpsState := 'IM6K4:PPM-YAG2';
 END_CASE
 
-
-
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbIM6K4.stOut.fPosition := -7.4;
+   fbIM6K4.stPower.fPosition := -46.5;
+   fbIM6K4.stYag1.fPosition := -70.5;
+   fbIM6K4.stYag2.fPosition := -96.51;
+END_IF
 
 
 fbIM6K4(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI1K4_IP1.TcPOU
@@ -10,7 +10,7 @@ VAR
     fbLI1K4: FB_LIC;
 
     stSiBP: ST_BeamParams := PMPS_GVL.cstFullBeam;
-
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -21,29 +21,37 @@ END_VAR
 //stSiBP.nTran := 0.20;
 
 
-fbLI1K4.stOut.fPosition := 0.118;
+//fbLI1K4.stOut.fPosition := 0.118;
 fbLI1K4.stOut.bUseRawCounts := FALSE;
 fbLI1K4.stOut.bValid := TRUE;
 fbLI1K4.stOut.bMoveOk := TRUE;
 fbLI1K4.stOut.stPMPS.sPmpsState := 'LI1K4:IP1-OUT';
 
-fbLI1K4.stMirror1.fPosition := -36.38;
+//fbLI1K4.stMirror1.fPosition := -36.38;
 fbLI1K4.stMirror1.bUseRawCounts := FALSE;
 fbLI1K4.stMirror1.bValid := TRUE;
 fbLI1K4.stMirror1.bMoveOk := TRUE;
 fbLI1K4.stMirror1.stPMPS.sPmpsState := 'LI1K4:IP1-MIRROR1';
 
-fbLI1K4.stMirror2.fPosition := -70.38;
+//fbLI1K4.stMirror2.fPosition := -70.38;
 fbLI1K4.stMirror2.bUseRawCounts := FALSE;
 fbLI1K4.stMirror2.bValid := TRUE;
 fbLI1K4.stMirror2.bMoveOk := TRUE;
 fbLI1K4.stMirror2.stPMPS.sPmpsState := 'LI1K4:IP1-MIRROR2';
 
-fbLI1K4.stTarget1.fPosition := -102.38;
+//fbLI1K4.stTarget1.fPosition := -102.38;
 fbLI1K4.stTarget1.bUseRawCounts := FALSE;
 fbLI1K4.stTarget1.bValid := TRUE;
 fbLI1K4.stTarget1.bMoveOk := TRUE;
 fbLI1K4.stTarget1.stPMPS.sPmpsState := 'LI1K4:IP1-TARGET1';
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbLI1K4.stOut.fPosition := 0.118;
+   fbLI1K4.stMirror1.fPosition := -36.38;
+   fbLI1K4.stMirror2.fPosition := -70.38;
+   fbLI1K4.stTarget1.fPosition := -102.38;
+END_IF
 
 fbLI1K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
@@ -20,6 +20,8 @@ VAR
     fbPF1K4: FB_WFS;
 
     stSiBP: ST_BeamParams := PMPS_GVL.cstFullBeam;
+
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -29,41 +31,53 @@ END_VAR
 //stSiBP.nTran := 0.20;
 
 
-fbPF1K4.stOut.fPosition := -10.5;
+//fbPF1K4.stOut.fPosition := -10.5;
 fbPF1K4.stOut.bUseRawCounts := FALSE;
 fbPF1K4.stOut.bValid := TRUE;
 fbPF1K4.stOut.bMoveOk := TRUE;
 fbPF1K4.stOut.stPMPS.sPmpsState := 'PF1K4:WFS-OUT';
 
-fbPF1K4.stTarget1.fPosition := -93.033;
+//fbPF1K4.stTarget1.fPosition := -93.033;
 fbPF1K4.stTarget1.bUseRawCounts := FALSE;
 fbPF1K4.stTarget1.bValid := TRUE;
 fbPF1K4.stTarget1.bMoveOk := TRUE;
 fbPF1K4.stTarget1.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET1';
 
-fbPF1K4.stTarget2.fPosition := -78.658;
+//fbPF1K4.stTarget2.fPosition := -78.658;
 fbPF1K4.stTarget2.bUseRawCounts := FALSE;
 fbPF1K4.stTarget2.bValid := TRUE;
 fbPF1K4.stTarget2.bMoveOk := TRUE;
 fbPF1K4.stTarget2.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET2';
 
-fbPF1K4.stTarget3.fPosition := -64.282;
+//fbPF1K4.stTarget3.fPosition := -64.282;
 fbPF1K4.stTarget3.bUseRawCounts := FALSE;
 fbPF1K4.stTarget3.bValid := TRUE;
 fbPF1K4.stTarget3.bMoveOk := TRUE;
 fbPF1K4.stTarget3.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET3';
 
-fbPF1K4.stTarget4.fPosition := -49.907;
+//fbPF1K4.stTarget4.fPosition := -49.907;
 fbPF1K4.stTarget4.bUseRawCounts := FALSE;
 fbPF1K4.stTarget4.bValid := TRUE;
 fbPF1K4.stTarget4.bMoveOk := TRUE;
 fbPF1K4.stTarget4.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET4';
 
-fbPF1K4.stTarget5.fPosition := -35.533;
+//fbPF1K4.stTarget5.fPosition := -35.533;
 fbPF1K4.stTarget5.bUseRawCounts := FALSE;
 fbPF1K4.stTarget5.bValid := TRUE;
 fbPF1K4.stTarget5.bMoveOk := TRUE;
 fbPF1K4.stTarget5.stPMPS.sPmpsState := 'PF1K4:WFS-TARGET5';
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbPF1K4.stOut.fPosition := -10.5;
+   fbPF1K4.stTarget1.fPosition := -93.033;
+   fbPF1K4.stTarget2.fPosition := -78.658;
+   fbPF1K4.stTarget3.fPosition := -64.282;
+   fbPF1K4.stTarget4.fPosition := -49.907;
+   fbPF1K4.stTarget5.fPosition := -35.533;
+
+END_IF
+
 
 fbPF1K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
@@ -18,6 +18,7 @@ VAR
     fbPF2K4: FB_WFS;
 
     stSiBP: ST_BeamParams := PMPS_GVL.cstFullBeam;
+    bInit: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -26,41 +27,54 @@ END_VAR
 // Drop transmission to 20%
 //stSiBP.nTran := 0.20;
 
-fbPF2K4.stOut.fPosition := -13.5;
+//fbPF2K4.stOut.fPosition := -13.5;
 fbPF2K4.stOut.bUseRawCounts := FALSE;
 fbPF2K4.stOut.bValid := TRUE;
 fbPF2K4.stOut.bMoveOk := TRUE;
 fbPF2K4.stOut.stPMPS.sPmpsState := 'PF2K4:WFS-OUT';
 
-fbPF2K4.stTarget1.fPosition := -96.127;
+//fbPF2K4.stTarget1.fPosition := -96.127;
 fbPF2K4.stTarget1.bUseRawCounts := FALSE;
 fbPF2K4.stTarget1.bValid := TRUE;
 fbPF2K4.stTarget1.bMoveOk := TRUE;
 fbPF2K4.stTarget1.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET1';
 
-fbPF2K4.stTarget2.fPosition := -81.753;
+//fbPF2K4.stTarget2.fPosition := -81.753;
 fbPF2K4.stTarget2.bUseRawCounts := FALSE;
 fbPF2K4.stTarget2.bValid := TRUE;
 fbPF2K4.stTarget2.bMoveOk := TRUE;
 fbPF2K4.stTarget2.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET2';
 
-fbPF2K4.stTarget3.fPosition := -67.378;
+//fbPF2K4.stTarget3.fPosition := -67.378;
 fbPF2K4.stTarget3.bUseRawCounts := FALSE;
 fbPF2K4.stTarget3.bValid := TRUE;
 fbPF2K4.stTarget3.bMoveOk := TRUE;
 fbPF2K4.stTarget3.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET3';
 
-fbPF2K4.stTarget4.fPosition := -53.002;
+//fbPF2K4.stTarget4.fPosition := -53.002;
 fbPF2K4.stTarget4.bUseRawCounts := FALSE;
 fbPF2K4.stTarget4.bValid := TRUE;
 fbPF2K4.stTarget4.bMoveOk := TRUE;
 fbPF2K4.stTarget4.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET4';
 
-fbPF2K4.stTarget5.fPosition := -38.627;
+//fbPF2K4.stTarget5.fPosition := -38.627;
 fbPF2K4.stTarget5.bUseRawCounts := FALSE;
 fbPF2K4.stTarget5.bValid := TRUE;
 fbPF2K4.stTarget5.bMoveOk := TRUE;
 fbPF2K4.stTarget5.stPMPS.sPmpsState := 'PF2K4:WFS-TARGET5';
+
+IF NOT bInit THEN
+   bInit := TRUE;
+   fbPF2K4.stOut.fPosition := -13.5;
+   fbPF2K4.stTarget1.fPosition := -96.127;
+   fbPF2K4.stTarget2.fPosition := -81.753;
+   fbPF2K4.stTarget3.fPosition := -67.387;
+   fbPF2K4.stTarget4.fPosition := -53.002;
+   fbPF2K4.stTarget5.fPosition := -38.627;
+
+END_IF
+
+
 
 fbPF2K4(
     fbArbiter := fbArbiter2,

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FD26F0E3-7FD4-D910-8FE6-7B468AC7A2AD}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{7A06D170-B721-B7FC-296D-7F13562B6A5B}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85690500</GetCodeOffs>
+        <GetCodeOffs>85690508</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85690532</GetCodeOffs>
+        <GetCodeOffs>85690540</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690540</GetCodeOffs>
+        <GetCodeOffs>85690548</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690524</GetCodeOffs>
+        <GetCodeOffs>85690532</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690536</GetCodeOffs>
+        <GetCodeOffs>85690544</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690444</GetCodeOffs>
-        <SetCodeOffs>85690468</SetCodeOffs>
+        <GetCodeOffs>85690452</GetCodeOffs>
+        <SetCodeOffs>85690476</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690480</GetCodeOffs>
-        <SetCodeOffs>85690492</SetCodeOffs>
+        <GetCodeOffs>85690488</GetCodeOffs>
+        <SetCodeOffs>85690500</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>85690588</GetCodeOffs>
+        <GetCodeOffs>85690596</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690568</GetCodeOffs>
+        <GetCodeOffs>85690576</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85690656</GetCodeOffs>
+        <GetCodeOffs>85690664</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690616</GetCodeOffs>
+        <GetCodeOffs>85690624</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85690660</GetCodeOffs>
+        <GetCodeOffs>85690668</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85690684</GetCodeOffs>
+        <GetCodeOffs>85690692</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -52958,6 +52958,39 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
       <BitSize>87808</BitSize>
       <SubItem>
@@ -53509,39 +53542,6 @@ Digital outputs</Comment>
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
     </DataType>
     <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
@@ -54305,8 +54305,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85697216</GetCodeOffs>
-        <SetCodeOffs>85697224</SetCodeOffs>
+        <GetCodeOffs>85697224</GetCodeOffs>
+        <SetCodeOffs>85697232</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -55600,31 +55600,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85696784</GetCodeOffs>
+        <GetCodeOffs>85696792</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85696816</GetCodeOffs>
+        <GetCodeOffs>85696824</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85696820</GetCodeOffs>
+        <GetCodeOffs>85696828</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85696808</GetCodeOffs>
+        <GetCodeOffs>85696816</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85696828</GetCodeOffs>
+        <GetCodeOffs>85696836</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -64074,23 +64074,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662609776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bHallInput2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[LensX_EL1004]^Channel 2^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662609784</BitOffs>
+            <BitOffs>662609848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64102,7 +64086,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662613376</BitOffs>
+            <BitOffs>662613440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64114,7 +64098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662911296</BitOffs>
+            <BitOffs>662911360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64126,7 +64110,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663209216</BitOffs>
+            <BitOffs>663209280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64138,7 +64122,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663507136</BitOffs>
+            <BitOffs>663507200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
@@ -64150,7 +64134,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663952832</BitOffs>
+            <BitOffs>663952896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -64163,7 +64147,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664065312</BitOffs>
+            <BitOffs>664065376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -64175,7 +64159,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664065320</BitOffs>
+            <BitOffs>664065384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64187,7 +64171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664100480</BitOffs>
+            <BitOffs>664100544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64199,7 +64183,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664398400</BitOffs>
+            <BitOffs>664398464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -64223,7 +64207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389832</BitOffs>
+            <BitOffs>665389896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -64235,7 +64219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389840</BitOffs>
+            <BitOffs>665389904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -64247,7 +64231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389848</BitOffs>
+            <BitOffs>665389912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -64259,7 +64243,23 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665389856</BitOffs>
+            <BitOffs>665389920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bHallInput2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[LensX_EL1004]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>665390432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1High</Name>
@@ -64275,23 +64275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665390368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.bTL1Low</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>665390376</BitOffs>
+            <BitOffs>665390440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64303,7 +64287,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665416320</BitOffs>
+            <BitOffs>665416384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64315,7 +64299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665714240</BitOffs>
+            <BitOffs>665714304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -64339,7 +64323,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698376</BitOffs>
+            <BitOffs>666698440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -64351,7 +64335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698384</BitOffs>
+            <BitOffs>666698448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -64363,7 +64347,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698392</BitOffs>
+            <BitOffs>666698456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -64375,7 +64359,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666698400</BitOffs>
+            <BitOffs>666698464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64387,7 +64371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666701504</BitOffs>
+            <BitOffs>666701568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64399,7 +64383,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666999424</BitOffs>
+            <BitOffs>666999488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64411,7 +64395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667297344</BitOffs>
+            <BitOffs>667297408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64423,7 +64407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667595264</BitOffs>
+            <BitOffs>667595328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64435,7 +64419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667893184</BitOffs>
+            <BitOffs>667893248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64447,7 +64431,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668191104</BitOffs>
+            <BitOffs>668191168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64459,7 +64443,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668489024</BitOffs>
+            <BitOffs>668489088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64471,7 +64455,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668786944</BitOffs>
+            <BitOffs>668787008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64483,7 +64467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669084864</BitOffs>
+            <BitOffs>669084928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64495,7 +64479,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669382784</BitOffs>
+            <BitOffs>669382848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64507,7 +64491,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669680704</BitOffs>
+            <BitOffs>669680768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64519,7 +64503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669978624</BitOffs>
+            <BitOffs>669978688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64531,7 +64515,23 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670276544</BitOffs>
+            <BitOffs>670276608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL1Low</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>670572032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2High</Name>
@@ -64547,7 +64547,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670571984</BitOffs>
+            <BitOffs>670572040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2Low</Name>
@@ -64563,7 +64563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670571992</BitOffs>
+            <BitOffs>670572080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64575,7 +64575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671839808</BitOffs>
+            <BitOffs>671839872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64588,7 +64588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847744</BitOffs>
+            <BitOffs>671847808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64601,7 +64601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847752</BitOffs>
+            <BitOffs>671847816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -64614,7 +64614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847760</BitOffs>
+            <BitOffs>671847824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64637,7 +64637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847776</BitOffs>
+            <BitOffs>671847840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -64650,7 +64650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847808</BitOffs>
+            <BitOffs>671847872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -64663,7 +64663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847872</BitOffs>
+            <BitOffs>671847936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -64676,7 +64676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671847888</BitOffs>
+            <BitOffs>671847952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -64688,7 +64688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671865024</BitOffs>
+            <BitOffs>671865088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -64701,7 +64701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872960</BitOffs>
+            <BitOffs>671873024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -64714,7 +64714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872968</BitOffs>
+            <BitOffs>671873032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -64727,7 +64727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872976</BitOffs>
+            <BitOffs>671873040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -64750,7 +64750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671872992</BitOffs>
+            <BitOffs>671873056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -64763,7 +64763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873024</BitOffs>
+            <BitOffs>671873088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -64776,7 +64776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873088</BitOffs>
+            <BitOffs>671873152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -64789,7 +64789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671873104</BitOffs>
+            <BitOffs>671873168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -64801,7 +64801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671890240</BitOffs>
+            <BitOffs>671890304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -64814,7 +64814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898176</BitOffs>
+            <BitOffs>671898240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -64827,7 +64827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898184</BitOffs>
+            <BitOffs>671898248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -64840,7 +64840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898192</BitOffs>
+            <BitOffs>671898256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -64863,7 +64863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898208</BitOffs>
+            <BitOffs>671898272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -64876,7 +64876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898240</BitOffs>
+            <BitOffs>671898304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -64889,7 +64889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898304</BitOffs>
+            <BitOffs>671898368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -64902,7 +64902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671898320</BitOffs>
+            <BitOffs>671898384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64914,7 +64914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673601792</BitOffs>
+            <BitOffs>673601920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64927,7 +64927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609728</BitOffs>
+            <BitOffs>673609856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64940,7 +64940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609736</BitOffs>
+            <BitOffs>673609864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -64953,7 +64953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609744</BitOffs>
+            <BitOffs>673609872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64976,7 +64976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609760</BitOffs>
+            <BitOffs>673609888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -64989,7 +64989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609792</BitOffs>
+            <BitOffs>673609920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -65002,7 +65002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609856</BitOffs>
+            <BitOffs>673609984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -65015,7 +65015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673609872</BitOffs>
+            <BitOffs>673610000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -65027,7 +65027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673627008</BitOffs>
+            <BitOffs>673627136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -65040,7 +65040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634944</BitOffs>
+            <BitOffs>673635072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -65053,7 +65053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634952</BitOffs>
+            <BitOffs>673635080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -65066,7 +65066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634960</BitOffs>
+            <BitOffs>673635088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -65089,7 +65089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673634976</BitOffs>
+            <BitOffs>673635104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -65102,7 +65102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635008</BitOffs>
+            <BitOffs>673635136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -65115,7 +65115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635072</BitOffs>
+            <BitOffs>673635200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -65128,7 +65128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673635088</BitOffs>
+            <BitOffs>673635216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -65140,7 +65140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673652224</BitOffs>
+            <BitOffs>673652352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -65153,7 +65153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660160</BitOffs>
+            <BitOffs>673660288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -65166,7 +65166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660168</BitOffs>
+            <BitOffs>673660296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -65179,7 +65179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660176</BitOffs>
+            <BitOffs>673660304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -65202,7 +65202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660192</BitOffs>
+            <BitOffs>673660320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -65215,7 +65215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660224</BitOffs>
+            <BitOffs>673660352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -65228,7 +65228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660288</BitOffs>
+            <BitOffs>673660416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -65241,7 +65241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673660304</BitOffs>
+            <BitOffs>673660432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -65257,7 +65257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674042912</BitOffs>
+            <BitOffs>674042976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -65278,7 +65278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674046432</BitOffs>
+            <BitOffs>674046496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -65299,7 +65299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674046433</BitOffs>
+            <BitOffs>674046497</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -65311,7 +65311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684244864</BitOffs>
+            <BitOffs>684244928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -65324,7 +65324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252800</BitOffs>
+            <BitOffs>684252864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -65337,7 +65337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252808</BitOffs>
+            <BitOffs>684252872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -65350,7 +65350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252816</BitOffs>
+            <BitOffs>684252880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -65373,7 +65373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252832</BitOffs>
+            <BitOffs>684252896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -65386,7 +65386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252864</BitOffs>
+            <BitOffs>684252928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -65399,7 +65399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252928</BitOffs>
+            <BitOffs>684252992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -65412,7 +65412,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684252944</BitOffs>
+            <BitOffs>684253008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -65424,7 +65424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684270080</BitOffs>
+            <BitOffs>684270144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -65437,7 +65437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278016</BitOffs>
+            <BitOffs>684278080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -65450,7 +65450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278024</BitOffs>
+            <BitOffs>684278088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -65463,7 +65463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278032</BitOffs>
+            <BitOffs>684278096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -65486,7 +65486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278048</BitOffs>
+            <BitOffs>684278112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -65499,7 +65499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278080</BitOffs>
+            <BitOffs>684278144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -65512,7 +65512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278144</BitOffs>
+            <BitOffs>684278208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -65525,7 +65525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684278160</BitOffs>
+            <BitOffs>684278224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -65537,7 +65537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684295296</BitOffs>
+            <BitOffs>684295360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -65550,7 +65550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303232</BitOffs>
+            <BitOffs>684303296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -65563,7 +65563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303240</BitOffs>
+            <BitOffs>684303304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -65576,7 +65576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303248</BitOffs>
+            <BitOffs>684303312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -65599,7 +65599,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303264</BitOffs>
+            <BitOffs>684303328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -65612,7 +65612,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303296</BitOffs>
+            <BitOffs>684303360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -65625,7 +65625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303360</BitOffs>
+            <BitOffs>684303424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -65638,7 +65638,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684303376</BitOffs>
+            <BitOffs>684303440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -65650,7 +65650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684320512</BitOffs>
+            <BitOffs>684320576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -65663,7 +65663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328448</BitOffs>
+            <BitOffs>684328512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -65676,7 +65676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328456</BitOffs>
+            <BitOffs>684328520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -65689,7 +65689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328464</BitOffs>
+            <BitOffs>684328528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -65712,7 +65712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328480</BitOffs>
+            <BitOffs>684328544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -65725,7 +65725,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328512</BitOffs>
+            <BitOffs>684328576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -65738,7 +65738,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328576</BitOffs>
+            <BitOffs>684328640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -65751,7 +65751,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684328592</BitOffs>
+            <BitOffs>684328656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -65763,7 +65763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684345728</BitOffs>
+            <BitOffs>684345792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -65776,7 +65776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353664</BitOffs>
+            <BitOffs>684353728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -65789,7 +65789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353672</BitOffs>
+            <BitOffs>684353736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -65802,7 +65802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353680</BitOffs>
+            <BitOffs>684353744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -65825,7 +65825,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353696</BitOffs>
+            <BitOffs>684353760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -65838,7 +65838,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353728</BitOffs>
+            <BitOffs>684353792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -65851,7 +65851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353792</BitOffs>
+            <BitOffs>684353856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -65864,7 +65864,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684353808</BitOffs>
+            <BitOffs>684353872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -65876,7 +65876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684370944</BitOffs>
+            <BitOffs>684371008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -65889,7 +65889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378880</BitOffs>
+            <BitOffs>684378944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -65902,7 +65902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378888</BitOffs>
+            <BitOffs>684378952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -65915,7 +65915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378896</BitOffs>
+            <BitOffs>684378960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -65938,7 +65938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378912</BitOffs>
+            <BitOffs>684378976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -65951,7 +65951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684378944</BitOffs>
+            <BitOffs>684379008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -65964,7 +65964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379008</BitOffs>
+            <BitOffs>684379072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -65977,7 +65977,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684379024</BitOffs>
+            <BitOffs>684379088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -65989,7 +65989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684396160</BitOffs>
+            <BitOffs>684396224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -66002,7 +66002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404096</BitOffs>
+            <BitOffs>684404160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -66015,7 +66015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404104</BitOffs>
+            <BitOffs>684404168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -66028,7 +66028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404112</BitOffs>
+            <BitOffs>684404176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -66051,7 +66051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404128</BitOffs>
+            <BitOffs>684404192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -66064,7 +66064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404160</BitOffs>
+            <BitOffs>684404224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -66077,7 +66077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404224</BitOffs>
+            <BitOffs>684404288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -66090,7 +66090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684404240</BitOffs>
+            <BitOffs>684404304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -66102,7 +66102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684421376</BitOffs>
+            <BitOffs>684421440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -66115,7 +66115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429312</BitOffs>
+            <BitOffs>684429376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -66128,7 +66128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429320</BitOffs>
+            <BitOffs>684429384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -66141,7 +66141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429328</BitOffs>
+            <BitOffs>684429392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -66164,7 +66164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429344</BitOffs>
+            <BitOffs>684429408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -66177,7 +66177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429376</BitOffs>
+            <BitOffs>684429440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -66190,7 +66190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429440</BitOffs>
+            <BitOffs>684429504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -66203,7 +66203,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684429456</BitOffs>
+            <BitOffs>684429520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -66215,7 +66215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684446592</BitOffs>
+            <BitOffs>684446656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -66228,7 +66228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454528</BitOffs>
+            <BitOffs>684454592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -66241,7 +66241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454536</BitOffs>
+            <BitOffs>684454600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -66254,7 +66254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454544</BitOffs>
+            <BitOffs>684454608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -66277,7 +66277,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454560</BitOffs>
+            <BitOffs>684454624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -66290,7 +66290,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454592</BitOffs>
+            <BitOffs>684454656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -66303,7 +66303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454656</BitOffs>
+            <BitOffs>684454720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -66316,7 +66316,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684454672</BitOffs>
+            <BitOffs>684454736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -66328,7 +66328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684471808</BitOffs>
+            <BitOffs>684471872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -66341,7 +66341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479744</BitOffs>
+            <BitOffs>684479808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -66354,7 +66354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479752</BitOffs>
+            <BitOffs>684479816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -66367,7 +66367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479760</BitOffs>
+            <BitOffs>684479824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -66390,7 +66390,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479776</BitOffs>
+            <BitOffs>684479840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -66403,7 +66403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479808</BitOffs>
+            <BitOffs>684479872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -66416,7 +66416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479872</BitOffs>
+            <BitOffs>684479936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -66429,7 +66429,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684479888</BitOffs>
+            <BitOffs>684479952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -66441,7 +66441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684497024</BitOffs>
+            <BitOffs>684497088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -66454,7 +66454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504960</BitOffs>
+            <BitOffs>684505024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -66467,7 +66467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504968</BitOffs>
+            <BitOffs>684505032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -66480,7 +66480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504976</BitOffs>
+            <BitOffs>684505040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -66503,7 +66503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684504992</BitOffs>
+            <BitOffs>684505056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -66516,7 +66516,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505024</BitOffs>
+            <BitOffs>684505088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -66529,7 +66529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505088</BitOffs>
+            <BitOffs>684505152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -66542,7 +66542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684505104</BitOffs>
+            <BitOffs>684505168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -66554,7 +66554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684522240</BitOffs>
+            <BitOffs>684522304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -66567,7 +66567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530176</BitOffs>
+            <BitOffs>684530240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -66580,7 +66580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530184</BitOffs>
+            <BitOffs>684530248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -66593,7 +66593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530192</BitOffs>
+            <BitOffs>684530256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -66616,7 +66616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530208</BitOffs>
+            <BitOffs>684530272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -66629,7 +66629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530240</BitOffs>
+            <BitOffs>684530304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -66642,7 +66642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530304</BitOffs>
+            <BitOffs>684530368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -66655,7 +66655,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684530320</BitOffs>
+            <BitOffs>684530384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -66667,7 +66667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684547456</BitOffs>
+            <BitOffs>684547520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -66680,7 +66680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555392</BitOffs>
+            <BitOffs>684555456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -66693,7 +66693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555400</BitOffs>
+            <BitOffs>684555464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -66706,7 +66706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555408</BitOffs>
+            <BitOffs>684555472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -66729,7 +66729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555424</BitOffs>
+            <BitOffs>684555488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -66742,7 +66742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555456</BitOffs>
+            <BitOffs>684555520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -66755,7 +66755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555520</BitOffs>
+            <BitOffs>684555584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -66768,7 +66768,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684555536</BitOffs>
+            <BitOffs>684555600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -66780,7 +66780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684572672</BitOffs>
+            <BitOffs>684572736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -66793,7 +66793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580608</BitOffs>
+            <BitOffs>684580672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -66806,7 +66806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580616</BitOffs>
+            <BitOffs>684580680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -66819,7 +66819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580624</BitOffs>
+            <BitOffs>684580688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -66842,7 +66842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580640</BitOffs>
+            <BitOffs>684580704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -66855,7 +66855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580672</BitOffs>
+            <BitOffs>684580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -66868,7 +66868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580736</BitOffs>
+            <BitOffs>684580800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -66881,7 +66881,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684580752</BitOffs>
+            <BitOffs>684580816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -66893,7 +66893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684597888</BitOffs>
+            <BitOffs>684597952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -66906,7 +66906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605824</BitOffs>
+            <BitOffs>684605888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -66919,7 +66919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605832</BitOffs>
+            <BitOffs>684605896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -66932,7 +66932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605840</BitOffs>
+            <BitOffs>684605904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -66955,7 +66955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605856</BitOffs>
+            <BitOffs>684605920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -66968,7 +66968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605888</BitOffs>
+            <BitOffs>684605952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -66981,7 +66981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605952</BitOffs>
+            <BitOffs>684606016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -66994,7 +66994,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684605968</BitOffs>
+            <BitOffs>684606032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -67006,7 +67006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684623104</BitOffs>
+            <BitOffs>684623168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -67019,7 +67019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631040</BitOffs>
+            <BitOffs>684631104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -67032,7 +67032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631048</BitOffs>
+            <BitOffs>684631112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -67045,7 +67045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631056</BitOffs>
+            <BitOffs>684631120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -67068,7 +67068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631072</BitOffs>
+            <BitOffs>684631136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -67081,7 +67081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631104</BitOffs>
+            <BitOffs>684631168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -67094,7 +67094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631168</BitOffs>
+            <BitOffs>684631232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -67107,7 +67107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684631184</BitOffs>
+            <BitOffs>684631248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -67119,7 +67119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684648320</BitOffs>
+            <BitOffs>684648384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -67132,7 +67132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656256</BitOffs>
+            <BitOffs>684656320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -67145,7 +67145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656264</BitOffs>
+            <BitOffs>684656328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -67158,7 +67158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656272</BitOffs>
+            <BitOffs>684656336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -67181,7 +67181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656288</BitOffs>
+            <BitOffs>684656352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -67194,7 +67194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656320</BitOffs>
+            <BitOffs>684656384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -67207,7 +67207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656384</BitOffs>
+            <BitOffs>684656448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -67220,7 +67220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684656400</BitOffs>
+            <BitOffs>684656464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -67232,7 +67232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684673536</BitOffs>
+            <BitOffs>684673600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -67245,7 +67245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681472</BitOffs>
+            <BitOffs>684681536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -67258,7 +67258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681480</BitOffs>
+            <BitOffs>684681544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -67271,7 +67271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681488</BitOffs>
+            <BitOffs>684681552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -67294,7 +67294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681504</BitOffs>
+            <BitOffs>684681568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -67307,7 +67307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681536</BitOffs>
+            <BitOffs>684681600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -67320,7 +67320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681600</BitOffs>
+            <BitOffs>684681664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -67333,7 +67333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684681616</BitOffs>
+            <BitOffs>684681680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -67345,7 +67345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684698752</BitOffs>
+            <BitOffs>684698816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -67358,7 +67358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706688</BitOffs>
+            <BitOffs>684706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -67371,7 +67371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706696</BitOffs>
+            <BitOffs>684706760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -67384,7 +67384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706704</BitOffs>
+            <BitOffs>684706768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -67407,7 +67407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706720</BitOffs>
+            <BitOffs>684706784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -67420,7 +67420,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706752</BitOffs>
+            <BitOffs>684706816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -67433,7 +67433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706816</BitOffs>
+            <BitOffs>684706880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -67446,7 +67446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684706832</BitOffs>
+            <BitOffs>684706896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -67458,7 +67458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684723968</BitOffs>
+            <BitOffs>684724032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -67471,7 +67471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731904</BitOffs>
+            <BitOffs>684731968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -67484,7 +67484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731912</BitOffs>
+            <BitOffs>684731976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -67497,7 +67497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731920</BitOffs>
+            <BitOffs>684731984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -67520,7 +67520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731936</BitOffs>
+            <BitOffs>684732000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -67533,7 +67533,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684731968</BitOffs>
+            <BitOffs>684732032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -67546,7 +67546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732032</BitOffs>
+            <BitOffs>684732096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -67559,7 +67559,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684732048</BitOffs>
+            <BitOffs>684732112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -67571,7 +67571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684749184</BitOffs>
+            <BitOffs>684749248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -67584,7 +67584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757120</BitOffs>
+            <BitOffs>684757184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -67597,7 +67597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757128</BitOffs>
+            <BitOffs>684757192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -67610,7 +67610,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757136</BitOffs>
+            <BitOffs>684757200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -67633,7 +67633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757152</BitOffs>
+            <BitOffs>684757216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -67646,7 +67646,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757184</BitOffs>
+            <BitOffs>684757248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -67659,7 +67659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757248</BitOffs>
+            <BitOffs>684757312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -67672,7 +67672,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684757264</BitOffs>
+            <BitOffs>684757328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -67684,7 +67684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684774400</BitOffs>
+            <BitOffs>684774464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -67697,7 +67697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782336</BitOffs>
+            <BitOffs>684782400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -67710,7 +67710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782344</BitOffs>
+            <BitOffs>684782408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -67723,7 +67723,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782352</BitOffs>
+            <BitOffs>684782416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -67746,7 +67746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782368</BitOffs>
+            <BitOffs>684782432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -67759,7 +67759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782400</BitOffs>
+            <BitOffs>684782464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -67772,7 +67772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782464</BitOffs>
+            <BitOffs>684782528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -67785,7 +67785,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684782480</BitOffs>
+            <BitOffs>684782544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -67797,7 +67797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684799616</BitOffs>
+            <BitOffs>684799680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -67810,7 +67810,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807552</BitOffs>
+            <BitOffs>684807616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -67823,7 +67823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807560</BitOffs>
+            <BitOffs>684807624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -67836,7 +67836,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807568</BitOffs>
+            <BitOffs>684807632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -67859,7 +67859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807584</BitOffs>
+            <BitOffs>684807648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -67872,7 +67872,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807616</BitOffs>
+            <BitOffs>684807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -67885,7 +67885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807680</BitOffs>
+            <BitOffs>684807744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -67898,7 +67898,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684807696</BitOffs>
+            <BitOffs>684807760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -67910,7 +67910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684824832</BitOffs>
+            <BitOffs>684824896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -67923,7 +67923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832768</BitOffs>
+            <BitOffs>684832832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -67936,7 +67936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832776</BitOffs>
+            <BitOffs>684832840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -67949,7 +67949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832784</BitOffs>
+            <BitOffs>684832848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -67972,7 +67972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832800</BitOffs>
+            <BitOffs>684832864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -67985,7 +67985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832832</BitOffs>
+            <BitOffs>684832896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -67998,7 +67998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832896</BitOffs>
+            <BitOffs>684832960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -68011,7 +68011,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684832912</BitOffs>
+            <BitOffs>684832976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -68023,7 +68023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684850048</BitOffs>
+            <BitOffs>684850112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -68036,7 +68036,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857984</BitOffs>
+            <BitOffs>684858048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -68049,7 +68049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684857992</BitOffs>
+            <BitOffs>684858056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -68062,7 +68062,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858000</BitOffs>
+            <BitOffs>684858064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -68085,7 +68085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858016</BitOffs>
+            <BitOffs>684858080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -68098,7 +68098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858048</BitOffs>
+            <BitOffs>684858112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -68111,7 +68111,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858112</BitOffs>
+            <BitOffs>684858176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -68124,7 +68124,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684858128</BitOffs>
+            <BitOffs>684858192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -68136,7 +68136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684875264</BitOffs>
+            <BitOffs>684875328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -68149,7 +68149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883200</BitOffs>
+            <BitOffs>684883264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -68162,7 +68162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883208</BitOffs>
+            <BitOffs>684883272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -68175,7 +68175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883216</BitOffs>
+            <BitOffs>684883280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -68198,7 +68198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883232</BitOffs>
+            <BitOffs>684883296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -68211,7 +68211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883264</BitOffs>
+            <BitOffs>684883328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -68224,7 +68224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883328</BitOffs>
+            <BitOffs>684883392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -68237,7 +68237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684883344</BitOffs>
+            <BitOffs>684883408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -68249,7 +68249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684900480</BitOffs>
+            <BitOffs>684900544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -68262,7 +68262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908416</BitOffs>
+            <BitOffs>684908480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -68275,7 +68275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908424</BitOffs>
+            <BitOffs>684908488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -68288,7 +68288,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908432</BitOffs>
+            <BitOffs>684908496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -68311,7 +68311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908448</BitOffs>
+            <BitOffs>684908512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -68324,7 +68324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908480</BitOffs>
+            <BitOffs>684908544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -68337,7 +68337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908544</BitOffs>
+            <BitOffs>684908608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -68350,7 +68350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684908560</BitOffs>
+            <BitOffs>684908624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -68362,7 +68362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684925696</BitOffs>
+            <BitOffs>684925760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -68375,7 +68375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933632</BitOffs>
+            <BitOffs>684933696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -68388,7 +68388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933640</BitOffs>
+            <BitOffs>684933704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -68401,7 +68401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933648</BitOffs>
+            <BitOffs>684933712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -68424,7 +68424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933664</BitOffs>
+            <BitOffs>684933728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -68437,7 +68437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933696</BitOffs>
+            <BitOffs>684933760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -68450,7 +68450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933760</BitOffs>
+            <BitOffs>684933824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -68463,7 +68463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684933776</BitOffs>
+            <BitOffs>684933840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -68475,7 +68475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684950912</BitOffs>
+            <BitOffs>684950976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -68488,7 +68488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958848</BitOffs>
+            <BitOffs>684958912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -68501,7 +68501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958856</BitOffs>
+            <BitOffs>684958920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -68514,7 +68514,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958864</BitOffs>
+            <BitOffs>684958928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -68537,7 +68537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958880</BitOffs>
+            <BitOffs>684958944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -68550,7 +68550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958912</BitOffs>
+            <BitOffs>684958976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -68563,7 +68563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958976</BitOffs>
+            <BitOffs>684959040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -68576,7 +68576,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684958992</BitOffs>
+            <BitOffs>684959056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -68588,7 +68588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684976128</BitOffs>
+            <BitOffs>684976192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -68601,7 +68601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984064</BitOffs>
+            <BitOffs>684984128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -68614,7 +68614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984072</BitOffs>
+            <BitOffs>684984136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -68627,7 +68627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984080</BitOffs>
+            <BitOffs>684984144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -68650,7 +68650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984096</BitOffs>
+            <BitOffs>684984160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -68663,7 +68663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984128</BitOffs>
+            <BitOffs>684984192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -68676,7 +68676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984192</BitOffs>
+            <BitOffs>684984256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -68689,7 +68689,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>684984208</BitOffs>
+            <BitOffs>684984272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -68701,7 +68701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685001344</BitOffs>
+            <BitOffs>685001408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -68714,7 +68714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009280</BitOffs>
+            <BitOffs>685009344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -68727,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009288</BitOffs>
+            <BitOffs>685009352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -68740,7 +68740,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009296</BitOffs>
+            <BitOffs>685009360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -68763,7 +68763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009312</BitOffs>
+            <BitOffs>685009376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -68776,7 +68776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009344</BitOffs>
+            <BitOffs>685009408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -68789,7 +68789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009408</BitOffs>
+            <BitOffs>685009472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -68802,7 +68802,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685009424</BitOffs>
+            <BitOffs>685009488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -68814,7 +68814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685026560</BitOffs>
+            <BitOffs>685026624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -68827,7 +68827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034496</BitOffs>
+            <BitOffs>685034560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -68840,7 +68840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034504</BitOffs>
+            <BitOffs>685034568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -68853,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034512</BitOffs>
+            <BitOffs>685034576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -68876,7 +68876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034528</BitOffs>
+            <BitOffs>685034592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -68889,7 +68889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034560</BitOffs>
+            <BitOffs>685034624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -68902,7 +68902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034624</BitOffs>
+            <BitOffs>685034688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -68915,7 +68915,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685034640</BitOffs>
+            <BitOffs>685034704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -68927,7 +68927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685051776</BitOffs>
+            <BitOffs>685051840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -68940,7 +68940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059712</BitOffs>
+            <BitOffs>685059776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -68953,7 +68953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059720</BitOffs>
+            <BitOffs>685059784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -68966,7 +68966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059728</BitOffs>
+            <BitOffs>685059792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -68989,7 +68989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059744</BitOffs>
+            <BitOffs>685059808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -69002,7 +69002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059776</BitOffs>
+            <BitOffs>685059840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -69015,7 +69015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059840</BitOffs>
+            <BitOffs>685059904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -69028,7 +69028,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685059856</BitOffs>
+            <BitOffs>685059920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -69040,7 +69040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685076992</BitOffs>
+            <BitOffs>685077056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -69053,7 +69053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084928</BitOffs>
+            <BitOffs>685084992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -69066,7 +69066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084936</BitOffs>
+            <BitOffs>685085000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -69079,7 +69079,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084944</BitOffs>
+            <BitOffs>685085008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -69102,7 +69102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084960</BitOffs>
+            <BitOffs>685085024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -69115,7 +69115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685084992</BitOffs>
+            <BitOffs>685085056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -69128,7 +69128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085056</BitOffs>
+            <BitOffs>685085120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -69141,7 +69141,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685085072</BitOffs>
+            <BitOffs>685085136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -69153,7 +69153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685102208</BitOffs>
+            <BitOffs>685102272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -69166,7 +69166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110144</BitOffs>
+            <BitOffs>685110208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -69179,7 +69179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110152</BitOffs>
+            <BitOffs>685110216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -69192,7 +69192,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110160</BitOffs>
+            <BitOffs>685110224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -69215,7 +69215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110176</BitOffs>
+            <BitOffs>685110240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -69228,7 +69228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110208</BitOffs>
+            <BitOffs>685110272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -69241,7 +69241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110272</BitOffs>
+            <BitOffs>685110336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -69254,7 +69254,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685110288</BitOffs>
+            <BitOffs>685110352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -69266,7 +69266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685127424</BitOffs>
+            <BitOffs>685127488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -69279,7 +69279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135360</BitOffs>
+            <BitOffs>685135424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -69292,7 +69292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135368</BitOffs>
+            <BitOffs>685135432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -69305,7 +69305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135376</BitOffs>
+            <BitOffs>685135440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -69328,7 +69328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135392</BitOffs>
+            <BitOffs>685135456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -69341,7 +69341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135424</BitOffs>
+            <BitOffs>685135488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -69354,7 +69354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135488</BitOffs>
+            <BitOffs>685135552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -69367,7 +69367,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685135504</BitOffs>
+            <BitOffs>685135568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -69379,7 +69379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685152640</BitOffs>
+            <BitOffs>685152704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -69392,7 +69392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160576</BitOffs>
+            <BitOffs>685160640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -69405,7 +69405,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160584</BitOffs>
+            <BitOffs>685160648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -69418,7 +69418,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160592</BitOffs>
+            <BitOffs>685160656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -69441,7 +69441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160608</BitOffs>
+            <BitOffs>685160672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -69454,7 +69454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160640</BitOffs>
+            <BitOffs>685160704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -69467,7 +69467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160704</BitOffs>
+            <BitOffs>685160768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -69480,7 +69480,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685160720</BitOffs>
+            <BitOffs>685160784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -69492,7 +69492,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685177856</BitOffs>
+            <BitOffs>685177920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -69505,7 +69505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185792</BitOffs>
+            <BitOffs>685185856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -69518,7 +69518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185800</BitOffs>
+            <BitOffs>685185864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -69531,7 +69531,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185808</BitOffs>
+            <BitOffs>685185872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -69554,7 +69554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185824</BitOffs>
+            <BitOffs>685185888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -69567,7 +69567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185856</BitOffs>
+            <BitOffs>685185920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -69580,7 +69580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185920</BitOffs>
+            <BitOffs>685185984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -69593,7 +69593,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685185936</BitOffs>
+            <BitOffs>685186000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -69605,7 +69605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685203072</BitOffs>
+            <BitOffs>685203136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -69618,7 +69618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211008</BitOffs>
+            <BitOffs>685211072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -69631,7 +69631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211016</BitOffs>
+            <BitOffs>685211080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -69644,7 +69644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211024</BitOffs>
+            <BitOffs>685211088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -69667,7 +69667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211040</BitOffs>
+            <BitOffs>685211104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -69680,7 +69680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211072</BitOffs>
+            <BitOffs>685211136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -69693,7 +69693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211136</BitOffs>
+            <BitOffs>685211200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -69706,7 +69706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685211152</BitOffs>
+            <BitOffs>685211216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -69718,7 +69718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685228288</BitOffs>
+            <BitOffs>685228352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -69731,7 +69731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236224</BitOffs>
+            <BitOffs>685236288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -69744,7 +69744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236232</BitOffs>
+            <BitOffs>685236296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -69757,7 +69757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236240</BitOffs>
+            <BitOffs>685236304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -69780,7 +69780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236256</BitOffs>
+            <BitOffs>685236320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -69793,7 +69793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236288</BitOffs>
+            <BitOffs>685236352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -69806,7 +69806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236352</BitOffs>
+            <BitOffs>685236416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -69819,7 +69819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685236368</BitOffs>
+            <BitOffs>685236432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -69831,7 +69831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685253504</BitOffs>
+            <BitOffs>685253568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -69844,7 +69844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261440</BitOffs>
+            <BitOffs>685261504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -69857,7 +69857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261448</BitOffs>
+            <BitOffs>685261512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -69870,7 +69870,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261456</BitOffs>
+            <BitOffs>685261520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -69893,7 +69893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261472</BitOffs>
+            <BitOffs>685261536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -69906,7 +69906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261504</BitOffs>
+            <BitOffs>685261568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -69919,7 +69919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261568</BitOffs>
+            <BitOffs>685261632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -69932,7 +69932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685261584</BitOffs>
+            <BitOffs>685261648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -69944,7 +69944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685278720</BitOffs>
+            <BitOffs>685278784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -69957,7 +69957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286656</BitOffs>
+            <BitOffs>685286720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -69970,7 +69970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286664</BitOffs>
+            <BitOffs>685286728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -69983,7 +69983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286672</BitOffs>
+            <BitOffs>685286736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -70006,7 +70006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286688</BitOffs>
+            <BitOffs>685286752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -70019,7 +70019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286720</BitOffs>
+            <BitOffs>685286784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -70032,7 +70032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286784</BitOffs>
+            <BitOffs>685286848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -70045,7 +70045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685286800</BitOffs>
+            <BitOffs>685286864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -70057,7 +70057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685303936</BitOffs>
+            <BitOffs>685304000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -70070,7 +70070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311872</BitOffs>
+            <BitOffs>685311936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -70083,7 +70083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311880</BitOffs>
+            <BitOffs>685311944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -70096,7 +70096,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311888</BitOffs>
+            <BitOffs>685311952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -70119,7 +70119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311904</BitOffs>
+            <BitOffs>685311968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -70132,7 +70132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685311936</BitOffs>
+            <BitOffs>685312000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -70145,7 +70145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312000</BitOffs>
+            <BitOffs>685312064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -70158,7 +70158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685312016</BitOffs>
+            <BitOffs>685312080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -70170,7 +70170,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685329152</BitOffs>
+            <BitOffs>685329216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -70183,7 +70183,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337088</BitOffs>
+            <BitOffs>685337152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -70196,7 +70196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337096</BitOffs>
+            <BitOffs>685337160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -70209,7 +70209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337104</BitOffs>
+            <BitOffs>685337168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -70232,7 +70232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337120</BitOffs>
+            <BitOffs>685337184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -70245,7 +70245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337152</BitOffs>
+            <BitOffs>685337216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -70258,7 +70258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337216</BitOffs>
+            <BitOffs>685337280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -70271,7 +70271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685337232</BitOffs>
+            <BitOffs>685337296</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -71418,7 +71418,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662612352</BitOffs>
+            <BitOffs>662612416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71430,7 +71430,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662910272</BitOffs>
+            <BitOffs>662910336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71442,7 +71442,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663208192</BitOffs>
+            <BitOffs>663208256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71454,7 +71454,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663506112</BitOffs>
+            <BitOffs>663506176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -71466,7 +71466,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663952736</BitOffs>
+            <BitOffs>663952800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -71478,7 +71478,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664065328</BitOffs>
+            <BitOffs>664065392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -71490,7 +71490,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664065336</BitOffs>
+            <BitOffs>664065400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71502,7 +71502,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664099456</BitOffs>
+            <BitOffs>664099520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71514,7 +71514,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664397376</BitOffs>
+            <BitOffs>664397440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71526,7 +71526,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665415296</BitOffs>
+            <BitOffs>665415360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71538,7 +71538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665713216</BitOffs>
+            <BitOffs>665713280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71550,7 +71550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666700480</BitOffs>
+            <BitOffs>666700544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71562,7 +71562,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666998400</BitOffs>
+            <BitOffs>666998464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71574,7 +71574,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667296320</BitOffs>
+            <BitOffs>667296384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71586,7 +71586,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667594240</BitOffs>
+            <BitOffs>667594304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71598,7 +71598,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667892160</BitOffs>
+            <BitOffs>667892224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71610,7 +71610,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668190080</BitOffs>
+            <BitOffs>668190144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71622,7 +71622,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668488000</BitOffs>
+            <BitOffs>668488064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71634,7 +71634,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668785920</BitOffs>
+            <BitOffs>668785984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71646,7 +71646,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669083840</BitOffs>
+            <BitOffs>669083904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71658,7 +71658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669381760</BitOffs>
+            <BitOffs>669381824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71670,7 +71670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669679680</BitOffs>
+            <BitOffs>669679744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71682,7 +71682,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669977600</BitOffs>
+            <BitOffs>669977664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -71694,7 +71694,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670275520</BitOffs>
+            <BitOffs>670275584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71706,7 +71706,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671838784</BitOffs>
+            <BitOffs>671838848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71719,7 +71719,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671847768</BitOffs>
+            <BitOffs>671847832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71731,7 +71731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671864000</BitOffs>
+            <BitOffs>671864064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71744,7 +71744,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671872984</BitOffs>
+            <BitOffs>671873048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71756,7 +71756,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671889216</BitOffs>
+            <BitOffs>671889280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71769,7 +71769,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671898200</BitOffs>
+            <BitOffs>671898264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -71781,7 +71781,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673600768</BitOffs>
+            <BitOffs>673600896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -71794,7 +71794,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673609752</BitOffs>
+            <BitOffs>673609880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -71806,7 +71806,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673625984</BitOffs>
+            <BitOffs>673626112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -71819,7 +71819,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673634968</BitOffs>
+            <BitOffs>673635096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -71831,7 +71831,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673651200</BitOffs>
+            <BitOffs>673651328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -71844,7 +71844,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673660184</BitOffs>
+            <BitOffs>673660312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -71863,7 +71863,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>673840568</BitOffs>
+            <BitOffs>674042144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -71882,7 +71882,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674042080</BitOffs>
+            <BitOffs>674042152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -71898,7 +71898,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674044672</BitOffs>
+            <BitOffs>674044736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -71918,7 +71918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>680950152</BitOffs>
+            <BitOffs>680950216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -71938,7 +71938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>682597064</BitOffs>
+            <BitOffs>682597128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -71950,7 +71950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684243840</BitOffs>
+            <BitOffs>684243904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -71963,7 +71963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684252824</BitOffs>
+            <BitOffs>684252888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -71975,7 +71975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684269056</BitOffs>
+            <BitOffs>684269120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -71988,7 +71988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684278040</BitOffs>
+            <BitOffs>684278104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -72000,7 +72000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684294272</BitOffs>
+            <BitOffs>684294336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -72013,7 +72013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684303256</BitOffs>
+            <BitOffs>684303320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -72025,7 +72025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684319488</BitOffs>
+            <BitOffs>684319552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -72038,7 +72038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684328472</BitOffs>
+            <BitOffs>684328536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -72050,7 +72050,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684344704</BitOffs>
+            <BitOffs>684344768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -72063,7 +72063,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684353688</BitOffs>
+            <BitOffs>684353752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -72075,7 +72075,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684369920</BitOffs>
+            <BitOffs>684369984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -72088,7 +72088,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684378904</BitOffs>
+            <BitOffs>684378968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -72100,7 +72100,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684395136</BitOffs>
+            <BitOffs>684395200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -72113,7 +72113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684404120</BitOffs>
+            <BitOffs>684404184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -72125,7 +72125,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684420352</BitOffs>
+            <BitOffs>684420416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -72138,7 +72138,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684429336</BitOffs>
+            <BitOffs>684429400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -72150,7 +72150,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684445568</BitOffs>
+            <BitOffs>684445632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -72163,7 +72163,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684454552</BitOffs>
+            <BitOffs>684454616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -72175,7 +72175,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684470784</BitOffs>
+            <BitOffs>684470848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -72188,7 +72188,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684479768</BitOffs>
+            <BitOffs>684479832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -72200,7 +72200,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684496000</BitOffs>
+            <BitOffs>684496064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -72213,7 +72213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684504984</BitOffs>
+            <BitOffs>684505048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -72225,7 +72225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684521216</BitOffs>
+            <BitOffs>684521280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -72238,7 +72238,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684530200</BitOffs>
+            <BitOffs>684530264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -72250,7 +72250,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684546432</BitOffs>
+            <BitOffs>684546496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -72263,7 +72263,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684555416</BitOffs>
+            <BitOffs>684555480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -72275,7 +72275,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684571648</BitOffs>
+            <BitOffs>684571712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -72288,7 +72288,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684580632</BitOffs>
+            <BitOffs>684580696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -72300,7 +72300,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684596864</BitOffs>
+            <BitOffs>684596928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -72313,7 +72313,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684605848</BitOffs>
+            <BitOffs>684605912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -72325,7 +72325,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684622080</BitOffs>
+            <BitOffs>684622144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -72338,7 +72338,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684631064</BitOffs>
+            <BitOffs>684631128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -72350,7 +72350,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684647296</BitOffs>
+            <BitOffs>684647360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -72363,7 +72363,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684656280</BitOffs>
+            <BitOffs>684656344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -72375,7 +72375,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684672512</BitOffs>
+            <BitOffs>684672576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -72388,7 +72388,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684681496</BitOffs>
+            <BitOffs>684681560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -72400,7 +72400,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684697728</BitOffs>
+            <BitOffs>684697792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -72413,7 +72413,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684706712</BitOffs>
+            <BitOffs>684706776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -72425,7 +72425,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684722944</BitOffs>
+            <BitOffs>684723008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -72438,7 +72438,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684731928</BitOffs>
+            <BitOffs>684731992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -72450,7 +72450,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684748160</BitOffs>
+            <BitOffs>684748224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -72463,7 +72463,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684757144</BitOffs>
+            <BitOffs>684757208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -72475,7 +72475,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684773376</BitOffs>
+            <BitOffs>684773440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -72488,7 +72488,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684782360</BitOffs>
+            <BitOffs>684782424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -72500,7 +72500,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684798592</BitOffs>
+            <BitOffs>684798656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -72513,7 +72513,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684807576</BitOffs>
+            <BitOffs>684807640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -72525,7 +72525,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684823808</BitOffs>
+            <BitOffs>684823872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -72538,7 +72538,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684832792</BitOffs>
+            <BitOffs>684832856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -72550,7 +72550,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684849024</BitOffs>
+            <BitOffs>684849088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -72563,7 +72563,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684858008</BitOffs>
+            <BitOffs>684858072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -72575,7 +72575,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684874240</BitOffs>
+            <BitOffs>684874304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -72588,7 +72588,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684883224</BitOffs>
+            <BitOffs>684883288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -72600,7 +72600,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684899456</BitOffs>
+            <BitOffs>684899520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -72613,7 +72613,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684908440</BitOffs>
+            <BitOffs>684908504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -72625,7 +72625,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684924672</BitOffs>
+            <BitOffs>684924736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -72638,7 +72638,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684933656</BitOffs>
+            <BitOffs>684933720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -72650,7 +72650,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684949888</BitOffs>
+            <BitOffs>684949952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -72663,7 +72663,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684958872</BitOffs>
+            <BitOffs>684958936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -72675,7 +72675,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684975104</BitOffs>
+            <BitOffs>684975168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -72688,7 +72688,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>684984088</BitOffs>
+            <BitOffs>684984152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -72700,7 +72700,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685000320</BitOffs>
+            <BitOffs>685000384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -72713,7 +72713,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685009304</BitOffs>
+            <BitOffs>685009368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -72725,7 +72725,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685025536</BitOffs>
+            <BitOffs>685025600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -72738,7 +72738,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685034520</BitOffs>
+            <BitOffs>685034584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -72750,7 +72750,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685050752</BitOffs>
+            <BitOffs>685050816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -72763,7 +72763,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685059736</BitOffs>
+            <BitOffs>685059800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -72775,7 +72775,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685075968</BitOffs>
+            <BitOffs>685076032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -72788,7 +72788,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685084952</BitOffs>
+            <BitOffs>685085016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -72800,7 +72800,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685101184</BitOffs>
+            <BitOffs>685101248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -72813,7 +72813,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685110168</BitOffs>
+            <BitOffs>685110232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -72825,7 +72825,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685126400</BitOffs>
+            <BitOffs>685126464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -72838,7 +72838,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685135384</BitOffs>
+            <BitOffs>685135448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -72850,7 +72850,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685151616</BitOffs>
+            <BitOffs>685151680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -72863,7 +72863,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685160600</BitOffs>
+            <BitOffs>685160664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -72875,7 +72875,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685176832</BitOffs>
+            <BitOffs>685176896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -72888,7 +72888,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685185816</BitOffs>
+            <BitOffs>685185880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -72900,7 +72900,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685202048</BitOffs>
+            <BitOffs>685202112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -72913,7 +72913,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685211032</BitOffs>
+            <BitOffs>685211096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -72925,7 +72925,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685227264</BitOffs>
+            <BitOffs>685227328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -72938,7 +72938,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685236248</BitOffs>
+            <BitOffs>685236312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -72950,7 +72950,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685252480</BitOffs>
+            <BitOffs>685252544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -72963,7 +72963,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685261464</BitOffs>
+            <BitOffs>685261528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -72975,7 +72975,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685277696</BitOffs>
+            <BitOffs>685277760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -72988,7 +72988,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685286680</BitOffs>
+            <BitOffs>685286744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -73000,7 +73000,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685302912</BitOffs>
+            <BitOffs>685302976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -73013,7 +73013,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685311896</BitOffs>
+            <BitOffs>685311960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -73025,7 +73025,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685328128</BitOffs>
+            <BitOffs>685328192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -73038,7 +73038,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685337112</BitOffs>
+            <BitOffs>685337176</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -79343,14 +79343,9 @@ Digital outputs</Comment>
             <BitOffs>631337952</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
+            <Name>PRG_AL1K4_L2SI.bInit</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
             <BitOffs>631337960</BitOffs>
           </Symbol>
           <Symbol>
@@ -79570,63 +79565,27 @@ Digital outputs</Comment>
             <BitOffs>639714560</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <Name>PRG_IM2K4_PPM.bInit</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
             <BitOffs>639714848</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <Name>PRG_IM3K4_PPM.bInit</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
             <BitOffs>639714856</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
+            <Name>PRG_IM4K4_PPM.bInit</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
             <BitOffs>639714864</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
+            <Name>PRG_IM5K4_PPM.bInit</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL2K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
-              </Property>
-            </Properties>
             <BitOffs>639714872</BitOffs>
           </Symbol>
           <Symbol>
@@ -79661,14 +79620,28 @@ Digital outputs</Comment>
             <BitOffs>640343872</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
+            <Name>PRG_IM6K4_PPM.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <BitOffs>642272416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI1K4_IP1.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642272424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642272432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>642272440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
@@ -79919,14 +79892,55 @@ Digital outputs</Comment>
             <BitOffs>659019456</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>-15</Value>
+              <Value>1</Value>
             </Default>
             <BitOffs>659021216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>659021224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <BitOffs>659021232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <BitOffs>659021240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -79961,7 +79975,7 @@ Digital outputs</Comment>
             <BitOffs>661260736</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
@@ -79997,7 +80011,7 @@ Digital outputs</Comment>
             <BitOffs>662606336</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
             <Comment> 0+(-15)</Comment>
             <BitSize>32</BitSize>
             <BaseType>REAL</BaseType>
@@ -80007,19 +80021,59 @@ Digital outputs</Comment>
             <BitOffs>662609408</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>662609440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>662609472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL2K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>662609824</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_SL2K4_SCATTER.bTest</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>662609760</BitOffs>
+            <BitOffs>662609832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>662609768</BitOffs>
+            <BitOffs>662609840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -80034,7 +80088,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662609792</BitOffs>
+            <BitOffs>662609856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -80045,7 +80099,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663952960</BitOffs>
+            <BitOffs>663953024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
@@ -80055,7 +80109,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956032</BitOffs>
+            <BitOffs>663956096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -80065,7 +80119,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956064</BitOffs>
+            <BitOffs>663956128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -80075,7 +80129,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956096</BitOffs>
+            <BitOffs>663956160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -80085,7 +80139,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663956128</BitOffs>
+            <BitOffs>663956192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -80104,7 +80158,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663956416</BitOffs>
+            <BitOffs>663956480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -80126,13 +80180,13 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>664067264</BitOffs>
+            <BitOffs>664067328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>665390384</BitOffs>
+            <BitOffs>665390448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -80154,112 +80208,97 @@ Digital outputs</Comment>
                               .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>665390400</BitOffs>
+            <BitOffs>665390464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>666699008</BitOffs>
+            <BitOffs>666699072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>666996928</BitOffs>
+            <BitOffs>666996992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667294848</BitOffs>
+            <BitOffs>667294912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667592768</BitOffs>
+            <BitOffs>667592832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667890688</BitOffs>
+            <BitOffs>667890752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668188608</BitOffs>
+            <BitOffs>668188672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668486528</BitOffs>
+            <BitOffs>668486592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668784448</BitOffs>
+            <BitOffs>668784512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669082368</BitOffs>
+            <BitOffs>669082432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669380288</BitOffs>
+            <BitOffs>669380352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669678208</BitOffs>
+            <BitOffs>669678272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669976128</BitOffs>
+            <BitOffs>669976192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670274048</BitOffs>
+            <BitOffs>670274112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>670571968</BitOffs>
+            <BitOffs>670572048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>670572000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL2LowCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>670572016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <BitOffs>670572032</BitOffs>
+            <BitOffs>670572064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -80268,14 +80307,35 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>670572048</BitOffs>
+            <BitOffs>670572088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL2LowCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>670572096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <BitOffs>670572112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>670572056</BitOffs>
+            <BitOffs>670572128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>670572136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -80290,22 +80350,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>670572064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.zp_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_ZonePlate_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP:STATE:GET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>670572080</BitOffs>
+            <BitOffs>670572144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates</Name>
@@ -80320,13 +80365,70 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>670572096</BitOffs>
+            <BitOffs>670572160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.zp_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_ZonePlate_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:FZP:STATE:GET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>672078624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>672078640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>672078648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>672078528</BitOffs>
+            <BitOffs>672078656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -80350,7 +80452,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>672166336</BitOffs>
+            <BitOffs>672166464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -80360,7 +80462,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672169984</BitOffs>
+            <BitOffs>672170112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -80370,7 +80472,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672224704</BitOffs>
+            <BitOffs>672224832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -80380,7 +80482,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672279424</BitOffs>
+            <BitOffs>672279552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -80395,61 +80497,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672334144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:SET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>673840512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>673840528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>673840544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>673840552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>673840560</BitOffs>
+            <BitOffs>672334272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>673840576</BitOffs>
+            <BitOffs>673840640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -80473,7 +80527,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>673928384</BitOffs>
+            <BitOffs>673928448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -80483,7 +80537,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673932032</BitOffs>
+            <BitOffs>673932096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -80493,7 +80547,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673986752</BitOffs>
+            <BitOffs>673986816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF1K4State</Name>
@@ -80504,25 +80558,25 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674042096</BitOffs>
+            <BitOffs>674042160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>674042112</BitOffs>
+            <BitOffs>674042176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>674180480</BitOffs>
+            <BitOffs>674180544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>674211328</BitOffs>
+            <BitOffs>674211392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -80541,7 +80595,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680002944</BitOffs>
+            <BitOffs>680003008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -80560,7 +80614,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680476416</BitOffs>
+            <BitOffs>680476480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -80590,7 +80644,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680949888</BitOffs>
+            <BitOffs>680949952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -80620,7 +80674,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>682596800</BitOffs>
+            <BitOffs>682596864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -80631,7 +80685,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243712</BitOffs>
+            <BitOffs>684243776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -80646,7 +80700,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243728</BitOffs>
+            <BitOffs>684243800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -80661,7 +80715,21 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243736</BitOffs>
+            <BitOffs>684243808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bFPUSupport</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>684243816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -80676,22 +80744,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>8</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>684243760</BitOffs>
+            <BitOffs>684243824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -80720,7 +80773,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684243776</BitOffs>
+            <BitOffs>684243840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -80732,7 +80785,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684268992</BitOffs>
+            <BitOffs>684269056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -80743,7 +80796,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684294208</BitOffs>
+            <BitOffs>684294272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -80754,7 +80807,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684319424</BitOffs>
+            <BitOffs>684319488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -80765,7 +80818,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684344640</BitOffs>
+            <BitOffs>684344704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -80776,7 +80829,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684369856</BitOffs>
+            <BitOffs>684369920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -80787,7 +80840,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684395072</BitOffs>
+            <BitOffs>684395136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -80798,7 +80851,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684420288</BitOffs>
+            <BitOffs>684420352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -80827,7 +80880,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684445504</BitOffs>
+            <BitOffs>684445568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -80855,7 +80908,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684470720</BitOffs>
+            <BitOffs>684470784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -80882,7 +80935,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684495936</BitOffs>
+            <BitOffs>684496000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -80909,7 +80962,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684521152</BitOffs>
+            <BitOffs>684521216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -80936,7 +80989,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684546368</BitOffs>
+            <BitOffs>684546432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -80948,7 +81001,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684571584</BitOffs>
+            <BitOffs>684571648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -80977,7 +81030,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684596800</BitOffs>
+            <BitOffs>684596864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -81006,7 +81059,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684622016</BitOffs>
+            <BitOffs>684622080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -81035,7 +81088,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684647232</BitOffs>
+            <BitOffs>684647296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -81064,7 +81117,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684672448</BitOffs>
+            <BitOffs>684672512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -81089,7 +81142,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684697664</BitOffs>
+            <BitOffs>684697728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -81118,7 +81171,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684722880</BitOffs>
+            <BitOffs>684722944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -81147,7 +81200,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684748096</BitOffs>
+            <BitOffs>684748160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -81172,7 +81225,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684773312</BitOffs>
+            <BitOffs>684773376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -81200,7 +81253,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684798528</BitOffs>
+            <BitOffs>684798592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -81227,7 +81280,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684823744</BitOffs>
+            <BitOffs>684823808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -81254,7 +81307,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684848960</BitOffs>
+            <BitOffs>684849024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -81281,7 +81334,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684874176</BitOffs>
+            <BitOffs>684874240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -81310,7 +81363,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684899392</BitOffs>
+            <BitOffs>684899456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -81339,7 +81392,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684924608</BitOffs>
+            <BitOffs>684924672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -81364,7 +81417,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684949824</BitOffs>
+            <BitOffs>684949888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -81393,7 +81446,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>684975040</BitOffs>
+            <BitOffs>684975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -81418,7 +81471,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685000256</BitOffs>
+            <BitOffs>685000320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -81455,7 +81508,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685025472</BitOffs>
+            <BitOffs>685025536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -81500,7 +81553,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685050688</BitOffs>
+            <BitOffs>685050752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -81541,7 +81594,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685075904</BitOffs>
+            <BitOffs>685075968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -81582,7 +81635,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685101120</BitOffs>
+            <BitOffs>685101184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -81623,7 +81676,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685126336</BitOffs>
+            <BitOffs>685126400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -81664,7 +81717,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685151552</BitOffs>
+            <BitOffs>685151616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -81705,7 +81758,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685176768</BitOffs>
+            <BitOffs>685176832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -81746,7 +81799,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685201984</BitOffs>
+            <BitOffs>685202048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -81787,7 +81840,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685227200</BitOffs>
+            <BitOffs>685227264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -81823,7 +81876,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685252416</BitOffs>
+            <BitOffs>685252480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -81859,7 +81912,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685277632</BitOffs>
+            <BitOffs>685277696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -81895,7 +81948,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685302848</BitOffs>
+            <BitOffs>685302912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -81940,7 +81993,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685328064</BitOffs>
+            <BitOffs>685328128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -81970,7 +82023,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353280</BitOffs>
+            <BitOffs>685353344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -82000,21 +82053,22 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353344</BitOffs>
+            <BitOffs>685353408</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.bFPUSupport</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support an FPU</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
             <Default>
-              <Value>1</Value>
+              <Value>8</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353408</BitOffs>
+            <BitOffs>685353472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -82028,7 +82082,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353440</BitOffs>
+            <BitOffs>685353504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -82042,7 +82096,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353472</BitOffs>
+            <BitOffs>685353536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82056,7 +82110,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685353504</BitOffs>
+            <BitOffs>685353568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -82070,7 +82124,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685355552</BitOffs>
+            <BitOffs>685355616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -82088,7 +82142,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685355584</BitOffs>
+            <BitOffs>685355648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -82102,7 +82156,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685356608</BitOffs>
+            <BitOffs>685356672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -82123,7 +82177,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685356640</BitOffs>
+            <BitOffs>685356704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -82192,7 +82246,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370016</BitOffs>
+            <BitOffs>685370080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -82261,7 +82315,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370144</BitOffs>
+            <BitOffs>685370208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -82330,7 +82384,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370272</BitOffs>
+            <BitOffs>685370336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -82399,7 +82453,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370400</BitOffs>
+            <BitOffs>685370464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -82468,7 +82522,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370528</BitOffs>
+            <BitOffs>685370592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -82537,7 +82591,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685370656</BitOffs>
+            <BitOffs>685370720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -82560,7 +82614,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685400992</BitOffs>
+            <BitOffs>685401056</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82647,7 +82701,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-09-26T12:00:04</Value>
+          <Value>2023-09-28T13:53:37</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
TMO wants to modify target1 position from -93 to -81 to avoid collision from Epics but it does not work because every cycle it rewrite the default PLC value
<!--- Describe your changes in detail -->
only run once for all initial values of all targets for every common component from AL1K4 to PF2K4
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid collision for PF1K4
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
yes, tested with scientists many times 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
