### PR TITLE
adding SP1K4-solid-att-RTD-beckhoff

### DIFF
--- a/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT)/Power (EK1200)/PLC Junction 2 (EK1122)/PLC Coupler 2 (EK1100)/PLC Junction 9 (EK1122)/SP1K4 Top Rail (EK1100).xti
+++ b/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT)/Power (EK1200)/PLC Junction 2 (EK1122)/PLC Coupler 2 (EK1100)/PLC Junction 9 (EK1122)/SP1K4 Top Rail (EK1100).xti
@@ -46,8 +46,14 @@
 		<Box File="SP1K4-TL2-EL1124.xti" Id="14">
 			<EtherCAT PortABoxInfo="#x0100000d"/>
 		</Box>
-		<Box File="Term 15 (EK1122).xti" Id="15">
+		<Box File="SP1K4- EL3202-E9A.xti" Id="257">
 			<EtherCAT PortABoxInfo="#x0100000e"/>
+		</Box>
+		<Box File="SP1K4-EL3202-E9B.xti" Id="258">
+			<EtherCAT PortABoxInfo="#x01000101"/>
+		</Box>
+		<Box File="Term 15 (EK1122).xti" Id="15">
+			<EtherCAT PortABoxInfo="#x01000102"/>
 		</Box>
 		<Box File="Term 300 (EL9011).xti" Id="300">
 			<EtherCAT PortABoxInfo="#x0200000f"/>

--- a/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT)/Power (EK1200)/PLC Junction 2 (EK1122)/PLC Coupler 2 (EK1100)/PLC Junction 9 (EK1122)/SP1K4 Top Rail (EK1100)/SP1K4- EL3202-E9A.xti
+++ b/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT)/Power (EK1200)/PLC Junction 2 (EK1122)/PLC Coupler 2 (EK1100)/PLC Junction 9 (EK1122)/SP1K4 Top Rail (EK1100)/SP1K4- EL3202-E9A.xti
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+	<DataTypes>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
+			<BitSize>7</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>7</Elements>
+			</ArrayInfo>
+		</DataType>
+	</DataTypes>
+	<ImageDatas>
+		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
+	</ImageDatas>
+	<Box Id="257" BoxType="9099" BoxFlags="#x00000020">
+		<Name>__FILENAME__</Name>
+		<ImageId>1000</ImageId>
+		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">
+			<SyncMan>001080002600010001000000800080008000001026010000</SyncMan>
+			<SyncMan>801080002200010002000000800080008000801022010000</SyncMan>
+			<SyncMan>001100000400000003000000000000000000001104000000</SyncMan>
+			<SyncMan>801108002000010004000000000000000800801120010000</SyncMan>
+			<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
+			<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+			<BootStrapData>0010f400f410f400</BootStrapData>
+			<Pdo Name="RTD Inputs Channel 1" Index="#x1a00" Flags="#x0011" SyncMan="3">
+				<Entry Name="Status__Underrange" Index="#x6000" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Overrange" Index="#x6000" Sub="#x02">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Limit 1" Index="#x6000" Sub="#x03">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Limit 2" Index="#x6000" Sub="#x05">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Error" Index="#x6000" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry>
+					<Type GUID="{18071995-0000-0000-0000-002000000007}">ARRAY [0..6] OF BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO State" Index="#x1800" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO Toggle" Index="#x1800" Sub="#x09">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Value" Index="#x6000" Sub="#x11" Flags="#x00050000">
+					<Type>INT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="RTD Inputs Channel 2" Index="#x1a01" Flags="#x0011" SyncMan="3">
+				<Entry Name="Status__Underrange" Index="#x6010" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Overrange" Index="#x6010" Sub="#x02">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Limit 1" Index="#x6010" Sub="#x03">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Limit 2" Index="#x6010" Sub="#x05">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Error" Index="#x6010" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry>
+					<Type GUID="{18071995-0000-0000-0000-002000000007}">ARRAY [0..6] OF BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO State" Index="#x1801" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO Toggle" Index="#x1801" Sub="#x09">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Value" Index="#x6010" Sub="#x11" Flags="#x00050000">
+					<Type>INT</Type>
+				</Entry>
+			</Pdo>
+			<CoeProfile ProfileNo="20976521"/>
+			<CoeProfile ProfileNo="20976521"/>
+		</EtherCAT>
+	</Box>
+</TcSmItem>

--- a/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT)/Power (EK1200)/PLC Junction 2 (EK1122)/PLC Coupler 2 (EK1100)/PLC Junction 9 (EK1122)/SP1K4 Top Rail (EK1100)/SP1K4-EL3202-E9B.xti
+++ b/plc-tmo-motion/_Config/IO/Device 1 (EtherCAT)/Power (EK1200)/PLC Junction 2 (EK1122)/PLC Coupler 2 (EK1100)/PLC Junction 9 (EK1122)/SP1K4 Top Rail (EK1100)/SP1K4-EL3202-E9B.xti
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CFlbTermDef" SubType="9099">
+	<DataTypes>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-002000000007}" IecBaseType="true" BitType="true" AutoDeleteType="true" HideSubItems="true">ARRAY [0..6] OF BIT</Name>
+			<BitSize>7</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000010}">BIT</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>7</Elements>
+			</ArrayInfo>
+		</DataType>
+	</DataTypes>
+	<ImageDatas>
+		<ImageData Id="1000">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000c40e0000c40e00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ff808080808080808080808080808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c000ffffc0c0c000ffff808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0ff0000c0c0c0ff0000808080ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c00000ffc0c0c00000ff808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0000000c0c0c0000000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0008000c0c0c0008000808080ff00ffff00ffff00ffff00ffff00ff00ff0000ff0000ff0000ff0000ff0000ff00c0c0c0c0c0c0c0c0c0c0c0c0808080ff00ffff00ffff00ffff00ffff00ff</ImageData>
+	</ImageDatas>
+	<Box Id="258" BoxType="9099" BoxFlags="#x00000020">
+		<Name>__FILENAME__</Name>
+		<ImageId>1000</ImageId>
+		<EtherCAT SlaveType="2" PdiType="#x0005" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="3" FoeType="1" VendorId="#x00000002" ProductCode="#x0c823052" RevisionNo="#x0016000a" InfoDataAddr="true" TimeoutMailbox2="2000" CheckRevisionNoType="3" PortPhys="51" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL3202-0010 2Ch. Ana. Input PT100 (RTD), High Precision" Desc="EL3202-0010">
+			<SyncMan>001080002600010001000000800080008000001026010000</SyncMan>
+			<SyncMan>801080002200010002000000800080008000801022010000</SyncMan>
+			<SyncMan>001100000400000003000000000000000000001104000000</SyncMan>
+			<SyncMan>801108002000010004000000000000000800801120010000</SyncMan>
+			<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
+			<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
+			<BootStrapData>0010f400f410f400</BootStrapData>
+			<Pdo Name="RTD Inputs Channel 1" Index="#x1a00" Flags="#x0011" SyncMan="3">
+				<Entry Name="Status__Underrange" Index="#x6000" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Overrange" Index="#x6000" Sub="#x02">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Limit 1" Index="#x6000" Sub="#x03">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Limit 2" Index="#x6000" Sub="#x05">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Error" Index="#x6000" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry>
+					<Type GUID="{18071995-0000-0000-0000-002000000007}">ARRAY [0..6] OF BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO State" Index="#x1800" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO Toggle" Index="#x1800" Sub="#x09">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Value" Index="#x6000" Sub="#x11" Flags="#x00050000">
+					<Type>INT</Type>
+				</Entry>
+			</Pdo>
+			<Pdo Name="RTD Inputs Channel 2" Index="#x1a01" Flags="#x0011" SyncMan="3">
+				<Entry Name="Status__Underrange" Index="#x6010" Sub="#x01">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Overrange" Index="#x6010" Sub="#x02">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__Limit 1" Index="#x6010" Sub="#x03">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Limit 2" Index="#x6010" Sub="#x05">
+					<Type>BIT2</Type>
+				</Entry>
+				<Entry Name="Status__Error" Index="#x6010" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry>
+					<Type GUID="{18071995-0000-0000-0000-002000000007}">ARRAY [0..6] OF BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO State" Index="#x1801" Sub="#x07">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Status__TxPDO Toggle" Index="#x1801" Sub="#x09">
+					<Type>BIT</Type>
+				</Entry>
+				<Entry Name="Value" Index="#x6010" Sub="#x11" Flags="#x00050000">
+					<Type>INT</Type>
+				</Entry>
+			</Pdo>
+			<CoeProfile ProfileNo="20976521"/>
+			<CoeProfile ProfileNo="20976521"/>
+		</EtherCAT>
+	</Box>
+</TcSmItem>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -6652,6 +6652,38 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
 					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 					<SubVar>
@@ -12732,6 +12764,16 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Top Rail (EK1100)^FoilY-EL7041">
 				<Link VarA="PlcTask Inputs^Main.M44.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^Main.M44.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Top Rail (EK1100)^SP1K4- EL3202-E9A">
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Top Rail (EK1100)^SP1K4-TL1-EL1124">
 				<Link VarA="PlcTask Inputs^PRG_SP1K4.bTL1High" VarB="Channel 1^Input" AutoLink="true"/>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -96,6 +96,30 @@ VAR
 
     bPF1K4Out: BOOL;
 
+    // SP1K4 RTD-01
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: SP1K4:ATT:RTD:01
+        field: EGU C
+        io: i
+    '}
+    SP1K4_ATT_RTD_01 : FB_TempSensor;
+
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: SP1K4:ATT:RTD:02
+        field: EGU C
+        io: i
+    '}
+    SP1K4_ATT_RTD_02 : FB_TempSensor;
+
+
 
 END_VAR
 ]]></Declaration>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{5D589473-088F-5AFE-4CC9-359105A01C72}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{80154F0D-52E3-F26A-883E-7FB33004D347}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85792732</GetCodeOffs>
+        <GetCodeOffs>85792796</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85792764</GetCodeOffs>
+        <GetCodeOffs>85792828</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85792772</GetCodeOffs>
+        <GetCodeOffs>85792836</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85792756</GetCodeOffs>
+        <GetCodeOffs>85792820</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85792768</GetCodeOffs>
+        <GetCodeOffs>85792832</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85792676</GetCodeOffs>
-        <SetCodeOffs>85792700</SetCodeOffs>
+        <GetCodeOffs>85792740</GetCodeOffs>
+        <SetCodeOffs>85792764</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85792712</GetCodeOffs>
-        <SetCodeOffs>85792724</SetCodeOffs>
+        <GetCodeOffs>85792776</GetCodeOffs>
+        <SetCodeOffs>85792788</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>85792820</GetCodeOffs>
+        <GetCodeOffs>85792884</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85792800</GetCodeOffs>
+        <GetCodeOffs>85792864</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85792888</GetCodeOffs>
+        <GetCodeOffs>85792952</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85792848</GetCodeOffs>
+        <GetCodeOffs>85792912</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85792892</GetCodeOffs>
+        <GetCodeOffs>85792956</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85792916</GetCodeOffs>
+        <GetCodeOffs>85792980</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -6256,6 +6256,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_BOOL</Name>
@@ -6388,6 +6393,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6547,6 +6557,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfSuccessfulTests</Name>
@@ -6653,6 +6668,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6786,6 +6806,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -7266,6 +7291,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8034,6 +8064,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_TIME</Name>
@@ -8425,6 +8460,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_INT</Name>
@@ -8516,6 +8556,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8643,6 +8688,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_LWORD</Name>
@@ -8744,6 +8794,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9060,6 +9115,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AreAllTestsFinished</Name>
@@ -9224,6 +9284,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9408,6 +9473,11 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_LREAL</Name>
@@ -9505,6 +9575,11 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -17550,7 +17625,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Name>
       <BitSize>8</BitSize>
       <BaseType>BYTE</BaseType>
       <EnumInfo>
@@ -17729,7 +17804,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Name>
       <BitSize>6192</BitSize>
       <SubItem>
         <Name>TestName</Name>
@@ -17763,7 +17838,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>FailureType</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
         <BitSize>8</BitSize>
         <BitOffs>6160</BitOffs>
       </SubItem>
@@ -17775,7 +17850,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Name>
       <BitSize>621296</BitSize>
       <SubItem>
         <Name>Name</Name>
@@ -17805,7 +17880,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestCaseResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestCaseResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -17815,7 +17890,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Name>
       <BitSize>621296064</BitSize>
       <SubItem>
         <Name>NumberOfTestSuites</Name>
@@ -17847,7 +17922,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestSuiteResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -17858,7 +17933,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -17868,7 +17943,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestSuiteResults</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
     </DataType>
@@ -17888,13 +17963,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Name>
       <Comment> This function block holds results of the complete test run, i.e. results for all test suites </Comment>
       <BitSize>621296256</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Implements>
       <SubItem>
         <Name>TestSuiteResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_TestSuiteResults</Type>
         <Comment> Test results </Comment>
         <BitSize>621296064</BitSize>
         <BitOffs>64</BitOffs>
@@ -17937,7 +18012,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestSuiteResults</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Properties>
@@ -17948,7 +18023,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -17971,17 +18046,17 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Name>
       <Comment>
     This function block reports the results from the tests using the built-in ADSLOGSTR functionality
     provided by the Tc2_System library. This sends the result using ADS, which is consumed by the "Error List"
     of Visual Studio (which can print Errors, Warnings and Messages).
 </Comment>
       <BitSize>224</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
@@ -18015,7 +18090,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>TcUnitTestResults</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
@@ -18107,7 +18182,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BaseType PointerTo="1">BYTE</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Name>
       <Comment>
     This functionblock can open, close, read, write and delete files on the local filesystem
 </Comment>
@@ -18213,7 +18288,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Name>
       <BitSize>8</BitSize>
       <BaseType>BYTE</BaseType>
       <EnumInfo>
@@ -18234,7 +18309,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Name>
       <Comment>
     This functionblock acts as a stream buffer for use with FB_XmlControl
 </Comment>
@@ -18279,7 +18354,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Parameter>
           <Name>XmlError</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -18493,7 +18568,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Parameter>
           <Name>XmlError</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_XmlError</Type>
           <BitSize>8</BitSize>
           <Properties>
             <Property>
@@ -18531,7 +18606,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Name>
       <Comment>
     Organizes parsing and composing of XML data. Data can be treated as STRING or char array.
     Buffer size of file can be set via GVL_Param_TcUnit (xUnitBufferSize)
@@ -18539,13 +18614,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>5696</BitSize>
       <SubItem>
         <Name>XmlBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>32</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TagListBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>160</BitOffs>
       </SubItem>
@@ -18557,7 +18632,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TagListSeekBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>2336</BitOffs>
       </SubItem>
@@ -18569,7 +18644,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TagBuffer</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_StreamBuffer</Type>
         <BitSize>128</BitSize>
         <BitOffs>3136</BitOffs>
       </SubItem>
@@ -18805,15 +18880,15 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Name>
       <Comment>
     Publishes test results into an xUnit compatible Xml file
 </Comment>
       <BitSize>530304</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResults</Type>
         <Comment> Dependancy Injection via FB_Init</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
@@ -18830,13 +18905,13 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>File</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_FileControl</Type>
         <BitSize>96</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Xml</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_XmlControl</Type>
         <BitSize>5696</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
@@ -18880,7 +18955,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>UnitTestResults</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
           <BitSize>32</BitSize>
         </Local>
         <Local>
@@ -18922,7 +18997,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</Name>
       <Comment>
     This function block is responsible for holding track of the tests and executing them.
 </Comment>
@@ -18939,14 +19014,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestResults</Type>
         <Comment> Test result information </Comment>
         <BitSize>621296256</BitSize>
         <BitOffs>64</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsTestResultLogger</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsTestResultLogger</Type>
         <Comment> Prints the results to ADS so that Visual Studio can display the results.
        This test result formatter can be replaced with something else than ADS </Comment>
         <BitSize>224</BitSize>
@@ -18959,7 +19034,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>TestResultLogger</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
         <BitSize>32</BitSize>
         <BitOffs>621296544</BitOffs>
       </SubItem>
@@ -18973,7 +19048,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>xUnitXmlPublisher</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_xUnitXmlPublisher</Type>
         <Comment> Publishes a xUnit compatible XML file </Comment>
         <BitSize>530304</BitSize>
         <BitOffs>621296608</BitOffs>
@@ -18985,7 +19060,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>XmlTestResultPublisher</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_TestResultLogger</Type>
         <BitSize>32</BitSize>
         <BitOffs>621826912</BitOffs>
       </SubItem>
@@ -19086,7 +19161,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
 </Comment>
@@ -19141,14 +19216,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertionType</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
         <Comment> Assertion type for the first assertion in this test</Comment>
         <BitSize>8</BitSize>
         <BitOffs>4184</BitOffs>
       </SubItem>
       <Method>
         <Name>GetAssertionType</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
@@ -19218,7 +19293,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetAssertionType</Name>
         <Parameter>
           <Name>AssertType</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
           <BitSize>8</BitSize>
         </Parameter>
       </Method>
@@ -19260,7 +19335,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Name>
       <BitSize>4096</BitSize>
       <SubItem>
         <Name>boolExpectedOrActual</Name>
@@ -19402,17 +19477,17 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Name>
       <BitSize>12288</BitSize>
       <SubItem>
         <Name>Expected</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>4096</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Actual</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">U_ExpectedOrActual</Type>
         <BitSize>4096</BitSize>
         <BitOffs>4096</BitOffs>
       </SubItem>
@@ -19430,11 +19505,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Name>
       <BitSize>12352</BitSize>
       <SubItem>
         <Name>AssertResult</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
         <BitSize>12288</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -19454,7 +19529,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which asserts that have been made. The reason we need to
     keep track of these is because if the user does the same assert twice (because of running a test suite over several
@@ -19468,7 +19543,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>24640320</BitSize>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19496,7 +19571,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertResultInstances</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19845,7 +19920,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Name>
       <BitSize>4224</BitSize>
       <SubItem>
         <Name>ExpectedsSize</Name>
@@ -19889,11 +19964,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Name>
       <BitSize>4256</BitSize>
       <SubItem>
         <Name>AssertArrayResult</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
         <BitSize>4224</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -19913,7 +19988,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Name>
       <Comment>
     This function block is responsible for keeping track of which array-asserts that have been made.
     The reason we need to keep track of these is because if the user does the same assert twice
@@ -19929,7 +20004,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>8480256</BitSize>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResult</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -19957,7 +20032,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertArrayResultInstances</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AssertArrayResultInstances</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>1000</Elements>
@@ -20256,7 +20331,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Name>
       <BitSize>32</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
@@ -20284,7 +20359,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Name>
       <Comment>
     This function block is responsible for making sure that the asserted test instance path and test message are not
     loo long. The total printed message can not be more than 253 characters long.
@@ -20382,14 +20457,14 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Name>
       <Comment>
     This function block is responsible for printing the results of the assertions using the built-in
     ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
     is consumed by the error list of Visual Studio.
 </Comment>
       <BitSize>64</BitSize>
-      <Implements Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Implements>
+      <Implements Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Implements>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -20414,7 +20489,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Local>
           <Name>AdjustAssertFailureMessageToMax253CharLength</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
           <BitSize>11584</BitSize>
         </Local>
         <Local>
@@ -20451,7 +20526,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</Name>
       <Comment> This function block is responsible for holding the internal state of the test suite.
    Every test suite can have one or more tests, and every test can do one or more asserts.
    It's also responsible for providing all the assert-methods for asserting different data types.
@@ -20493,7 +20568,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>Tests</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_Test</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>100</Elements>
@@ -20527,19 +20602,19 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertResultStatic</Type>
         <BitSize>24640320</BitSize>
         <BitOffs>431040</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertArrayResults</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AssertArrayResultStatic</Type>
         <BitSize>8480256</BitSize>
         <BitOffs>25071360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsAssertMessageFormatter</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsAssertMessageFormatter</Type>
         <Comment> Prints the failed asserts to ADS so that Visual Studio can display the assert message.
        This assert formatter can be replaced with something else than ADS </Comment>
         <BitSize>64</BitSize>
@@ -20547,7 +20622,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>AssertMessageFormatter</Name>
-        <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Type>
+        <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">I_AssertMessageFormatter</Type>
         <BitSize>32</BitSize>
         <BitOffs>33551680</BitOffs>
       </SubItem>
@@ -20691,6 +20766,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -20851,7 +20931,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
       <Method>
         <Name>GetTestByPosition</Name>
-        <ReturnType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_Test</ReturnType>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_Test</ReturnType>
         <ReturnBitSize>4192</ReturnBitSize>
         <Parameter>
           <Name>Position</Name>
@@ -20949,6 +21029,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -21053,6 +21138,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -21212,6 +21302,11 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LTIME</Name>
@@ -21334,6 +21429,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -21475,6 +21575,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -22236,6 +22341,11 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>SetHasStartedRunning</Name>
@@ -22244,7 +22354,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetTestFailed</Name>
         <Parameter>
           <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -22396,6 +22506,11 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetHasStartedRunning</Name>
@@ -22498,6 +22613,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -22652,6 +22772,11 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DINT</Name>
@@ -22774,6 +22899,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -22949,6 +23079,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -23231,6 +23366,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -24027,6 +24167,11 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_UDINT</Name>
@@ -24121,6 +24266,11 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -24136,7 +24286,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Name>
       <BitSize>4128</BitSize>
       <SubItem>
         <Name>MsgCtrlMask</Name>
@@ -24164,7 +24314,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
+      <Name Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</Name>
       <Comment> This function block is responsible for making sure that the ADSLOGSTR-messages to the ADS-router are transmitted
    cyclically and not in a burst. The reason this is necessary is because that if too many messages are sent at the
    same time some get lost and are never printed to the error list output
@@ -24256,7 +24406,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
         <Local>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
       </Method>
@@ -24264,7 +24414,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetAndRemoveLogFromQueue</Name>
         <Parameter>
           <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
           <Properties>
             <Property>
@@ -54151,8 +54301,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>85799448</GetCodeOffs>
-        <SetCodeOffs>85799456</SetCodeOffs>
+        <GetCodeOffs>85799512</GetCodeOffs>
+        <SetCodeOffs>85799520</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -55446,31 +55596,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85799016</GetCodeOffs>
+        <GetCodeOffs>85799080</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>85799048</GetCodeOffs>
+        <GetCodeOffs>85799112</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85799052</GetCodeOffs>
+        <GetCodeOffs>85799116</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>85799040</GetCodeOffs>
+        <GetCodeOffs>85799104</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>85799060</GetCodeOffs>
+        <GetCodeOffs>85799124</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -65090,6 +65240,126 @@ Digital outputs</Comment>
             <BitOffs>674478160</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859744</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
             <BitSize>1760</BitSize>
             <BaseType GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</BaseType>
@@ -65103,7 +65373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674860704</BitOffs>
+            <BitOffs>674861216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -65124,7 +65394,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674864224</BitOffs>
+            <BitOffs>674864736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -65145,7 +65415,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674864225</BitOffs>
+            <BitOffs>674864737</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -65157,7 +65427,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685062720</BitOffs>
+            <BitOffs>685063232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -65170,7 +65440,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070656</BitOffs>
+            <BitOffs>685071168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -65183,7 +65453,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070664</BitOffs>
+            <BitOffs>685071176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -65196,7 +65466,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070672</BitOffs>
+            <BitOffs>685071184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -65219,7 +65489,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070688</BitOffs>
+            <BitOffs>685071200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -65232,7 +65502,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070720</BitOffs>
+            <BitOffs>685071232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -65245,7 +65515,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070784</BitOffs>
+            <BitOffs>685071296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -65258,7 +65528,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685070800</BitOffs>
+            <BitOffs>685071312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -65270,7 +65540,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685087936</BitOffs>
+            <BitOffs>685088448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -65283,7 +65553,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685095872</BitOffs>
+            <BitOffs>685096384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -65296,7 +65566,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685095880</BitOffs>
+            <BitOffs>685096392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -65309,7 +65579,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685095888</BitOffs>
+            <BitOffs>685096400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -65332,7 +65602,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685095904</BitOffs>
+            <BitOffs>685096416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -65345,7 +65615,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685095936</BitOffs>
+            <BitOffs>685096448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -65358,7 +65628,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685096000</BitOffs>
+            <BitOffs>685096512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -65371,7 +65641,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685096016</BitOffs>
+            <BitOffs>685096528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -65383,7 +65653,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685113152</BitOffs>
+            <BitOffs>685113664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -65396,7 +65666,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121088</BitOffs>
+            <BitOffs>685121600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -65409,7 +65679,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121096</BitOffs>
+            <BitOffs>685121608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -65422,7 +65692,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121104</BitOffs>
+            <BitOffs>685121616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -65445,7 +65715,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121120</BitOffs>
+            <BitOffs>685121632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -65458,7 +65728,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121152</BitOffs>
+            <BitOffs>685121664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -65471,7 +65741,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121216</BitOffs>
+            <BitOffs>685121728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -65484,7 +65754,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685121232</BitOffs>
+            <BitOffs>685121744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -65496,7 +65766,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685138368</BitOffs>
+            <BitOffs>685138880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -65509,7 +65779,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146304</BitOffs>
+            <BitOffs>685146816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -65522,7 +65792,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146312</BitOffs>
+            <BitOffs>685146824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -65535,7 +65805,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146320</BitOffs>
+            <BitOffs>685146832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -65558,7 +65828,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146336</BitOffs>
+            <BitOffs>685146848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -65571,7 +65841,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146368</BitOffs>
+            <BitOffs>685146880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -65584,7 +65854,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146432</BitOffs>
+            <BitOffs>685146944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -65597,7 +65867,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685146448</BitOffs>
+            <BitOffs>685146960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -65609,7 +65879,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685163584</BitOffs>
+            <BitOffs>685164096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -65622,7 +65892,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171520</BitOffs>
+            <BitOffs>685172032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -65635,7 +65905,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171528</BitOffs>
+            <BitOffs>685172040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -65648,7 +65918,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171536</BitOffs>
+            <BitOffs>685172048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -65671,7 +65941,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171552</BitOffs>
+            <BitOffs>685172064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -65684,7 +65954,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171584</BitOffs>
+            <BitOffs>685172096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -65697,7 +65967,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171648</BitOffs>
+            <BitOffs>685172160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -65710,7 +65980,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685171664</BitOffs>
+            <BitOffs>685172176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -65722,7 +65992,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685188800</BitOffs>
+            <BitOffs>685189312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -65735,7 +66005,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196736</BitOffs>
+            <BitOffs>685197248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -65748,7 +66018,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196744</BitOffs>
+            <BitOffs>685197256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -65761,7 +66031,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196752</BitOffs>
+            <BitOffs>685197264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -65784,7 +66054,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196768</BitOffs>
+            <BitOffs>685197280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -65797,7 +66067,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196800</BitOffs>
+            <BitOffs>685197312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -65810,7 +66080,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196864</BitOffs>
+            <BitOffs>685197376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -65823,7 +66093,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685196880</BitOffs>
+            <BitOffs>685197392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -65835,7 +66105,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685214016</BitOffs>
+            <BitOffs>685214528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -65848,7 +66118,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685221952</BitOffs>
+            <BitOffs>685222464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -65861,7 +66131,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685221960</BitOffs>
+            <BitOffs>685222472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -65874,7 +66144,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685221968</BitOffs>
+            <BitOffs>685222480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -65897,7 +66167,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685221984</BitOffs>
+            <BitOffs>685222496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -65910,7 +66180,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685222016</BitOffs>
+            <BitOffs>685222528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -65923,7 +66193,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685222080</BitOffs>
+            <BitOffs>685222592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -65936,7 +66206,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685222096</BitOffs>
+            <BitOffs>685222608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -65948,7 +66218,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685239232</BitOffs>
+            <BitOffs>685239744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -65961,7 +66231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247168</BitOffs>
+            <BitOffs>685247680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -65974,7 +66244,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247176</BitOffs>
+            <BitOffs>685247688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -65987,7 +66257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247184</BitOffs>
+            <BitOffs>685247696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -66010,7 +66280,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247200</BitOffs>
+            <BitOffs>685247712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -66023,7 +66293,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247232</BitOffs>
+            <BitOffs>685247744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -66036,7 +66306,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247296</BitOffs>
+            <BitOffs>685247808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -66049,7 +66319,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685247312</BitOffs>
+            <BitOffs>685247824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -66061,7 +66331,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685264448</BitOffs>
+            <BitOffs>685264960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -66074,7 +66344,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272384</BitOffs>
+            <BitOffs>685272896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -66087,7 +66357,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272392</BitOffs>
+            <BitOffs>685272904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -66100,7 +66370,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272400</BitOffs>
+            <BitOffs>685272912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -66123,7 +66393,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272416</BitOffs>
+            <BitOffs>685272928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -66136,7 +66406,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272448</BitOffs>
+            <BitOffs>685272960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -66149,7 +66419,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272512</BitOffs>
+            <BitOffs>685273024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -66162,7 +66432,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685272528</BitOffs>
+            <BitOffs>685273040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -66174,7 +66444,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685289664</BitOffs>
+            <BitOffs>685290176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -66187,7 +66457,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297600</BitOffs>
+            <BitOffs>685298112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -66200,7 +66470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297608</BitOffs>
+            <BitOffs>685298120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -66213,7 +66483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297616</BitOffs>
+            <BitOffs>685298128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -66236,7 +66506,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297632</BitOffs>
+            <BitOffs>685298144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -66249,7 +66519,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297664</BitOffs>
+            <BitOffs>685298176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -66262,7 +66532,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297728</BitOffs>
+            <BitOffs>685298240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -66275,7 +66545,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685297744</BitOffs>
+            <BitOffs>685298256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -66287,7 +66557,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685314880</BitOffs>
+            <BitOffs>685315392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -66300,7 +66570,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322816</BitOffs>
+            <BitOffs>685323328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -66313,7 +66583,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322824</BitOffs>
+            <BitOffs>685323336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -66326,7 +66596,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322832</BitOffs>
+            <BitOffs>685323344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -66349,7 +66619,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322848</BitOffs>
+            <BitOffs>685323360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -66362,7 +66632,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322880</BitOffs>
+            <BitOffs>685323392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -66375,7 +66645,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322944</BitOffs>
+            <BitOffs>685323456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -66388,7 +66658,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685322960</BitOffs>
+            <BitOffs>685323472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -66400,7 +66670,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685340096</BitOffs>
+            <BitOffs>685340608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -66413,7 +66683,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348032</BitOffs>
+            <BitOffs>685348544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -66426,7 +66696,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348040</BitOffs>
+            <BitOffs>685348552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -66439,7 +66709,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348048</BitOffs>
+            <BitOffs>685348560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -66462,7 +66732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348064</BitOffs>
+            <BitOffs>685348576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -66475,7 +66745,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348096</BitOffs>
+            <BitOffs>685348608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -66488,7 +66758,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348160</BitOffs>
+            <BitOffs>685348672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -66501,7 +66771,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685348176</BitOffs>
+            <BitOffs>685348688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -66513,7 +66783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685365312</BitOffs>
+            <BitOffs>685365824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -66526,7 +66796,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373248</BitOffs>
+            <BitOffs>685373760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -66539,7 +66809,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373256</BitOffs>
+            <BitOffs>685373768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -66552,7 +66822,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373264</BitOffs>
+            <BitOffs>685373776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -66575,7 +66845,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373280</BitOffs>
+            <BitOffs>685373792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -66588,7 +66858,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373312</BitOffs>
+            <BitOffs>685373824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -66601,7 +66871,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373376</BitOffs>
+            <BitOffs>685373888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -66614,7 +66884,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685373392</BitOffs>
+            <BitOffs>685373904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -66626,7 +66896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685390528</BitOffs>
+            <BitOffs>685391040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -66639,7 +66909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398464</BitOffs>
+            <BitOffs>685398976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -66652,7 +66922,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398472</BitOffs>
+            <BitOffs>685398984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -66665,7 +66935,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398480</BitOffs>
+            <BitOffs>685398992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -66688,7 +66958,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398496</BitOffs>
+            <BitOffs>685399008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -66701,7 +66971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398528</BitOffs>
+            <BitOffs>685399040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -66714,7 +66984,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398592</BitOffs>
+            <BitOffs>685399104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -66727,7 +66997,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685398608</BitOffs>
+            <BitOffs>685399120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -66739,7 +67009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685415744</BitOffs>
+            <BitOffs>685416256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -66752,7 +67022,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423680</BitOffs>
+            <BitOffs>685424192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -66765,7 +67035,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423688</BitOffs>
+            <BitOffs>685424200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -66778,7 +67048,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423696</BitOffs>
+            <BitOffs>685424208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -66801,7 +67071,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423712</BitOffs>
+            <BitOffs>685424224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -66814,7 +67084,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423744</BitOffs>
+            <BitOffs>685424256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -66827,7 +67097,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423808</BitOffs>
+            <BitOffs>685424320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -66840,7 +67110,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685423824</BitOffs>
+            <BitOffs>685424336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -66852,7 +67122,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685440960</BitOffs>
+            <BitOffs>685441472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -66865,7 +67135,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685448896</BitOffs>
+            <BitOffs>685449408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -66878,7 +67148,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685448904</BitOffs>
+            <BitOffs>685449416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -66891,7 +67161,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685448912</BitOffs>
+            <BitOffs>685449424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -66914,7 +67184,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685448928</BitOffs>
+            <BitOffs>685449440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -66927,7 +67197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685448960</BitOffs>
+            <BitOffs>685449472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -66940,7 +67210,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685449024</BitOffs>
+            <BitOffs>685449536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -66953,7 +67223,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685449040</BitOffs>
+            <BitOffs>685449552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -66965,7 +67235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685466176</BitOffs>
+            <BitOffs>685466688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -66978,7 +67248,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474112</BitOffs>
+            <BitOffs>685474624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -66991,7 +67261,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474120</BitOffs>
+            <BitOffs>685474632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -67004,7 +67274,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474128</BitOffs>
+            <BitOffs>685474640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -67027,7 +67297,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474144</BitOffs>
+            <BitOffs>685474656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -67040,7 +67310,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474176</BitOffs>
+            <BitOffs>685474688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -67053,7 +67323,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474240</BitOffs>
+            <BitOffs>685474752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -67066,7 +67336,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685474256</BitOffs>
+            <BitOffs>685474768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -67078,7 +67348,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685491392</BitOffs>
+            <BitOffs>685491904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -67091,7 +67361,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499328</BitOffs>
+            <BitOffs>685499840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -67104,7 +67374,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499336</BitOffs>
+            <BitOffs>685499848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -67117,7 +67387,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499344</BitOffs>
+            <BitOffs>685499856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -67140,7 +67410,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499360</BitOffs>
+            <BitOffs>685499872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -67153,7 +67423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499392</BitOffs>
+            <BitOffs>685499904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -67166,7 +67436,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499456</BitOffs>
+            <BitOffs>685499968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -67179,7 +67449,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685499472</BitOffs>
+            <BitOffs>685499984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -67191,7 +67461,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685516608</BitOffs>
+            <BitOffs>685517120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -67204,7 +67474,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524544</BitOffs>
+            <BitOffs>685525056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -67217,7 +67487,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524552</BitOffs>
+            <BitOffs>685525064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -67230,7 +67500,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524560</BitOffs>
+            <BitOffs>685525072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -67253,7 +67523,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524576</BitOffs>
+            <BitOffs>685525088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -67266,7 +67536,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524608</BitOffs>
+            <BitOffs>685525120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -67279,7 +67549,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524672</BitOffs>
+            <BitOffs>685525184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -67292,7 +67562,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685524688</BitOffs>
+            <BitOffs>685525200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -67304,7 +67574,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685541824</BitOffs>
+            <BitOffs>685542336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -67317,7 +67587,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549760</BitOffs>
+            <BitOffs>685550272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -67330,7 +67600,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549768</BitOffs>
+            <BitOffs>685550280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -67343,7 +67613,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549776</BitOffs>
+            <BitOffs>685550288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -67366,7 +67636,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549792</BitOffs>
+            <BitOffs>685550304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -67379,7 +67649,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549824</BitOffs>
+            <BitOffs>685550336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -67392,7 +67662,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549888</BitOffs>
+            <BitOffs>685550400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -67405,7 +67675,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685549904</BitOffs>
+            <BitOffs>685550416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -67417,7 +67687,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685567040</BitOffs>
+            <BitOffs>685567552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -67430,7 +67700,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685574976</BitOffs>
+            <BitOffs>685575488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -67443,7 +67713,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685574984</BitOffs>
+            <BitOffs>685575496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -67456,7 +67726,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685574992</BitOffs>
+            <BitOffs>685575504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -67479,7 +67749,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685575008</BitOffs>
+            <BitOffs>685575520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -67492,7 +67762,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685575040</BitOffs>
+            <BitOffs>685575552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -67505,7 +67775,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685575104</BitOffs>
+            <BitOffs>685575616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -67518,7 +67788,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685575120</BitOffs>
+            <BitOffs>685575632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -67530,7 +67800,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685592256</BitOffs>
+            <BitOffs>685592768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -67543,7 +67813,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600192</BitOffs>
+            <BitOffs>685600704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -67556,7 +67826,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600200</BitOffs>
+            <BitOffs>685600712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -67569,7 +67839,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600208</BitOffs>
+            <BitOffs>685600720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -67592,7 +67862,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600224</BitOffs>
+            <BitOffs>685600736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -67605,7 +67875,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600256</BitOffs>
+            <BitOffs>685600768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -67618,7 +67888,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600320</BitOffs>
+            <BitOffs>685600832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -67631,7 +67901,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685600336</BitOffs>
+            <BitOffs>685600848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -67643,7 +67913,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685617472</BitOffs>
+            <BitOffs>685617984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -67656,7 +67926,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625408</BitOffs>
+            <BitOffs>685625920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -67669,7 +67939,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625416</BitOffs>
+            <BitOffs>685625928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -67682,7 +67952,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625424</BitOffs>
+            <BitOffs>685625936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -67705,7 +67975,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625440</BitOffs>
+            <BitOffs>685625952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -67718,7 +67988,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625472</BitOffs>
+            <BitOffs>685625984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -67731,7 +68001,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625536</BitOffs>
+            <BitOffs>685626048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -67744,7 +68014,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685625552</BitOffs>
+            <BitOffs>685626064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -67756,7 +68026,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685642688</BitOffs>
+            <BitOffs>685643200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -67769,7 +68039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650624</BitOffs>
+            <BitOffs>685651136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -67782,7 +68052,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650632</BitOffs>
+            <BitOffs>685651144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -67795,7 +68065,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650640</BitOffs>
+            <BitOffs>685651152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -67818,7 +68088,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650656</BitOffs>
+            <BitOffs>685651168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -67831,7 +68101,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650688</BitOffs>
+            <BitOffs>685651200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -67844,7 +68114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650752</BitOffs>
+            <BitOffs>685651264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -67857,7 +68127,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685650768</BitOffs>
+            <BitOffs>685651280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -67869,7 +68139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685667904</BitOffs>
+            <BitOffs>685668416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -67882,7 +68152,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675840</BitOffs>
+            <BitOffs>685676352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -67895,7 +68165,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675848</BitOffs>
+            <BitOffs>685676360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -67908,7 +68178,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675856</BitOffs>
+            <BitOffs>685676368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -67931,7 +68201,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675872</BitOffs>
+            <BitOffs>685676384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -67944,7 +68214,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675904</BitOffs>
+            <BitOffs>685676416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -67957,7 +68227,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675968</BitOffs>
+            <BitOffs>685676480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -67970,7 +68240,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685675984</BitOffs>
+            <BitOffs>685676496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -67982,7 +68252,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685693120</BitOffs>
+            <BitOffs>685693632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -67995,7 +68265,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701056</BitOffs>
+            <BitOffs>685701568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -68008,7 +68278,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701064</BitOffs>
+            <BitOffs>685701576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -68021,7 +68291,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701072</BitOffs>
+            <BitOffs>685701584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -68044,7 +68314,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701088</BitOffs>
+            <BitOffs>685701600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -68057,7 +68327,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701120</BitOffs>
+            <BitOffs>685701632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -68070,7 +68340,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701184</BitOffs>
+            <BitOffs>685701696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -68083,7 +68353,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685701200</BitOffs>
+            <BitOffs>685701712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -68095,7 +68365,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685718336</BitOffs>
+            <BitOffs>685718848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -68108,7 +68378,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726272</BitOffs>
+            <BitOffs>685726784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -68121,7 +68391,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726280</BitOffs>
+            <BitOffs>685726792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -68134,7 +68404,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726288</BitOffs>
+            <BitOffs>685726800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -68157,7 +68427,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726304</BitOffs>
+            <BitOffs>685726816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -68170,7 +68440,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726336</BitOffs>
+            <BitOffs>685726848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -68183,7 +68453,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726400</BitOffs>
+            <BitOffs>685726912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -68196,7 +68466,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685726416</BitOffs>
+            <BitOffs>685726928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -68208,7 +68478,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685743552</BitOffs>
+            <BitOffs>685744064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -68221,7 +68491,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751488</BitOffs>
+            <BitOffs>685752000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -68234,7 +68504,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751496</BitOffs>
+            <BitOffs>685752008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -68247,7 +68517,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751504</BitOffs>
+            <BitOffs>685752016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -68270,7 +68540,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751520</BitOffs>
+            <BitOffs>685752032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -68283,7 +68553,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751552</BitOffs>
+            <BitOffs>685752064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -68296,7 +68566,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751616</BitOffs>
+            <BitOffs>685752128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -68309,7 +68579,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685751632</BitOffs>
+            <BitOffs>685752144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -68321,7 +68591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685768768</BitOffs>
+            <BitOffs>685769280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -68334,7 +68604,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776704</BitOffs>
+            <BitOffs>685777216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -68347,7 +68617,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776712</BitOffs>
+            <BitOffs>685777224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -68360,7 +68630,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776720</BitOffs>
+            <BitOffs>685777232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -68383,7 +68653,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776736</BitOffs>
+            <BitOffs>685777248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -68396,7 +68666,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776768</BitOffs>
+            <BitOffs>685777280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -68409,7 +68679,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776832</BitOffs>
+            <BitOffs>685777344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -68422,7 +68692,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685776848</BitOffs>
+            <BitOffs>685777360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -68434,7 +68704,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685793984</BitOffs>
+            <BitOffs>685794496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -68447,7 +68717,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685801920</BitOffs>
+            <BitOffs>685802432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -68460,7 +68730,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685801928</BitOffs>
+            <BitOffs>685802440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -68473,7 +68743,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685801936</BitOffs>
+            <BitOffs>685802448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -68496,7 +68766,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685801952</BitOffs>
+            <BitOffs>685802464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -68509,7 +68779,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685801984</BitOffs>
+            <BitOffs>685802496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -68522,7 +68792,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685802048</BitOffs>
+            <BitOffs>685802560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -68535,7 +68805,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685802064</BitOffs>
+            <BitOffs>685802576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -68547,7 +68817,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685819200</BitOffs>
+            <BitOffs>685819712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -68560,7 +68830,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827136</BitOffs>
+            <BitOffs>685827648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -68573,7 +68843,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827144</BitOffs>
+            <BitOffs>685827656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -68586,7 +68856,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827152</BitOffs>
+            <BitOffs>685827664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -68609,7 +68879,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827168</BitOffs>
+            <BitOffs>685827680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -68622,7 +68892,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827200</BitOffs>
+            <BitOffs>685827712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -68635,7 +68905,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827264</BitOffs>
+            <BitOffs>685827776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -68648,7 +68918,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685827280</BitOffs>
+            <BitOffs>685827792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -68660,7 +68930,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685844416</BitOffs>
+            <BitOffs>685844928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -68673,7 +68943,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852352</BitOffs>
+            <BitOffs>685852864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -68686,7 +68956,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852360</BitOffs>
+            <BitOffs>685852872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -68699,7 +68969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852368</BitOffs>
+            <BitOffs>685852880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -68722,7 +68992,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852384</BitOffs>
+            <BitOffs>685852896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -68735,7 +69005,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852416</BitOffs>
+            <BitOffs>685852928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -68748,7 +69018,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852480</BitOffs>
+            <BitOffs>685852992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -68761,7 +69031,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685852496</BitOffs>
+            <BitOffs>685853008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -68773,7 +69043,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685869632</BitOffs>
+            <BitOffs>685870144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -68786,7 +69056,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877568</BitOffs>
+            <BitOffs>685878080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -68799,7 +69069,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877576</BitOffs>
+            <BitOffs>685878088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -68812,7 +69082,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877584</BitOffs>
+            <BitOffs>685878096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -68835,7 +69105,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877600</BitOffs>
+            <BitOffs>685878112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -68848,7 +69118,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877632</BitOffs>
+            <BitOffs>685878144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -68861,7 +69131,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877696</BitOffs>
+            <BitOffs>685878208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -68874,7 +69144,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685877712</BitOffs>
+            <BitOffs>685878224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -68886,7 +69156,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685894848</BitOffs>
+            <BitOffs>685895360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -68899,7 +69169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902784</BitOffs>
+            <BitOffs>685903296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -68912,7 +69182,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902792</BitOffs>
+            <BitOffs>685903304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -68925,7 +69195,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902800</BitOffs>
+            <BitOffs>685903312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -68948,7 +69218,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902816</BitOffs>
+            <BitOffs>685903328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -68961,7 +69231,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902848</BitOffs>
+            <BitOffs>685903360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -68974,7 +69244,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902912</BitOffs>
+            <BitOffs>685903424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -68987,7 +69257,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685902928</BitOffs>
+            <BitOffs>685903440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -68999,7 +69269,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685920064</BitOffs>
+            <BitOffs>685920576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -69012,7 +69282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928000</BitOffs>
+            <BitOffs>685928512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -69025,7 +69295,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928008</BitOffs>
+            <BitOffs>685928520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -69038,7 +69308,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928016</BitOffs>
+            <BitOffs>685928528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -69061,7 +69331,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928032</BitOffs>
+            <BitOffs>685928544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -69074,7 +69344,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928064</BitOffs>
+            <BitOffs>685928576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -69087,7 +69357,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928128</BitOffs>
+            <BitOffs>685928640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -69100,7 +69370,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685928144</BitOffs>
+            <BitOffs>685928656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -69112,7 +69382,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685945280</BitOffs>
+            <BitOffs>685945792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -69125,7 +69395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953216</BitOffs>
+            <BitOffs>685953728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -69138,7 +69408,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953224</BitOffs>
+            <BitOffs>685953736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -69151,7 +69421,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953232</BitOffs>
+            <BitOffs>685953744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -69174,7 +69444,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953248</BitOffs>
+            <BitOffs>685953760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -69187,7 +69457,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953280</BitOffs>
+            <BitOffs>685953792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -69200,7 +69470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953344</BitOffs>
+            <BitOffs>685953856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -69213,7 +69483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685953360</BitOffs>
+            <BitOffs>685953872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -69225,7 +69495,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685970496</BitOffs>
+            <BitOffs>685971008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -69238,7 +69508,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978432</BitOffs>
+            <BitOffs>685978944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -69251,7 +69521,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978440</BitOffs>
+            <BitOffs>685978952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -69264,7 +69534,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978448</BitOffs>
+            <BitOffs>685978960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -69287,7 +69557,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978464</BitOffs>
+            <BitOffs>685978976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -69300,7 +69570,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978496</BitOffs>
+            <BitOffs>685979008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -69313,7 +69583,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978560</BitOffs>
+            <BitOffs>685979072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -69326,7 +69596,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685978576</BitOffs>
+            <BitOffs>685979088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -69338,7 +69608,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>685995712</BitOffs>
+            <BitOffs>685996224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -69351,7 +69621,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003648</BitOffs>
+            <BitOffs>686004160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -69364,7 +69634,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003656</BitOffs>
+            <BitOffs>686004168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -69377,7 +69647,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003664</BitOffs>
+            <BitOffs>686004176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -69400,7 +69670,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003680</BitOffs>
+            <BitOffs>686004192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -69413,7 +69683,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003712</BitOffs>
+            <BitOffs>686004224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -69426,7 +69696,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003776</BitOffs>
+            <BitOffs>686004288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -69439,7 +69709,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686003792</BitOffs>
+            <BitOffs>686004304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -69451,7 +69721,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686020928</BitOffs>
+            <BitOffs>686021440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -69464,7 +69734,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686028864</BitOffs>
+            <BitOffs>686029376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -69477,7 +69747,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686028872</BitOffs>
+            <BitOffs>686029384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -69490,7 +69760,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686028880</BitOffs>
+            <BitOffs>686029392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -69513,7 +69783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686028896</BitOffs>
+            <BitOffs>686029408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -69526,7 +69796,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686028928</BitOffs>
+            <BitOffs>686029440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -69539,7 +69809,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686028992</BitOffs>
+            <BitOffs>686029504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -69552,7 +69822,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686029008</BitOffs>
+            <BitOffs>686029520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -69564,7 +69834,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686046144</BitOffs>
+            <BitOffs>686046656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -69577,7 +69847,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054080</BitOffs>
+            <BitOffs>686054592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -69590,7 +69860,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054088</BitOffs>
+            <BitOffs>686054600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -69603,7 +69873,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054096</BitOffs>
+            <BitOffs>686054608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -69626,7 +69896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054112</BitOffs>
+            <BitOffs>686054624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -69639,7 +69909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054144</BitOffs>
+            <BitOffs>686054656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -69652,7 +69922,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054208</BitOffs>
+            <BitOffs>686054720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -69665,7 +69935,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686054224</BitOffs>
+            <BitOffs>686054736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -69677,7 +69947,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686071360</BitOffs>
+            <BitOffs>686071872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -69690,7 +69960,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079296</BitOffs>
+            <BitOffs>686079808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -69703,7 +69973,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079304</BitOffs>
+            <BitOffs>686079816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -69716,7 +69986,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079312</BitOffs>
+            <BitOffs>686079824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -69739,7 +70009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079328</BitOffs>
+            <BitOffs>686079840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -69752,7 +70022,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079360</BitOffs>
+            <BitOffs>686079872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -69765,7 +70035,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079424</BitOffs>
+            <BitOffs>686079936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -69778,7 +70048,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686079440</BitOffs>
+            <BitOffs>686079952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -69790,7 +70060,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686096576</BitOffs>
+            <BitOffs>686097088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -69803,7 +70073,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104512</BitOffs>
+            <BitOffs>686105024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -69816,7 +70086,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104520</BitOffs>
+            <BitOffs>686105032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -69829,7 +70099,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104528</BitOffs>
+            <BitOffs>686105040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -69852,7 +70122,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104544</BitOffs>
+            <BitOffs>686105056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -69865,7 +70135,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104576</BitOffs>
+            <BitOffs>686105088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -69878,7 +70148,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104640</BitOffs>
+            <BitOffs>686105152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -69891,7 +70161,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686104656</BitOffs>
+            <BitOffs>686105168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -69903,7 +70173,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686121792</BitOffs>
+            <BitOffs>686122304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -69916,7 +70186,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129728</BitOffs>
+            <BitOffs>686130240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -69929,7 +70199,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129736</BitOffs>
+            <BitOffs>686130248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -69942,7 +70212,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129744</BitOffs>
+            <BitOffs>686130256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -69965,7 +70235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129760</BitOffs>
+            <BitOffs>686130272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -69978,7 +70248,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129792</BitOffs>
+            <BitOffs>686130304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -69991,7 +70261,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129856</BitOffs>
+            <BitOffs>686130368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -70004,7 +70274,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686129872</BitOffs>
+            <BitOffs>686130384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -70016,7 +70286,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686147008</BitOffs>
+            <BitOffs>686147520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -70029,7 +70299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686154944</BitOffs>
+            <BitOffs>686155456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -70042,7 +70312,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686154952</BitOffs>
+            <BitOffs>686155464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -70055,7 +70325,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686154960</BitOffs>
+            <BitOffs>686155472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -70078,7 +70348,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686154976</BitOffs>
+            <BitOffs>686155488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -70091,7 +70361,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686155008</BitOffs>
+            <BitOffs>686155520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -70104,7 +70374,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686155072</BitOffs>
+            <BitOffs>686155584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -70117,7 +70387,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>686155088</BitOffs>
+            <BitOffs>686155600</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -71709,7 +71979,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>674859896</BitOffs>
+            <BitOffs>674860408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -71725,7 +71995,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674862464</BitOffs>
+            <BitOffs>674862976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -71745,7 +72015,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681767944</BitOffs>
+            <BitOffs>681768456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -71765,7 +72035,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>683414856</BitOffs>
+            <BitOffs>683415368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -71784,7 +72054,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061504</BitOffs>
+            <BitOffs>685062016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -71796,7 +72066,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685061696</BitOffs>
+            <BitOffs>685062208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -71809,7 +72079,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685070680</BitOffs>
+            <BitOffs>685071192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -71821,7 +72091,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685086912</BitOffs>
+            <BitOffs>685087424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -71834,7 +72104,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685095896</BitOffs>
+            <BitOffs>685096408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -71846,7 +72116,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685112128</BitOffs>
+            <BitOffs>685112640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -71859,7 +72129,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685121112</BitOffs>
+            <BitOffs>685121624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -71871,7 +72141,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685137344</BitOffs>
+            <BitOffs>685137856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -71884,7 +72154,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685146328</BitOffs>
+            <BitOffs>685146840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -71896,7 +72166,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685162560</BitOffs>
+            <BitOffs>685163072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -71909,7 +72179,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685171544</BitOffs>
+            <BitOffs>685172056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -71921,7 +72191,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685187776</BitOffs>
+            <BitOffs>685188288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -71934,7 +72204,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685196760</BitOffs>
+            <BitOffs>685197272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -71946,7 +72216,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685212992</BitOffs>
+            <BitOffs>685213504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -71959,7 +72229,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685221976</BitOffs>
+            <BitOffs>685222488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -71971,7 +72241,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685238208</BitOffs>
+            <BitOffs>685238720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -71984,7 +72254,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685247192</BitOffs>
+            <BitOffs>685247704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -71996,7 +72266,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685263424</BitOffs>
+            <BitOffs>685263936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -72009,7 +72279,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685272408</BitOffs>
+            <BitOffs>685272920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -72021,7 +72291,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685288640</BitOffs>
+            <BitOffs>685289152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -72034,7 +72304,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685297624</BitOffs>
+            <BitOffs>685298136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -72046,7 +72316,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685313856</BitOffs>
+            <BitOffs>685314368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -72059,7 +72329,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685322840</BitOffs>
+            <BitOffs>685323352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -72071,7 +72341,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685339072</BitOffs>
+            <BitOffs>685339584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -72084,7 +72354,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685348056</BitOffs>
+            <BitOffs>685348568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -72096,7 +72366,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685364288</BitOffs>
+            <BitOffs>685364800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -72109,7 +72379,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685373272</BitOffs>
+            <BitOffs>685373784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -72121,7 +72391,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685389504</BitOffs>
+            <BitOffs>685390016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -72134,7 +72404,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685398488</BitOffs>
+            <BitOffs>685399000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -72146,7 +72416,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685414720</BitOffs>
+            <BitOffs>685415232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -72159,7 +72429,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685423704</BitOffs>
+            <BitOffs>685424216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -72171,7 +72441,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685439936</BitOffs>
+            <BitOffs>685440448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -72184,7 +72454,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685448920</BitOffs>
+            <BitOffs>685449432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -72196,7 +72466,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685465152</BitOffs>
+            <BitOffs>685465664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -72209,7 +72479,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685474136</BitOffs>
+            <BitOffs>685474648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -72221,7 +72491,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685490368</BitOffs>
+            <BitOffs>685490880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -72234,7 +72504,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685499352</BitOffs>
+            <BitOffs>685499864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -72246,7 +72516,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685515584</BitOffs>
+            <BitOffs>685516096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -72259,7 +72529,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685524568</BitOffs>
+            <BitOffs>685525080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -72271,7 +72541,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685540800</BitOffs>
+            <BitOffs>685541312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -72284,7 +72554,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685549784</BitOffs>
+            <BitOffs>685550296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -72296,7 +72566,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685566016</BitOffs>
+            <BitOffs>685566528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -72309,7 +72579,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685575000</BitOffs>
+            <BitOffs>685575512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -72321,7 +72591,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685591232</BitOffs>
+            <BitOffs>685591744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -72334,7 +72604,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685600216</BitOffs>
+            <BitOffs>685600728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -72346,7 +72616,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685616448</BitOffs>
+            <BitOffs>685616960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -72359,7 +72629,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685625432</BitOffs>
+            <BitOffs>685625944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -72371,7 +72641,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685641664</BitOffs>
+            <BitOffs>685642176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -72384,7 +72654,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685650648</BitOffs>
+            <BitOffs>685651160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -72396,7 +72666,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685666880</BitOffs>
+            <BitOffs>685667392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -72409,7 +72679,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685675864</BitOffs>
+            <BitOffs>685676376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -72421,7 +72691,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685692096</BitOffs>
+            <BitOffs>685692608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -72434,7 +72704,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685701080</BitOffs>
+            <BitOffs>685701592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -72446,7 +72716,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685717312</BitOffs>
+            <BitOffs>685717824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -72459,7 +72729,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685726296</BitOffs>
+            <BitOffs>685726808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -72471,7 +72741,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685742528</BitOffs>
+            <BitOffs>685743040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -72484,7 +72754,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685751512</BitOffs>
+            <BitOffs>685752024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -72496,7 +72766,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685767744</BitOffs>
+            <BitOffs>685768256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -72509,7 +72779,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685776728</BitOffs>
+            <BitOffs>685777240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -72521,7 +72791,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685792960</BitOffs>
+            <BitOffs>685793472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -72534,7 +72804,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685801944</BitOffs>
+            <BitOffs>685802456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -72546,7 +72816,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685818176</BitOffs>
+            <BitOffs>685818688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -72559,7 +72829,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685827160</BitOffs>
+            <BitOffs>685827672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -72571,7 +72841,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685843392</BitOffs>
+            <BitOffs>685843904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -72584,7 +72854,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685852376</BitOffs>
+            <BitOffs>685852888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -72596,7 +72866,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685868608</BitOffs>
+            <BitOffs>685869120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -72609,7 +72879,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685877592</BitOffs>
+            <BitOffs>685878104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -72621,7 +72891,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685893824</BitOffs>
+            <BitOffs>685894336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -72634,7 +72904,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685902808</BitOffs>
+            <BitOffs>685903320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -72646,7 +72916,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685919040</BitOffs>
+            <BitOffs>685919552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -72659,7 +72929,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685928024</BitOffs>
+            <BitOffs>685928536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -72671,7 +72941,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685944256</BitOffs>
+            <BitOffs>685944768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -72684,7 +72954,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685953240</BitOffs>
+            <BitOffs>685953752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -72696,7 +72966,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685969472</BitOffs>
+            <BitOffs>685969984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -72709,7 +72979,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685978456</BitOffs>
+            <BitOffs>685978968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -72721,7 +72991,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>685994688</BitOffs>
+            <BitOffs>685995200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -72734,7 +73004,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686003672</BitOffs>
+            <BitOffs>686004184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -72746,7 +73016,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686019904</BitOffs>
+            <BitOffs>686020416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -72759,7 +73029,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686028888</BitOffs>
+            <BitOffs>686029400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -72771,7 +73041,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686045120</BitOffs>
+            <BitOffs>686045632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -72784,7 +73054,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686054104</BitOffs>
+            <BitOffs>686054616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -72796,7 +73066,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686070336</BitOffs>
+            <BitOffs>686070848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -72809,7 +73079,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686079320</BitOffs>
+            <BitOffs>686079832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -72821,7 +73091,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686095552</BitOffs>
+            <BitOffs>686096064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -72834,7 +73104,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686104536</BitOffs>
+            <BitOffs>686105048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -72846,7 +73116,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686120768</BitOffs>
+            <BitOffs>686121280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -72859,7 +73129,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686129752</BitOffs>
+            <BitOffs>686130264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -72871,7 +73141,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686145984</BitOffs>
+            <BitOffs>686146496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -72884,7 +73154,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686154968</BitOffs>
+            <BitOffs>686155480</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -79182,7 +79452,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
             <BitSize>621827200</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -79194,7 +79464,7 @@ Digital outputs</Comment>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
             <Comment> Pointer to current test suite being called </Comment>
             <BitSize>32</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -79255,7 +79525,7 @@ Digital outputs</Comment>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
             <BitSize>32000</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>1000</Elements>
@@ -79297,7 +79567,7 @@ Digital outputs</Comment>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
             <Comment> Buffered ADS message queue for output to the error list </Comment>
             <BitSize>8320864</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -80550,40 +80820,87 @@ Digital outputs</Comment>
             <BitOffs>674804544</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_01</Name>
+            <Comment> SP1K4 RTD-01</Comment>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:RTD:01
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.SP1K4_ATT_RTD_02</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:RTD:02
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>674859520</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>674859872</BitOffs>
+            <BitOffs>674860384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>674859880</BitOffs>
+            <BitOffs>674860392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>674859888</BitOffs>
+            <BitOffs>674860400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>674859904</BitOffs>
+            <BitOffs>674860416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>674998272</BitOffs>
+            <BitOffs>674998784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>675029120</BitOffs>
+            <BitOffs>675029632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -80602,7 +80919,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680820736</BitOffs>
+            <BitOffs>680821248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -80621,7 +80938,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>681294208</BitOffs>
+            <BitOffs>681294720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -80651,7 +80968,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>681767680</BitOffs>
+            <BitOffs>681768192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -80681,7 +80998,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>683414592</BitOffs>
+            <BitOffs>683415104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF1K4State</Name>
@@ -80692,7 +81009,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061520</BitOffs>
+            <BitOffs>685062032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -80703,7 +81020,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061536</BitOffs>
+            <BitOffs>685062048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4ATT</Name>
@@ -80714,7 +81031,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061552</BitOffs>
+            <BitOffs>685062064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4FZP</Name>
@@ -80725,7 +81042,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061568</BitOffs>
+            <BitOffs>685062080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -80740,7 +81057,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061584</BitOffs>
+            <BitOffs>685062096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -80755,7 +81072,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061592</BitOffs>
+            <BitOffs>685062104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -80770,7 +81087,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061600</BitOffs>
+            <BitOffs>685062112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -80785,7 +81102,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061616</BitOffs>
+            <BitOffs>685062128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -80814,7 +81131,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685061632</BitOffs>
+            <BitOffs>685062144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -80826,7 +81143,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685086848</BitOffs>
+            <BitOffs>685087360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -80837,7 +81154,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685112064</BitOffs>
+            <BitOffs>685112576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -80848,7 +81165,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685137280</BitOffs>
+            <BitOffs>685137792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -80859,7 +81176,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685162496</BitOffs>
+            <BitOffs>685163008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -80870,7 +81187,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685187712</BitOffs>
+            <BitOffs>685188224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -80881,7 +81198,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685212928</BitOffs>
+            <BitOffs>685213440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -80892,7 +81209,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685238144</BitOffs>
+            <BitOffs>685238656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -80921,7 +81238,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685263360</BitOffs>
+            <BitOffs>685263872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -80949,7 +81266,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685288576</BitOffs>
+            <BitOffs>685289088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -80976,7 +81293,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685313792</BitOffs>
+            <BitOffs>685314304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -81003,7 +81320,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685339008</BitOffs>
+            <BitOffs>685339520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -81030,7 +81347,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685364224</BitOffs>
+            <BitOffs>685364736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -81042,7 +81359,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685389440</BitOffs>
+            <BitOffs>685389952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -81071,7 +81388,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685414656</BitOffs>
+            <BitOffs>685415168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -81100,7 +81417,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685439872</BitOffs>
+            <BitOffs>685440384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -81129,7 +81446,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685465088</BitOffs>
+            <BitOffs>685465600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -81158,7 +81475,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685490304</BitOffs>
+            <BitOffs>685490816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -81183,7 +81500,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685515520</BitOffs>
+            <BitOffs>685516032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -81212,7 +81529,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685540736</BitOffs>
+            <BitOffs>685541248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -81241,7 +81558,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685565952</BitOffs>
+            <BitOffs>685566464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -81266,7 +81583,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685591168</BitOffs>
+            <BitOffs>685591680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -81294,7 +81611,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685616384</BitOffs>
+            <BitOffs>685616896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -81321,7 +81638,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685641600</BitOffs>
+            <BitOffs>685642112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -81348,7 +81665,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685666816</BitOffs>
+            <BitOffs>685667328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -81375,7 +81692,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685692032</BitOffs>
+            <BitOffs>685692544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -81404,7 +81721,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685717248</BitOffs>
+            <BitOffs>685717760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -81433,7 +81750,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685742464</BitOffs>
+            <BitOffs>685742976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -81458,7 +81775,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685767680</BitOffs>
+            <BitOffs>685768192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -81487,7 +81804,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685792896</BitOffs>
+            <BitOffs>685793408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -81512,7 +81829,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685818112</BitOffs>
+            <BitOffs>685818624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -81549,7 +81866,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685843328</BitOffs>
+            <BitOffs>685843840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -81594,7 +81911,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685868544</BitOffs>
+            <BitOffs>685869056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -81635,7 +81952,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685893760</BitOffs>
+            <BitOffs>685894272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -81676,7 +81993,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685918976</BitOffs>
+            <BitOffs>685919488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -81717,7 +82034,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685944192</BitOffs>
+            <BitOffs>685944704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -81758,7 +82075,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685969408</BitOffs>
+            <BitOffs>685969920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -81799,7 +82116,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685994624</BitOffs>
+            <BitOffs>685995136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -81840,7 +82157,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686019840</BitOffs>
+            <BitOffs>686020352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -81881,7 +82198,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686045056</BitOffs>
+            <BitOffs>686045568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -81917,7 +82234,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686070272</BitOffs>
+            <BitOffs>686070784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -81953,7 +82270,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686095488</BitOffs>
+            <BitOffs>686096000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -81989,7 +82306,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686120704</BitOffs>
+            <BitOffs>686121216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -82034,7 +82351,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686145920</BitOffs>
+            <BitOffs>686146432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -82064,7 +82381,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686171136</BitOffs>
+            <BitOffs>686171648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -82094,7 +82411,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686171200</BitOffs>
+            <BitOffs>686171712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -82108,7 +82425,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686171264</BitOffs>
+            <BitOffs>686171776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -82122,7 +82439,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686171296</BitOffs>
+            <BitOffs>686171808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -82136,7 +82453,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686171328</BitOffs>
+            <BitOffs>686171840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82150,7 +82467,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686171360</BitOffs>
+            <BitOffs>686171872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -82164,7 +82481,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686173408</BitOffs>
+            <BitOffs>686173920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -82182,7 +82499,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686173440</BitOffs>
+            <BitOffs>686173952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -82196,7 +82513,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686174464</BitOffs>
+            <BitOffs>686174976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -82217,7 +82534,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686174496</BitOffs>
+            <BitOffs>686175008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -82240,30 +82557,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686217824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>686217536</BitOffs>
+            <BitOffs>686218336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -82332,7 +82626,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686226848</BitOffs>
+            <BitOffs>686227360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -82401,7 +82695,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686226976</BitOffs>
+            <BitOffs>686227488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -82470,7 +82764,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686227104</BitOffs>
+            <BitOffs>686227616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -82539,7 +82833,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686227232</BitOffs>
+            <BitOffs>686227744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -82608,7 +82902,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686227360</BitOffs>
+            <BitOffs>686227872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -82677,7 +82971,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686227488</BitOffs>
+            <BitOffs>686228000</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82764,15 +83058,15 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-10-18T14:51:58</Value>
+          <Value>2023-10-19T16:27:45</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1032192</Value>
+          <Value>1077248</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>85303296</Value>
+          <Value>85364736</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sp1k4 solid attenuator has two RTD, that controls need to add
<!--- Describe your changes in detail -->
Two El3202 added into SP1K4 top rail and add link to two RTDs for sp1k4-att
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sp1K4-solid-atten needs to read RTD
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Not tested yet. Because I need to talk to scientists to know the status of RTD(maybe broken), cable is all setup and not connected to the feedthrough yet. 
Currently In a rush to merge so that Nick can work on his issue. I will come back to update after we test later.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://jira.slac.stanford.edu/browse/ECS-3982
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
