### PR TITLE
tuning El3302 CoE to read rtd-01

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -12765,16 +12765,6 @@ External Setpoint Generation:
 				<Link VarA="PlcTask Inputs^Main.M44.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^Main.M44.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true"/>
 			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Top Rail (EK1100)^SP1K4- EL3202-E9A">
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
-			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 9 (EK1122)^SP1K4 Top Rail (EK1100)^SP1K4-TL1-EL1124">
 				<Link VarA="PlcTask Inputs^PRG_SP1K4.bTL1High" VarB="Channel 1^Input" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_SP1K4.bTL1Low" VarB="Channel 2^Input" AutoLink="true"/>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -97,10 +97,10 @@ VAR
     bPF1K4Out: BOOL;
 
     // SP1K4 RTD-01
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Value;
-                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Underrange;
-                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Overrange;
-                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Status^Error'}
     {attribute 'pytmc' := '
         pv: SP1K4:ATT:RTD:01
         field: EGU C
@@ -108,10 +108,10 @@ VAR
     '}
     SP1K4_ATT_RTD_01 : FB_TempSensor;
 
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Value;
-                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Underrange;
-                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Overrange;
-                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Error'}
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Status^Error'}
     {attribute 'pytmc' := '
         pv: SP1K4:ATT:RTD:02
         field: EGU C

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{80154F0D-52E3-F26A-883E-7FB33004D347}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{EFD2AE43-F566-6748-9BAC-E68979D22C87}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -6256,11 +6256,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_BOOL</Name>
@@ -6393,11 +6388,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6557,11 +6547,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfSuccessfulTests</Name>
@@ -6668,11 +6653,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -6806,11 +6786,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -7291,11 +7266,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8064,11 +8034,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_TIME</Name>
@@ -8460,11 +8425,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_INT</Name>
@@ -8556,11 +8516,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8688,11 +8643,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_LWORD</Name>
@@ -8794,11 +8744,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9115,11 +9060,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AreAllTestsFinished</Name>
@@ -9284,11 +9224,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9473,11 +9408,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_LREAL</Name>
@@ -9575,11 +9505,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -20769,11 +20694,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>FindTestSuiteInstancePath</Name>
@@ -21032,11 +20952,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_BYTE</Name>
@@ -21138,11 +21053,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -21302,11 +21212,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LTIME</Name>
@@ -21429,11 +21334,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -21575,11 +21475,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -22341,11 +22236,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>SetHasStartedRunning</Name>
@@ -22506,11 +22396,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetHasStartedRunning</Name>
@@ -22613,11 +22498,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -22772,11 +22652,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DINT</Name>
@@ -22899,11 +22774,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -23079,11 +22949,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -23366,11 +23231,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -24167,11 +24027,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_UDINT</Name>
@@ -24263,11 +24118,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -59754,7 +59604,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86966272</ByteSize>
+          <ByteSize>87097344</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -70394,7 +70244,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86966272</ByteSize>
+          <ByteSize>87097344</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -73161,7 +73011,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86966272</ByteSize>
+          <ByteSize>87097344</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -80827,10 +80677,10 @@ Digital outputs</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Value;
-                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Underrange;
-                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Overrange;
-                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 1^Status^Error</Value>
+                <Value>.iRaw := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 1^Status^Error</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -80850,10 +80700,10 @@ Digital outputs</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Value;
-                              .bUnderrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Underrange;
-                              .bOverrange := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Overrange;
-                              .bError := TIIB[SP1K4- EL3202-E9A]^RTD Inputs Channel 2^Status^Error</Value>
+                <Value>.iRaw := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Value;
+                              .bUnderrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Status^Underrange;
+                              .bOverrange := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Status^Overrange;
+                              .bError := TIIB[SP1K4-EL3202-E9A]^RTD Inputs Channel 2^Status^Error</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -82978,7 +82828,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>86966272</ByteSize>
+          <ByteSize>87097344</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -83058,7 +82908,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-10-19T16:27:45</Value>
+          <Value>2023-10-24T14:48:02</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sp1k4 solid attenuator has one working rtd.
I tune the parameter of EL3202on CoE and works now
<!--- Describe your changes in detail -->
Tune CoE of EL3202 for Sp1K4-att
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sp1K4-att-rtd 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I already can read from PLC, ~20C
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

https://jira.slac.stanford.edu/browse/ECS-3982
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
