### PR TITLE
More fdq cooling

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -4328,6 +4328,13 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -4754,6 +4761,13 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowSwitch.bFlowOk</Name>
 					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
+					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -5337,6 +5351,13 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_TM1K4.fbTM1K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -5448,6 +5469,13 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_TM2K4.fbTM2K4.fbFlowMeter.iRaw</Name>
+					<Comment>
+						<![CDATA[ Connect this input to the terminal]]>
+					</Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -13782,6 +13810,8 @@ External Setpoint Generation:
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL3052-E5">
 				<Link VarA="PlcTask Inputs^PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_TM2K4.fbTM2K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 10 (EK1122)^Granite3 (EK1100)^PLC Junction 12  (EK1122)^IM6K4 (EK1100)^IM6K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
@@ -13867,6 +13897,8 @@ External Setpoint Generation:
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL3052-E5">
 				<Link VarA="PlcTask Inputs^PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_TM1K4.fbTM1K4.fbFlowMeter.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Power (EK1200)^PLC Junction 2 (EK1122)^PLC Coupler 2 (EK1100)^PLC Junction 8 (EK1122)^IM5K4-PPM (EK1100)^IM5K4-EL3062-E6">
 				<Link VarA="PlcTask Inputs^PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT" VarB="AI Standard Channel 1^Value" AutoLink="true"/>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF1K4_WFS_TARGET.TcPOU
@@ -14,9 +14,8 @@ VAR
                               .fbThermoCouple2.bError 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Error;
                               .fbThermoCouple2.bUnderrange 	:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Underrange;
                               .fbThermoCouple2.bOverrange 	:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Overrange;
-                              .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value'}
-
-
+                              .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw             := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value'} // same cooling loop as IM5K4
     fbPF1K4: FB_WFS;
 
     fbStateSetup: FB_StateSetupHelper;

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_PF2K4_WFS_TARGET.TcPOU
@@ -14,7 +14,8 @@ VAR
                               .fbThermoCouple2.bError 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Status^Error;
                               .fbThermoCouple2.bUnderrange 	:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Status^Underrange;
                               .fbThermoCouple2.bOverrange 	:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Status^Overrange;
-                              .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value'}
+                              .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw             := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value'} // same cooling loop as IM6K4
     fbPF2K4: FB_WFS;
     fbStateSetup: FB_StateSetupHelper;
     stDefault: ST_PositionState :=(

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_TM1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_TM1K4.TcPOU
@@ -10,7 +10,8 @@ VAR
     {attribute 'TcLinkTo' := '.fbThermoCouple1.bError := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Status^Error;
                               .fbThermoCouple1.bUnderrange := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Status^Underrange;
                               .fbThermoCouple1.bOverrange := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Status^Overrange;
-                              .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value'}
+                              .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value;
+                              .fbFlowMeter.iRaw := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value'} // same cooling loop as IM5K4
     fbTM1K4: FB_TM1K4;
 END_VAR
 ]]></Declaration>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_TM2K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_TM2K4.TcPOU
@@ -10,7 +10,8 @@ VAR
      {attribute 'TcLinkTo' := '.fbThermoCouple1.bError := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Status^Error;
                               .fbThermoCouple1.bUnderrange := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Status^Underrange;
                               .fbThermoCouple1.bOverrange := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Status^Overrange;
-                              .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value'}
+                              .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value;
+                              .fbFlowMeter.iRaw := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value'} // same as IM6K4
     fbTM2K4: FB_TM2K4;
 END_VAR
 ]]></Declaration>

--- a/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4.TcPOU
@@ -42,6 +42,11 @@ VAR
         io: input
     '}
     fbThermoCouple1: FB_TempSensor;
+    {attribute 'pytmc' := '
+        pv: FWM
+        EGU: lpm
+    '}
+    fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -73,7 +78,8 @@ fbStates(
     stTarget4:=stTarget4,
     stTarget5:=stTarget5);
 
-fbThermoCouple1();]]></ST>
+fbThermoCouple1();
+fbFlowMeter();]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM1K4/FB_TM1K4.TcPOU
@@ -44,7 +44,7 @@ VAR
     fbThermoCouple1: FB_TempSensor;
     {attribute 'pytmc' := '
         pv: FWM
-        EGU: lpm
+        field: EGU lpm
     '}
     fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
 END_VAR

--- a/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4.TcPOU
@@ -40,6 +40,11 @@ VAR
         io: input
     '}
     fbThermoCouple1: FB_TempSensor;
+    {attribute 'pytmc' := '
+        pv: FWM
+        EGU: lpm
+    '}
+    fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -70,7 +75,8 @@ fbStates(
     stTarget5:=stTarget5,
 );
 
-fbThermoCouple1();]]></ST>
+fbThermoCouple1();
+fbFlowMeter();]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/TM2K4/FB_TM2K4.TcPOU
@@ -42,7 +42,7 @@ VAR
     fbThermoCouple1: FB_TempSensor;
     {attribute 'pytmc' := '
         pv: FWM
-        EGU: lpm
+        field: EGU lpm
     '}
     fbFlowMeter: FB_AnalogInput := (iTermBits:=15, fTermMax:=60, fTermMin:=0);
 END_VAR

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -209,7 +209,7 @@
       <Resolution>LCLS General, 2.9.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-common-components">
-      <Resolution>lcls-twincat-common-components, 3.3.0 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-common-components, 3.4.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 4.0.7 (SLAC)</Resolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{F1E6A152-C1A1-6080-920B-AB89A14216EF}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{9202CFF4-0FA2-4353-2A51-3E2E499243B4}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -52433,7 +52433,7 @@ Digital outputs</Comment>
             <Name>pytmc</Name>
             <Value>
         pv: FWM
-        EGU: lpm
+        field: EGU lpm
     </Value>
           </Property>
         </Properties>
@@ -52888,7 +52888,7 @@ Digital outputs</Comment>
             <Name>pytmc</Name>
             <Value>
         pv: FWM
-        EGU: lpm
+        field: EGU lpm
     </Value>
           </Property>
         </Properties>
@@ -59188,44 +59188,6 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
-      </Hides>
-    </DataType>
-    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -60029,6 +59991,44 @@ Digital outputs</Comment>
       </EventId>
       <Hides>
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
       </Hides>
     </DataType>
   </DataTypes>
@@ -84744,29 +84744,6 @@ Digital outputs</Comment>
             <BitOffs>690512672</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>690556000</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
             <Comment> 11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31</Comment>
             <BitSize>128</BitSize>
@@ -84833,7 +84810,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690565024</BitOffs>
+            <BitOffs>690526048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -84902,7 +84879,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690565152</BitOffs>
+            <BitOffs>690526176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -84971,7 +84948,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690565280</BitOffs>
+            <BitOffs>690526304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -85040,7 +85017,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690565408</BitOffs>
+            <BitOffs>690526432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -85109,7 +85086,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690565536</BitOffs>
+            <BitOffs>690526560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -85178,7 +85155,30 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690565664</BitOffs>
+            <BitOffs>690526688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>690557024</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -85240,9 +85240,6 @@ Digital outputs</Comment>
       <Deployment/>
       <EventClasses>
         <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
-        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -85257,6 +85254,9 @@ Digital outputs</Comment>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
+        <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -85265,7 +85265,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-03-25T15:58:54</Value>
+          <Value>2024-03-25T16:16:21</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D6CE4E72-BC3D-64DC-1129-21036F155D9C}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{F1E6A152-C1A1-6080-920B-AB89A14216EF}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -180,31 +180,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86334848</GetCodeOffs>
+        <GetCodeOffs>86335072</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86334880</GetCodeOffs>
+        <GetCodeOffs>86335104</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86334888</GetCodeOffs>
+        <GetCodeOffs>86335112</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86334872</GetCodeOffs>
+        <GetCodeOffs>86335096</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86334884</GetCodeOffs>
+        <GetCodeOffs>86335108</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -1413,15 +1413,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86334792</GetCodeOffs>
-        <SetCodeOffs>86334816</SetCodeOffs>
+        <GetCodeOffs>86335016</GetCodeOffs>
+        <SetCodeOffs>86335040</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86334828</GetCodeOffs>
-        <SetCodeOffs>86334840</SetCodeOffs>
+        <GetCodeOffs>86335052</GetCodeOffs>
+        <SetCodeOffs>86335064</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="9">__setbCutInstancePathByLastInst</Name>
@@ -1689,31 +1689,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>86334936</GetCodeOffs>
+        <GetCodeOffs>86335160</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86334916</GetCodeOffs>
+        <GetCodeOffs>86335140</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86335004</GetCodeOffs>
+        <GetCodeOffs>86335228</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86334964</GetCodeOffs>
+        <GetCodeOffs>86335188</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86335008</GetCodeOffs>
+        <GetCodeOffs>86335232</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -2286,7 +2286,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86335032</GetCodeOffs>
+        <GetCodeOffs>86335256</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -47395,7 +47395,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_common_components">FB_WFS</Name>
-      <BitSize>2239936</BitSize>
+      <BitSize>2240384</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -47749,11 +47749,37 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>fbFlowMeter</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>2239744</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.iTermBits</Name>
+            <Value>15</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMax</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMin</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: FWM</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>fDelta</Name>
         <Type>LREAL</Type>
         <Comment> State defaults if not provided</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>2239744</BitOffs>
+        <BitOffs>2240192</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -47762,7 +47788,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2239808</BitOffs>
+        <BitOffs>2240256</BitOffs>
         <Default>
           <Value>200</Value>
         </Default>
@@ -47771,7 +47797,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDecel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2239872</BitOffs>
+        <BitOffs>2240320</BitOffs>
         <Default>
           <Value>25</Value>
         </Default>
@@ -52169,7 +52195,7 @@ Digital outputs</Comment>
     </DataType>
     <DataType>
       <Name>FB_TM1K4</Name>
-      <BitSize>1322752</BitSize>
+      <BitSize>1323200</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -52379,6 +52405,35 @@ Digital outputs</Comment>
             <Value>
         pv: STC:01
         io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlowMeter</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>1322752</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.iTermBits</Name>
+            <Value>15</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMax</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMin</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM
+        EGU: lpm
     </Value>
           </Property>
         </Properties>
@@ -52619,7 +52674,7 @@ Digital outputs</Comment>
     </DataType>
     <DataType>
       <Name>FB_TM2K4</Name>
-      <BitSize>1308160</BitSize>
+      <BitSize>1308608</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -52805,6 +52860,35 @@ Digital outputs</Comment>
             <Value>
         pv: STC:01
         io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlowMeter</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>1308160</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.iTermBits</Name>
+            <Value>15</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMax</Name>
+            <Value>60</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.fTermMin</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM
+        EGU: lpm
     </Value>
           </Property>
         </Properties>
@@ -54515,8 +54599,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86341616</GetCodeOffs>
-        <SetCodeOffs>86341624</SetCodeOffs>
+        <GetCodeOffs>86341840</GetCodeOffs>
+        <SetCodeOffs>86341848</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="44">__getnTimestamp</Name>
@@ -55810,31 +55894,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86341184</GetCodeOffs>
+        <GetCodeOffs>86341408</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86341216</GetCodeOffs>
+        <GetCodeOffs>86341440</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86341220</GetCodeOffs>
+        <GetCodeOffs>86341444</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86341208</GetCodeOffs>
+        <GetCodeOffs>86341432</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86341228</GetCodeOffs>
+        <GetCodeOffs>86341452</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -59104,6 +59188,44 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
+      <DisplayName TxtId="">Log event</DisplayName>
+      <EventId>
+        <Name Id="0">Critical</Name>
+        <DisplayName TxtId="">Critical</DisplayName>
+        <Severity>Critical</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="1">Error</Name>
+        <DisplayName TxtId="">Error</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="2">Warning</Name>
+        <DisplayName TxtId="">Warning</DisplayName>
+        <Severity>Warning</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="3">Info</Name>
+        <DisplayName TxtId="">Info</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="4">Verbose</Name>
+        <DisplayName TxtId="">Verbose</DisplayName>
+        <Severity>Verbose</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
+        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
+        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
+        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
       <Name GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}" TcBaseType="true" CName="TcSystemEventClass">TcSystemEventClass</Name>
       <DisplayName TxtId="">TcSystemEventClass</DisplayName>
       <EventId>
@@ -59907,44 +60029,6 @@ Digital outputs</Comment>
       </EventId>
       <Hides>
         <Hide GUID="{3FEAA938-D042-4B1E-8ADD-BB2F7BE872B0}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Name>
-      <DisplayName TxtId="">Log event</DisplayName>
-      <EventId>
-        <Name Id="0">Critical</Name>
-        <DisplayName TxtId="">Critical</DisplayName>
-        <Severity>Critical</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="1">Error</Name>
-        <DisplayName TxtId="">Error</DisplayName>
-        <Severity>Error</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="2">Warning</Name>
-        <DisplayName TxtId="">Warning</DisplayName>
-        <Severity>Warning</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="3">Info</Name>
-        <DisplayName TxtId="">Info</DisplayName>
-        <Severity>Info</Severity>
-      </EventId>
-      <EventId>
-        <Name Id="4">Verbose</Name>
-        <DisplayName TxtId="">Verbose</DisplayName>
-        <Severity>Verbose</Severity>
-      </EventId>
-      <Hides>
-        <Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
-        <Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
-        <Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
-        <Hide GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}"/>
-        <Hide GUID="{B7E60A74-CB5C-4A02-B59C-74B86A888DE9}"/>
-        <Hide GUID="{6B58EF80-AB34-4F6C-81D0-B0589F4FC534}"/>
-        <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
       </Hides>
     </DataType>
   </DataTypes>
@@ -63848,6 +63932,19 @@ Digital outputs</Comment>
             <BitOffs>659661728</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>659661792</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
             <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
@@ -63857,7 +63954,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659781888</BitOffs>
+            <BitOffs>659782336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -63869,7 +63966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>660079808</BitOffs>
+            <BitOffs>660080256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -63881,7 +63978,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661644224</BitOffs>
+            <BitOffs>661644672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -63894,7 +63991,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652160</BitOffs>
+            <BitOffs>661652608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -63907,7 +64004,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652168</BitOffs>
+            <BitOffs>661652616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -63920,7 +64017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652176</BitOffs>
+            <BitOffs>661652624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -63943,7 +64040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652192</BitOffs>
+            <BitOffs>661652640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -63956,7 +64053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652224</BitOffs>
+            <BitOffs>661652672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -63969,7 +64066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652288</BitOffs>
+            <BitOffs>661652736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -63982,7 +64079,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661652304</BitOffs>
+            <BitOffs>661652752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -63994,7 +64091,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661669440</BitOffs>
+            <BitOffs>661669888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -64007,7 +64104,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677376</BitOffs>
+            <BitOffs>661677824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -64020,7 +64117,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677384</BitOffs>
+            <BitOffs>661677832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -64033,7 +64130,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677392</BitOffs>
+            <BitOffs>661677840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -64056,7 +64153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677408</BitOffs>
+            <BitOffs>661677856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -64069,7 +64166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677440</BitOffs>
+            <BitOffs>661677888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -64082,7 +64179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677504</BitOffs>
+            <BitOffs>661677952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -64095,7 +64192,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661677520</BitOffs>
+            <BitOffs>661677968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -64107,7 +64204,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661694656</BitOffs>
+            <BitOffs>661695104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -64120,7 +64217,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702592</BitOffs>
+            <BitOffs>661703040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -64133,7 +64230,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702600</BitOffs>
+            <BitOffs>661703048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -64146,7 +64243,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702608</BitOffs>
+            <BitOffs>661703056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -64169,7 +64266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702624</BitOffs>
+            <BitOffs>661703072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -64182,7 +64279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702656</BitOffs>
+            <BitOffs>661703104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -64195,7 +64292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702720</BitOffs>
+            <BitOffs>661703168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -64208,7 +64305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661702736</BitOffs>
+            <BitOffs>661703184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -64232,7 +64329,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661992776</BitOffs>
+            <BitOffs>661993224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -64244,7 +64341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661992784</BitOffs>
+            <BitOffs>661993232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -64256,7 +64353,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661992792</BitOffs>
+            <BitOffs>661993240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -64268,7 +64365,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661992800</BitOffs>
+            <BitOffs>661993248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -64292,7 +64389,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661993032</BitOffs>
+            <BitOffs>661993480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -64304,7 +64401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661993040</BitOffs>
+            <BitOffs>661993488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -64316,7 +64413,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661993048</BitOffs>
+            <BitOffs>661993496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -64328,7 +64425,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661993056</BitOffs>
+            <BitOffs>661993504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowSwitch.bFlowOk</Name>
@@ -64348,7 +64445,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661993120</BitOffs>
+            <BitOffs>661993568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>661993632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64360,7 +64470,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662089024</BitOffs>
+            <BitOffs>662089920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64372,7 +64482,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662386944</BitOffs>
+            <BitOffs>662387840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64384,7 +64494,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662684864</BitOffs>
+            <BitOffs>662685760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64396,7 +64506,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662982784</BitOffs>
+            <BitOffs>662983680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -64408,7 +64518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663428480</BitOffs>
+            <BitOffs>663429376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64420,7 +64530,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663435712</BitOffs>
+            <BitOffs>663436608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64432,7 +64542,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663733632</BitOffs>
+            <BitOffs>663734528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64444,7 +64554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664031552</BitOffs>
+            <BitOffs>664032448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64456,7 +64566,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664329472</BitOffs>
+            <BitOffs>664330368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
@@ -64468,7 +64578,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664775168</BitOffs>
+            <BitOffs>664776064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -64481,7 +64591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664887648</BitOffs>
+            <BitOffs>664888544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -64493,7 +64603,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664887656</BitOffs>
+            <BitOffs>664888552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -64509,7 +64619,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664887688</BitOffs>
+            <BitOffs>664888584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -64525,7 +64635,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664887696</BitOffs>
+            <BitOffs>664888592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1High</Name>
@@ -64541,7 +64651,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664887704</BitOffs>
+            <BitOffs>664888600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1Low</Name>
@@ -64557,7 +64667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664889648</BitOffs>
+            <BitOffs>664890544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2High</Name>
@@ -64573,7 +64683,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664889656</BitOffs>
+            <BitOffs>664890552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64585,7 +64695,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664922880</BitOffs>
+            <BitOffs>664923776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64597,7 +64707,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665220800</BitOffs>
+            <BitOffs>665221696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -64621,7 +64731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666212360</BitOffs>
+            <BitOffs>666213256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -64633,7 +64743,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666212368</BitOffs>
+            <BitOffs>666213264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -64645,7 +64755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666212376</BitOffs>
+            <BitOffs>666213272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -64657,7 +64767,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666212384</BitOffs>
+            <BitOffs>666213280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_TM1K4.fbTM1K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>666213344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64669,7 +64792,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666238848</BitOffs>
+            <BitOffs>666240192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64681,7 +64804,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666536768</BitOffs>
+            <BitOffs>666538112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -64705,7 +64828,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667521032</BitOffs>
+            <BitOffs>667522376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -64717,7 +64840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667521040</BitOffs>
+            <BitOffs>667522384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -64729,7 +64852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667521048</BitOffs>
+            <BitOffs>667522392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -64741,7 +64864,20 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667521056</BitOffs>
+            <BitOffs>667522400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_TM2K4.fbTM2K4.fbFlowMeter.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>667522464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64753,7 +64889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667523968</BitOffs>
+            <BitOffs>667525760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64765,7 +64901,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667821888</BitOffs>
+            <BitOffs>667823680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64777,7 +64913,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668119808</BitOffs>
+            <BitOffs>668121600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64789,7 +64925,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668417728</BitOffs>
+            <BitOffs>668419520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64801,7 +64937,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668715648</BitOffs>
+            <BitOffs>668717440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64813,7 +64949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669013568</BitOffs>
+            <BitOffs>669015360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64825,7 +64961,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669311488</BitOffs>
+            <BitOffs>669313280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64837,7 +64973,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669609408</BitOffs>
+            <BitOffs>669611200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64849,7 +64985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669907328</BitOffs>
+            <BitOffs>669909120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64861,7 +64997,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670205248</BitOffs>
+            <BitOffs>670207040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64873,7 +65009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670503168</BitOffs>
+            <BitOffs>670504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64885,7 +65021,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670801088</BitOffs>
+            <BitOffs>670802880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -64897,7 +65033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671099008</BitOffs>
+            <BitOffs>671100800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2Low</Name>
@@ -64913,7 +65049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671394432</BitOffs>
+            <BitOffs>671396224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -64925,7 +65061,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672662592</BitOffs>
+            <BitOffs>672664384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -64938,7 +65074,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670528</BitOffs>
+            <BitOffs>672672320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -64951,7 +65087,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670536</BitOffs>
+            <BitOffs>672672328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -64964,7 +65100,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670544</BitOffs>
+            <BitOffs>672672336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -64987,7 +65123,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670560</BitOffs>
+            <BitOffs>672672352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -65000,7 +65136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670592</BitOffs>
+            <BitOffs>672672384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -65013,7 +65149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670656</BitOffs>
+            <BitOffs>672672448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -65026,7 +65162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672670672</BitOffs>
+            <BitOffs>672672464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -65038,7 +65174,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672687808</BitOffs>
+            <BitOffs>672689600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -65051,7 +65187,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695744</BitOffs>
+            <BitOffs>672697536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -65064,7 +65200,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695752</BitOffs>
+            <BitOffs>672697544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -65077,7 +65213,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695760</BitOffs>
+            <BitOffs>672697552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -65100,7 +65236,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695776</BitOffs>
+            <BitOffs>672697568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -65113,7 +65249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695808</BitOffs>
+            <BitOffs>672697600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -65126,7 +65262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695872</BitOffs>
+            <BitOffs>672697664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -65139,7 +65275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672695888</BitOffs>
+            <BitOffs>672697680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -65151,7 +65287,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672713024</BitOffs>
+            <BitOffs>672714816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -65164,7 +65300,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672720960</BitOffs>
+            <BitOffs>672722752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -65177,7 +65313,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672720968</BitOffs>
+            <BitOffs>672722760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -65190,7 +65326,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672720976</BitOffs>
+            <BitOffs>672722768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -65213,7 +65349,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672720992</BitOffs>
+            <BitOffs>672722784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -65226,7 +65362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672721024</BitOffs>
+            <BitOffs>672722816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -65239,7 +65375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672721088</BitOffs>
+            <BitOffs>672722880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -65252,7 +65388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672721104</BitOffs>
+            <BitOffs>672722896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -65264,7 +65400,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674425024</BitOffs>
+            <BitOffs>674426816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -65277,7 +65413,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674432960</BitOffs>
+            <BitOffs>674434752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -65290,7 +65426,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674432968</BitOffs>
+            <BitOffs>674434760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -65303,7 +65439,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674432976</BitOffs>
+            <BitOffs>674434768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -65326,7 +65462,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674432992</BitOffs>
+            <BitOffs>674434784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -65339,7 +65475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674433024</BitOffs>
+            <BitOffs>674434816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -65352,7 +65488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674433088</BitOffs>
+            <BitOffs>674434880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -65365,7 +65501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674433104</BitOffs>
+            <BitOffs>674434896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -65377,7 +65513,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674450240</BitOffs>
+            <BitOffs>674452032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -65390,7 +65526,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458176</BitOffs>
+            <BitOffs>674459968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -65403,7 +65539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458184</BitOffs>
+            <BitOffs>674459976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -65416,7 +65552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458192</BitOffs>
+            <BitOffs>674459984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -65439,7 +65575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458208</BitOffs>
+            <BitOffs>674460000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -65452,7 +65588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458240</BitOffs>
+            <BitOffs>674460032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -65465,7 +65601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458304</BitOffs>
+            <BitOffs>674460096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -65478,7 +65614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674458320</BitOffs>
+            <BitOffs>674460112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -65490,7 +65626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674475456</BitOffs>
+            <BitOffs>674477248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -65503,7 +65639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483392</BitOffs>
+            <BitOffs>674485184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -65516,7 +65652,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483400</BitOffs>
+            <BitOffs>674485192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -65529,7 +65665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483408</BitOffs>
+            <BitOffs>674485200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -65552,7 +65688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483424</BitOffs>
+            <BitOffs>674485216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -65565,7 +65701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483456</BitOffs>
+            <BitOffs>674485248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -65578,7 +65714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483520</BitOffs>
+            <BitOffs>674485312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -65591,7 +65727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674483536</BitOffs>
+            <BitOffs>674485328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bError</Name>
@@ -65615,7 +65751,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674864840</BitOffs>
+            <BitOffs>674866632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange</Name>
@@ -65627,7 +65763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674864848</BitOffs>
+            <BitOffs>674866640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange</Name>
@@ -65639,7 +65775,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674864856</BitOffs>
+            <BitOffs>674866648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw</Name>
@@ -65651,7 +65787,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674864864</BitOffs>
+            <BitOffs>674866656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bError</Name>
@@ -65675,7 +65811,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674865096</BitOffs>
+            <BitOffs>674866888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange</Name>
@@ -65687,7 +65823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674865104</BitOffs>
+            <BitOffs>674866896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange</Name>
@@ -65699,7 +65835,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674865112</BitOffs>
+            <BitOffs>674866904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw</Name>
@@ -65711,7 +65847,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674865120</BitOffs>
+            <BitOffs>674866912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -65723,7 +65859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674867904</BitOffs>
+            <BitOffs>674869696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -65735,7 +65871,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675165824</BitOffs>
+            <BitOffs>675167616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -65747,7 +65883,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676729280</BitOffs>
+            <BitOffs>676731072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -65760,7 +65896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737216</BitOffs>
+            <BitOffs>676739008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -65773,7 +65909,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737224</BitOffs>
+            <BitOffs>676739016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHome</Name>
@@ -65786,7 +65922,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737232</BitOffs>
+            <BitOffs>676739024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -65809,7 +65945,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737248</BitOffs>
+            <BitOffs>676739040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -65822,7 +65958,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737280</BitOffs>
+            <BitOffs>676739072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -65835,7 +65971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737344</BitOffs>
+            <BitOffs>676739136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -65848,7 +65984,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676737360</BitOffs>
+            <BitOffs>676739152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -65860,7 +65996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676754496</BitOffs>
+            <BitOffs>676756288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -65873,7 +66009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762432</BitOffs>
+            <BitOffs>676764224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -65886,7 +66022,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762440</BitOffs>
+            <BitOffs>676764232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHome</Name>
@@ -65899,7 +66035,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762448</BitOffs>
+            <BitOffs>676764240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -65922,7 +66058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762464</BitOffs>
+            <BitOffs>676764256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -65935,7 +66071,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762496</BitOffs>
+            <BitOffs>676764288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -65948,7 +66084,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762560</BitOffs>
+            <BitOffs>676764352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -65961,7 +66097,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676762576</BitOffs>
+            <BitOffs>676764368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -65973,7 +66109,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676779712</BitOffs>
+            <BitOffs>676781504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -65986,7 +66122,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787648</BitOffs>
+            <BitOffs>676789440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -65999,7 +66135,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787656</BitOffs>
+            <BitOffs>676789448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHome</Name>
@@ -66012,7 +66148,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787664</BitOffs>
+            <BitOffs>676789456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -66035,7 +66171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787680</BitOffs>
+            <BitOffs>676789472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -66048,7 +66184,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787712</BitOffs>
+            <BitOffs>676789504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -66061,7 +66197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787776</BitOffs>
+            <BitOffs>676789568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -66074,7 +66210,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676787792</BitOffs>
+            <BitOffs>676789584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbMotionCF1K4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -66086,7 +66222,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677171712</BitOffs>
+            <BitOffs>677173504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -66098,7 +66234,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678735104</BitOffs>
+            <BitOffs>678736896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -66111,7 +66247,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743040</BitOffs>
+            <BitOffs>678744832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -66124,7 +66260,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743048</BitOffs>
+            <BitOffs>678744840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].bHome</Name>
@@ -66137,7 +66273,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743056</BitOffs>
+            <BitOffs>678744848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -66160,7 +66296,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743072</BitOffs>
+            <BitOffs>678744864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -66173,7 +66309,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743104</BitOffs>
+            <BitOffs>678744896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -66186,7 +66322,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743168</BitOffs>
+            <BitOffs>678744960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -66199,7 +66335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678743184</BitOffs>
+            <BitOffs>678744976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -66211,7 +66347,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678760320</BitOffs>
+            <BitOffs>678762112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -66224,7 +66360,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768256</BitOffs>
+            <BitOffs>678770048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -66237,7 +66373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768264</BitOffs>
+            <BitOffs>678770056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].bHome</Name>
@@ -66250,7 +66386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768272</BitOffs>
+            <BitOffs>678770064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -66273,7 +66409,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768288</BitOffs>
+            <BitOffs>678770080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -66286,7 +66422,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768320</BitOffs>
+            <BitOffs>678770112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -66299,7 +66435,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768384</BitOffs>
+            <BitOffs>678770176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -66312,7 +66448,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678768400</BitOffs>
+            <BitOffs>678770192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -66324,7 +66460,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678785536</BitOffs>
+            <BitOffs>678787328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -66337,7 +66473,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793472</BitOffs>
+            <BitOffs>678795264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -66350,7 +66486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793480</BitOffs>
+            <BitOffs>678795272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].bHome</Name>
@@ -66363,7 +66499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793488</BitOffs>
+            <BitOffs>678795280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -66386,7 +66522,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793504</BitOffs>
+            <BitOffs>678795296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -66399,7 +66535,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793536</BitOffs>
+            <BitOffs>678795328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -66412,7 +66548,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793600</BitOffs>
+            <BitOffs>678795392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -66425,7 +66561,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678793616</BitOffs>
+            <BitOffs>678795408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -66441,7 +66577,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679121440</BitOffs>
+            <BitOffs>679123232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -66462,7 +66598,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679124960</BitOffs>
+            <BitOffs>679126752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -66483,7 +66619,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679124961</BitOffs>
+            <BitOffs>679126753</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -66495,7 +66631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689323456</BitOffs>
+            <BitOffs>689325248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -66508,7 +66644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331392</BitOffs>
+            <BitOffs>689333184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -66521,7 +66657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331400</BitOffs>
+            <BitOffs>689333192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -66534,7 +66670,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331408</BitOffs>
+            <BitOffs>689333200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -66557,7 +66693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331424</BitOffs>
+            <BitOffs>689333216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -66570,7 +66706,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331456</BitOffs>
+            <BitOffs>689333248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -66583,7 +66719,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331520</BitOffs>
+            <BitOffs>689333312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -66596,7 +66732,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689331536</BitOffs>
+            <BitOffs>689333328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -66608,7 +66744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689348672</BitOffs>
+            <BitOffs>689350464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -66621,7 +66757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356608</BitOffs>
+            <BitOffs>689358400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -66634,7 +66770,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356616</BitOffs>
+            <BitOffs>689358408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -66647,7 +66783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356624</BitOffs>
+            <BitOffs>689358416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -66670,7 +66806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356640</BitOffs>
+            <BitOffs>689358432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -66683,7 +66819,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356672</BitOffs>
+            <BitOffs>689358464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -66696,7 +66832,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356736</BitOffs>
+            <BitOffs>689358528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -66709,7 +66845,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689356752</BitOffs>
+            <BitOffs>689358544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -66721,7 +66857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689373888</BitOffs>
+            <BitOffs>689375680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -66734,7 +66870,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381824</BitOffs>
+            <BitOffs>689383616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -66747,7 +66883,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381832</BitOffs>
+            <BitOffs>689383624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -66760,7 +66896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381840</BitOffs>
+            <BitOffs>689383632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -66783,7 +66919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381856</BitOffs>
+            <BitOffs>689383648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -66796,7 +66932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381888</BitOffs>
+            <BitOffs>689383680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -66809,7 +66945,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381952</BitOffs>
+            <BitOffs>689383744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -66822,7 +66958,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689381968</BitOffs>
+            <BitOffs>689383760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -66834,7 +66970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689399104</BitOffs>
+            <BitOffs>689400896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -66847,7 +66983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407040</BitOffs>
+            <BitOffs>689408832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -66860,7 +66996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407048</BitOffs>
+            <BitOffs>689408840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -66873,7 +67009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407056</BitOffs>
+            <BitOffs>689408848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -66896,7 +67032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407072</BitOffs>
+            <BitOffs>689408864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -66909,7 +67045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407104</BitOffs>
+            <BitOffs>689408896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -66922,7 +67058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407168</BitOffs>
+            <BitOffs>689408960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -66935,7 +67071,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689407184</BitOffs>
+            <BitOffs>689408976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -66947,7 +67083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689424320</BitOffs>
+            <BitOffs>689426112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -66960,7 +67096,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432256</BitOffs>
+            <BitOffs>689434048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -66973,7 +67109,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432264</BitOffs>
+            <BitOffs>689434056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -66986,7 +67122,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432272</BitOffs>
+            <BitOffs>689434064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -67009,7 +67145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432288</BitOffs>
+            <BitOffs>689434080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -67022,7 +67158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432320</BitOffs>
+            <BitOffs>689434112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -67035,7 +67171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432384</BitOffs>
+            <BitOffs>689434176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -67048,7 +67184,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689432400</BitOffs>
+            <BitOffs>689434192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -67060,7 +67196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689449536</BitOffs>
+            <BitOffs>689451328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -67073,7 +67209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457472</BitOffs>
+            <BitOffs>689459264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -67086,7 +67222,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457480</BitOffs>
+            <BitOffs>689459272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -67099,7 +67235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457488</BitOffs>
+            <BitOffs>689459280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -67122,7 +67258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457504</BitOffs>
+            <BitOffs>689459296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -67135,7 +67271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457536</BitOffs>
+            <BitOffs>689459328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -67148,7 +67284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457600</BitOffs>
+            <BitOffs>689459392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -67161,7 +67297,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689457616</BitOffs>
+            <BitOffs>689459408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -67173,7 +67309,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689474752</BitOffs>
+            <BitOffs>689476544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -67186,7 +67322,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482688</BitOffs>
+            <BitOffs>689484480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -67199,7 +67335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482696</BitOffs>
+            <BitOffs>689484488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -67212,7 +67348,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482704</BitOffs>
+            <BitOffs>689484496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -67235,7 +67371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482720</BitOffs>
+            <BitOffs>689484512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -67248,7 +67384,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482752</BitOffs>
+            <BitOffs>689484544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -67261,7 +67397,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482816</BitOffs>
+            <BitOffs>689484608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -67274,7 +67410,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689482832</BitOffs>
+            <BitOffs>689484624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -67286,7 +67422,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689499968</BitOffs>
+            <BitOffs>689501760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -67299,7 +67435,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689507904</BitOffs>
+            <BitOffs>689509696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -67312,7 +67448,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689507912</BitOffs>
+            <BitOffs>689509704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -67325,7 +67461,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689507920</BitOffs>
+            <BitOffs>689509712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -67348,7 +67484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689507936</BitOffs>
+            <BitOffs>689509728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -67361,7 +67497,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689507968</BitOffs>
+            <BitOffs>689509760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -67374,7 +67510,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689508032</BitOffs>
+            <BitOffs>689509824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -67387,7 +67523,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689508048</BitOffs>
+            <BitOffs>689509840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -67399,7 +67535,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689525184</BitOffs>
+            <BitOffs>689526976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -67412,7 +67548,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533120</BitOffs>
+            <BitOffs>689534912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -67425,7 +67561,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533128</BitOffs>
+            <BitOffs>689534920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -67438,7 +67574,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533136</BitOffs>
+            <BitOffs>689534928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -67461,7 +67597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533152</BitOffs>
+            <BitOffs>689534944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -67474,7 +67610,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533184</BitOffs>
+            <BitOffs>689534976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -67487,7 +67623,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533248</BitOffs>
+            <BitOffs>689535040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -67500,7 +67636,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689533264</BitOffs>
+            <BitOffs>689535056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -67512,7 +67648,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689550400</BitOffs>
+            <BitOffs>689552192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -67525,7 +67661,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558336</BitOffs>
+            <BitOffs>689560128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -67538,7 +67674,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558344</BitOffs>
+            <BitOffs>689560136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -67551,7 +67687,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558352</BitOffs>
+            <BitOffs>689560144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -67574,7 +67710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558368</BitOffs>
+            <BitOffs>689560160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -67587,7 +67723,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558400</BitOffs>
+            <BitOffs>689560192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -67600,7 +67736,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558464</BitOffs>
+            <BitOffs>689560256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -67613,7 +67749,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689558480</BitOffs>
+            <BitOffs>689560272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -67625,7 +67761,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689575616</BitOffs>
+            <BitOffs>689577408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -67638,7 +67774,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583552</BitOffs>
+            <BitOffs>689585344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -67651,7 +67787,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583560</BitOffs>
+            <BitOffs>689585352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -67664,7 +67800,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583568</BitOffs>
+            <BitOffs>689585360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -67687,7 +67823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583584</BitOffs>
+            <BitOffs>689585376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -67700,7 +67836,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583616</BitOffs>
+            <BitOffs>689585408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -67713,7 +67849,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583680</BitOffs>
+            <BitOffs>689585472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -67726,7 +67862,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689583696</BitOffs>
+            <BitOffs>689585488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -67738,7 +67874,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689600832</BitOffs>
+            <BitOffs>689602624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -67751,7 +67887,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608768</BitOffs>
+            <BitOffs>689610560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -67764,7 +67900,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608776</BitOffs>
+            <BitOffs>689610568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -67777,7 +67913,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608784</BitOffs>
+            <BitOffs>689610576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -67800,7 +67936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608800</BitOffs>
+            <BitOffs>689610592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -67813,7 +67949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608832</BitOffs>
+            <BitOffs>689610624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -67826,7 +67962,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608896</BitOffs>
+            <BitOffs>689610688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -67839,7 +67975,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689608912</BitOffs>
+            <BitOffs>689610704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -67851,7 +67987,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689626048</BitOffs>
+            <BitOffs>689627840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -67864,7 +68000,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689633984</BitOffs>
+            <BitOffs>689635776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -67877,7 +68013,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689633992</BitOffs>
+            <BitOffs>689635784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -67890,7 +68026,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689634000</BitOffs>
+            <BitOffs>689635792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -67913,7 +68049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689634016</BitOffs>
+            <BitOffs>689635808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -67926,7 +68062,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689634048</BitOffs>
+            <BitOffs>689635840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -67939,7 +68075,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689634112</BitOffs>
+            <BitOffs>689635904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -67952,7 +68088,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689634128</BitOffs>
+            <BitOffs>689635920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -67964,7 +68100,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689651264</BitOffs>
+            <BitOffs>689653056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -67977,7 +68113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659200</BitOffs>
+            <BitOffs>689660992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -67990,7 +68126,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659208</BitOffs>
+            <BitOffs>689661000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -68003,7 +68139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659216</BitOffs>
+            <BitOffs>689661008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -68026,7 +68162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659232</BitOffs>
+            <BitOffs>689661024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -68039,7 +68175,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659264</BitOffs>
+            <BitOffs>689661056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -68052,7 +68188,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659328</BitOffs>
+            <BitOffs>689661120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -68065,7 +68201,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689659344</BitOffs>
+            <BitOffs>689661136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -68077,7 +68213,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689676480</BitOffs>
+            <BitOffs>689678272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -68090,7 +68226,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684416</BitOffs>
+            <BitOffs>689686208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -68103,7 +68239,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684424</BitOffs>
+            <BitOffs>689686216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -68116,7 +68252,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684432</BitOffs>
+            <BitOffs>689686224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -68139,7 +68275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684448</BitOffs>
+            <BitOffs>689686240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -68152,7 +68288,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684480</BitOffs>
+            <BitOffs>689686272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -68165,7 +68301,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684544</BitOffs>
+            <BitOffs>689686336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -68178,7 +68314,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689684560</BitOffs>
+            <BitOffs>689686352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -68190,7 +68326,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689701696</BitOffs>
+            <BitOffs>689703488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -68203,7 +68339,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709632</BitOffs>
+            <BitOffs>689711424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -68216,7 +68352,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709640</BitOffs>
+            <BitOffs>689711432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -68229,7 +68365,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709648</BitOffs>
+            <BitOffs>689711440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -68252,7 +68388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709664</BitOffs>
+            <BitOffs>689711456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -68265,7 +68401,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709696</BitOffs>
+            <BitOffs>689711488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -68278,7 +68414,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709760</BitOffs>
+            <BitOffs>689711552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -68291,7 +68427,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689709776</BitOffs>
+            <BitOffs>689711568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -68303,7 +68439,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689726912</BitOffs>
+            <BitOffs>689728704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -68316,7 +68452,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734848</BitOffs>
+            <BitOffs>689736640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -68329,7 +68465,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734856</BitOffs>
+            <BitOffs>689736648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -68342,7 +68478,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734864</BitOffs>
+            <BitOffs>689736656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -68365,7 +68501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734880</BitOffs>
+            <BitOffs>689736672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -68378,7 +68514,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734912</BitOffs>
+            <BitOffs>689736704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -68391,7 +68527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734976</BitOffs>
+            <BitOffs>689736768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -68404,7 +68540,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689734992</BitOffs>
+            <BitOffs>689736784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -68416,7 +68552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689752128</BitOffs>
+            <BitOffs>689753920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -68429,7 +68565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760064</BitOffs>
+            <BitOffs>689761856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -68442,7 +68578,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760072</BitOffs>
+            <BitOffs>689761864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -68455,7 +68591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760080</BitOffs>
+            <BitOffs>689761872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -68478,7 +68614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760096</BitOffs>
+            <BitOffs>689761888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -68491,7 +68627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760128</BitOffs>
+            <BitOffs>689761920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -68504,7 +68640,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760192</BitOffs>
+            <BitOffs>689761984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -68517,7 +68653,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689760208</BitOffs>
+            <BitOffs>689762000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -68529,7 +68665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689777344</BitOffs>
+            <BitOffs>689779136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -68542,7 +68678,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785280</BitOffs>
+            <BitOffs>689787072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -68555,7 +68691,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785288</BitOffs>
+            <BitOffs>689787080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -68568,7 +68704,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785296</BitOffs>
+            <BitOffs>689787088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -68591,7 +68727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785312</BitOffs>
+            <BitOffs>689787104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -68604,7 +68740,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785344</BitOffs>
+            <BitOffs>689787136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -68617,7 +68753,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785408</BitOffs>
+            <BitOffs>689787200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -68630,7 +68766,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689785424</BitOffs>
+            <BitOffs>689787216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -68642,7 +68778,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689802560</BitOffs>
+            <BitOffs>689804352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -68655,7 +68791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810496</BitOffs>
+            <BitOffs>689812288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -68668,7 +68804,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810504</BitOffs>
+            <BitOffs>689812296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -68681,7 +68817,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810512</BitOffs>
+            <BitOffs>689812304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -68704,7 +68840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810528</BitOffs>
+            <BitOffs>689812320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -68717,7 +68853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810560</BitOffs>
+            <BitOffs>689812352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -68730,7 +68866,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810624</BitOffs>
+            <BitOffs>689812416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -68743,7 +68879,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689810640</BitOffs>
+            <BitOffs>689812432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -68755,7 +68891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689827776</BitOffs>
+            <BitOffs>689829568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -68768,7 +68904,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835712</BitOffs>
+            <BitOffs>689837504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -68781,7 +68917,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835720</BitOffs>
+            <BitOffs>689837512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -68794,7 +68930,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835728</BitOffs>
+            <BitOffs>689837520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -68817,7 +68953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835744</BitOffs>
+            <BitOffs>689837536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -68830,7 +68966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835776</BitOffs>
+            <BitOffs>689837568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -68843,7 +68979,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835840</BitOffs>
+            <BitOffs>689837632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -68856,7 +68992,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689835856</BitOffs>
+            <BitOffs>689837648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -68868,7 +69004,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689852992</BitOffs>
+            <BitOffs>689854784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -68881,7 +69017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689860928</BitOffs>
+            <BitOffs>689862720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -68894,7 +69030,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689860936</BitOffs>
+            <BitOffs>689862728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -68907,7 +69043,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689860944</BitOffs>
+            <BitOffs>689862736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -68930,7 +69066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689860960</BitOffs>
+            <BitOffs>689862752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -68943,7 +69079,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689860992</BitOffs>
+            <BitOffs>689862784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -68956,7 +69092,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689861056</BitOffs>
+            <BitOffs>689862848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -68969,7 +69105,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689861072</BitOffs>
+            <BitOffs>689862864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -68981,7 +69117,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689878208</BitOffs>
+            <BitOffs>689880000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -68994,7 +69130,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886144</BitOffs>
+            <BitOffs>689887936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -69007,7 +69143,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886152</BitOffs>
+            <BitOffs>689887944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -69020,7 +69156,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886160</BitOffs>
+            <BitOffs>689887952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -69043,7 +69179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886176</BitOffs>
+            <BitOffs>689887968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -69056,7 +69192,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886208</BitOffs>
+            <BitOffs>689888000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -69069,7 +69205,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886272</BitOffs>
+            <BitOffs>689888064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -69082,7 +69218,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689886288</BitOffs>
+            <BitOffs>689888080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -69094,7 +69230,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689903424</BitOffs>
+            <BitOffs>689905216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -69107,7 +69243,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911360</BitOffs>
+            <BitOffs>689913152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -69120,7 +69256,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911368</BitOffs>
+            <BitOffs>689913160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -69133,7 +69269,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911376</BitOffs>
+            <BitOffs>689913168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -69156,7 +69292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911392</BitOffs>
+            <BitOffs>689913184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -69169,7 +69305,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911424</BitOffs>
+            <BitOffs>689913216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -69182,7 +69318,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911488</BitOffs>
+            <BitOffs>689913280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -69195,7 +69331,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689911504</BitOffs>
+            <BitOffs>689913296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -69207,7 +69343,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689928640</BitOffs>
+            <BitOffs>689930432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -69220,7 +69356,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936576</BitOffs>
+            <BitOffs>689938368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -69233,7 +69369,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936584</BitOffs>
+            <BitOffs>689938376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -69246,7 +69382,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936592</BitOffs>
+            <BitOffs>689938384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -69269,7 +69405,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936608</BitOffs>
+            <BitOffs>689938400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -69282,7 +69418,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936640</BitOffs>
+            <BitOffs>689938432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -69295,7 +69431,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936704</BitOffs>
+            <BitOffs>689938496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -69308,7 +69444,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689936720</BitOffs>
+            <BitOffs>689938512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -69320,7 +69456,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689953856</BitOffs>
+            <BitOffs>689955648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -69333,7 +69469,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961792</BitOffs>
+            <BitOffs>689963584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -69346,7 +69482,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961800</BitOffs>
+            <BitOffs>689963592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -69359,7 +69495,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961808</BitOffs>
+            <BitOffs>689963600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -69382,7 +69518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961824</BitOffs>
+            <BitOffs>689963616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -69395,7 +69531,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961856</BitOffs>
+            <BitOffs>689963648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -69408,7 +69544,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961920</BitOffs>
+            <BitOffs>689963712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -69421,7 +69557,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689961936</BitOffs>
+            <BitOffs>689963728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -69433,7 +69569,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689979072</BitOffs>
+            <BitOffs>689980864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -69446,7 +69582,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987008</BitOffs>
+            <BitOffs>689988800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -69459,7 +69595,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987016</BitOffs>
+            <BitOffs>689988808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -69472,7 +69608,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987024</BitOffs>
+            <BitOffs>689988816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -69495,7 +69631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987040</BitOffs>
+            <BitOffs>689988832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -69508,7 +69644,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987072</BitOffs>
+            <BitOffs>689988864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -69521,7 +69657,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987136</BitOffs>
+            <BitOffs>689988928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -69534,7 +69670,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>689987152</BitOffs>
+            <BitOffs>689988944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -69546,7 +69682,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690004288</BitOffs>
+            <BitOffs>690006080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -69559,7 +69695,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012224</BitOffs>
+            <BitOffs>690014016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -69572,7 +69708,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012232</BitOffs>
+            <BitOffs>690014024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -69585,7 +69721,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012240</BitOffs>
+            <BitOffs>690014032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -69608,7 +69744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012256</BitOffs>
+            <BitOffs>690014048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -69621,7 +69757,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012288</BitOffs>
+            <BitOffs>690014080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -69634,7 +69770,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012352</BitOffs>
+            <BitOffs>690014144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -69647,7 +69783,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690012368</BitOffs>
+            <BitOffs>690014160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -69659,7 +69795,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690029504</BitOffs>
+            <BitOffs>690031296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -69672,7 +69808,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037440</BitOffs>
+            <BitOffs>690039232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -69685,7 +69821,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037448</BitOffs>
+            <BitOffs>690039240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -69698,7 +69834,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037456</BitOffs>
+            <BitOffs>690039248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -69721,7 +69857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037472</BitOffs>
+            <BitOffs>690039264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -69734,7 +69870,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037504</BitOffs>
+            <BitOffs>690039296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -69747,7 +69883,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037568</BitOffs>
+            <BitOffs>690039360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -69760,7 +69896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690037584</BitOffs>
+            <BitOffs>690039376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -69772,7 +69908,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690054720</BitOffs>
+            <BitOffs>690056512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -69785,7 +69921,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062656</BitOffs>
+            <BitOffs>690064448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -69798,7 +69934,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062664</BitOffs>
+            <BitOffs>690064456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -69811,7 +69947,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062672</BitOffs>
+            <BitOffs>690064464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -69834,7 +69970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062688</BitOffs>
+            <BitOffs>690064480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -69847,7 +69983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062720</BitOffs>
+            <BitOffs>690064512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -69860,7 +69996,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062784</BitOffs>
+            <BitOffs>690064576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -69873,7 +70009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690062800</BitOffs>
+            <BitOffs>690064592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -69885,7 +70021,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690079936</BitOffs>
+            <BitOffs>690081728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -69898,7 +70034,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690087872</BitOffs>
+            <BitOffs>690089664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -69911,7 +70047,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690087880</BitOffs>
+            <BitOffs>690089672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -69924,7 +70060,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690087888</BitOffs>
+            <BitOffs>690089680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -69947,7 +70083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690087904</BitOffs>
+            <BitOffs>690089696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -69960,7 +70096,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690087936</BitOffs>
+            <BitOffs>690089728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -69973,7 +70109,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690088000</BitOffs>
+            <BitOffs>690089792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -69986,7 +70122,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690088016</BitOffs>
+            <BitOffs>690089808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -69998,7 +70134,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690105152</BitOffs>
+            <BitOffs>690106944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -70011,7 +70147,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113088</BitOffs>
+            <BitOffs>690114880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -70024,7 +70160,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113096</BitOffs>
+            <BitOffs>690114888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -70037,7 +70173,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113104</BitOffs>
+            <BitOffs>690114896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -70060,7 +70196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113120</BitOffs>
+            <BitOffs>690114912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -70073,7 +70209,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113152</BitOffs>
+            <BitOffs>690114944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -70086,7 +70222,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113216</BitOffs>
+            <BitOffs>690115008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -70099,7 +70235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690113232</BitOffs>
+            <BitOffs>690115024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -70111,7 +70247,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690130368</BitOffs>
+            <BitOffs>690132160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -70124,7 +70260,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138304</BitOffs>
+            <BitOffs>690140096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -70137,7 +70273,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138312</BitOffs>
+            <BitOffs>690140104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -70150,7 +70286,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138320</BitOffs>
+            <BitOffs>690140112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -70173,7 +70309,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138336</BitOffs>
+            <BitOffs>690140128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -70186,7 +70322,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138368</BitOffs>
+            <BitOffs>690140160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -70199,7 +70335,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138432</BitOffs>
+            <BitOffs>690140224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -70212,7 +70348,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690138448</BitOffs>
+            <BitOffs>690140240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -70224,7 +70360,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690155584</BitOffs>
+            <BitOffs>690157376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -70237,7 +70373,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163520</BitOffs>
+            <BitOffs>690165312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -70250,7 +70386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163528</BitOffs>
+            <BitOffs>690165320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -70263,7 +70399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163536</BitOffs>
+            <BitOffs>690165328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -70286,7 +70422,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163552</BitOffs>
+            <BitOffs>690165344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -70299,7 +70435,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163584</BitOffs>
+            <BitOffs>690165376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -70312,7 +70448,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163648</BitOffs>
+            <BitOffs>690165440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -70325,7 +70461,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690163664</BitOffs>
+            <BitOffs>690165456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -70337,7 +70473,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690180800</BitOffs>
+            <BitOffs>690182592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -70350,7 +70486,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188736</BitOffs>
+            <BitOffs>690190528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -70363,7 +70499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188744</BitOffs>
+            <BitOffs>690190536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -70376,7 +70512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188752</BitOffs>
+            <BitOffs>690190544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -70399,7 +70535,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188768</BitOffs>
+            <BitOffs>690190560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -70412,7 +70548,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188800</BitOffs>
+            <BitOffs>690190592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -70425,7 +70561,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188864</BitOffs>
+            <BitOffs>690190656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -70438,7 +70574,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690188880</BitOffs>
+            <BitOffs>690190672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -70450,7 +70586,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690206016</BitOffs>
+            <BitOffs>690207808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -70463,7 +70599,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690213952</BitOffs>
+            <BitOffs>690215744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -70476,7 +70612,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690213960</BitOffs>
+            <BitOffs>690215752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -70489,7 +70625,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690213968</BitOffs>
+            <BitOffs>690215760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -70512,7 +70648,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690213984</BitOffs>
+            <BitOffs>690215776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -70525,7 +70661,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690214016</BitOffs>
+            <BitOffs>690215808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -70538,7 +70674,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690214080</BitOffs>
+            <BitOffs>690215872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -70551,7 +70687,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690214096</BitOffs>
+            <BitOffs>690215888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -70563,7 +70699,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690231232</BitOffs>
+            <BitOffs>690233024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -70576,7 +70712,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239168</BitOffs>
+            <BitOffs>690240960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -70589,7 +70725,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239176</BitOffs>
+            <BitOffs>690240968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -70602,7 +70738,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239184</BitOffs>
+            <BitOffs>690240976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -70625,7 +70761,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239200</BitOffs>
+            <BitOffs>690240992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -70638,7 +70774,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239232</BitOffs>
+            <BitOffs>690241024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -70651,7 +70787,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239296</BitOffs>
+            <BitOffs>690241088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -70664,7 +70800,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690239312</BitOffs>
+            <BitOffs>690241104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -70676,7 +70812,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690256448</BitOffs>
+            <BitOffs>690258240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -70689,7 +70825,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264384</BitOffs>
+            <BitOffs>690266176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -70702,7 +70838,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264392</BitOffs>
+            <BitOffs>690266184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -70715,7 +70851,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264400</BitOffs>
+            <BitOffs>690266192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -70738,7 +70874,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264416</BitOffs>
+            <BitOffs>690266208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -70751,7 +70887,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264448</BitOffs>
+            <BitOffs>690266240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -70764,7 +70900,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264512</BitOffs>
+            <BitOffs>690266304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -70777,7 +70913,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690264528</BitOffs>
+            <BitOffs>690266320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -70789,7 +70925,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690281664</BitOffs>
+            <BitOffs>690283456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -70802,7 +70938,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289600</BitOffs>
+            <BitOffs>690291392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -70815,7 +70951,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289608</BitOffs>
+            <BitOffs>690291400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -70828,7 +70964,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289616</BitOffs>
+            <BitOffs>690291408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -70851,7 +70987,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289632</BitOffs>
+            <BitOffs>690291424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -70864,7 +71000,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289664</BitOffs>
+            <BitOffs>690291456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -70877,7 +71013,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289728</BitOffs>
+            <BitOffs>690291520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -70890,7 +71026,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690289744</BitOffs>
+            <BitOffs>690291536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -70902,7 +71038,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690306880</BitOffs>
+            <BitOffs>690308672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -70915,7 +71051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314816</BitOffs>
+            <BitOffs>690316608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -70928,7 +71064,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314824</BitOffs>
+            <BitOffs>690316616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -70941,7 +71077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314832</BitOffs>
+            <BitOffs>690316624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -70964,7 +71100,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314848</BitOffs>
+            <BitOffs>690316640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -70977,7 +71113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314880</BitOffs>
+            <BitOffs>690316672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -70990,7 +71126,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314944</BitOffs>
+            <BitOffs>690316736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -71003,7 +71139,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690314960</BitOffs>
+            <BitOffs>690316752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -71015,7 +71151,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690332096</BitOffs>
+            <BitOffs>690333888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -71028,7 +71164,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340032</BitOffs>
+            <BitOffs>690341824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -71041,7 +71177,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340040</BitOffs>
+            <BitOffs>690341832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -71054,7 +71190,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340048</BitOffs>
+            <BitOffs>690341840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -71077,7 +71213,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340064</BitOffs>
+            <BitOffs>690341856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -71090,7 +71226,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340096</BitOffs>
+            <BitOffs>690341888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -71103,7 +71239,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340160</BitOffs>
+            <BitOffs>690341952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -71116,7 +71252,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690340176</BitOffs>
+            <BitOffs>690341968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -71128,7 +71264,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690357312</BitOffs>
+            <BitOffs>690359104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -71141,7 +71277,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365248</BitOffs>
+            <BitOffs>690367040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -71154,7 +71290,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365256</BitOffs>
+            <BitOffs>690367048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -71167,7 +71303,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365264</BitOffs>
+            <BitOffs>690367056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -71190,7 +71326,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365280</BitOffs>
+            <BitOffs>690367072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -71203,7 +71339,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365312</BitOffs>
+            <BitOffs>690367104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -71216,7 +71352,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365376</BitOffs>
+            <BitOffs>690367168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -71229,7 +71365,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690365392</BitOffs>
+            <BitOffs>690367184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -71241,7 +71377,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690382528</BitOffs>
+            <BitOffs>690384320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -71254,7 +71390,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390464</BitOffs>
+            <BitOffs>690392256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -71267,7 +71403,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390472</BitOffs>
+            <BitOffs>690392264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -71280,7 +71416,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390480</BitOffs>
+            <BitOffs>690392272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -71303,7 +71439,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390496</BitOffs>
+            <BitOffs>690392288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -71316,7 +71452,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390528</BitOffs>
+            <BitOffs>690392320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -71329,7 +71465,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390592</BitOffs>
+            <BitOffs>690392384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -71342,7 +71478,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690390608</BitOffs>
+            <BitOffs>690392400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -71354,7 +71490,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690407744</BitOffs>
+            <BitOffs>690409536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -71367,7 +71503,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415680</BitOffs>
+            <BitOffs>690417472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -71380,7 +71516,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415688</BitOffs>
+            <BitOffs>690417480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -71393,7 +71529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415696</BitOffs>
+            <BitOffs>690417488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -71416,7 +71552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415712</BitOffs>
+            <BitOffs>690417504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -71429,7 +71565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415744</BitOffs>
+            <BitOffs>690417536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -71442,7 +71578,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415808</BitOffs>
+            <BitOffs>690417600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -71455,7 +71591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690415824</BitOffs>
+            <BitOffs>690417616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.NcToPlc</Name>
@@ -71467,7 +71603,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690432960</BitOffs>
+            <BitOffs>690434752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitForwardEnable</Name>
@@ -71480,7 +71616,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690440896</BitOffs>
+            <BitOffs>690442688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitBackwardEnable</Name>
@@ -71493,7 +71629,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690440904</BitOffs>
+            <BitOffs>690442696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHome</Name>
@@ -71506,7 +71642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690440912</BitOffs>
+            <BitOffs>690442704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHardwareEnable</Name>
@@ -71529,7 +71665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690440928</BitOffs>
+            <BitOffs>690442720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderULINT</Name>
@@ -71542,7 +71678,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690440960</BitOffs>
+            <BitOffs>690442752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderUINT</Name>
@@ -71555,7 +71691,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690441024</BitOffs>
+            <BitOffs>690442816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderINT</Name>
@@ -71568,7 +71704,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690441040</BitOffs>
+            <BitOffs>690442832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.NcToPlc</Name>
@@ -71580,7 +71716,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690458176</BitOffs>
+            <BitOffs>690459968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitForwardEnable</Name>
@@ -71593,7 +71729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466112</BitOffs>
+            <BitOffs>690467904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitBackwardEnable</Name>
@@ -71606,7 +71742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466120</BitOffs>
+            <BitOffs>690467912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHome</Name>
@@ -71619,7 +71755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466128</BitOffs>
+            <BitOffs>690467920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHardwareEnable</Name>
@@ -71642,7 +71778,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466144</BitOffs>
+            <BitOffs>690467936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderULINT</Name>
@@ -71655,7 +71791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466176</BitOffs>
+            <BitOffs>690467968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderUINT</Name>
@@ -71668,7 +71804,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466240</BitOffs>
+            <BitOffs>690468032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderINT</Name>
@@ -71681,7 +71817,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690466256</BitOffs>
+            <BitOffs>690468048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.NcToPlc</Name>
@@ -71693,7 +71829,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690483392</BitOffs>
+            <BitOffs>690485184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitForwardEnable</Name>
@@ -71706,7 +71842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491328</BitOffs>
+            <BitOffs>690493120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitBackwardEnable</Name>
@@ -71719,7 +71855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491336</BitOffs>
+            <BitOffs>690493128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHome</Name>
@@ -71732,7 +71868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491344</BitOffs>
+            <BitOffs>690493136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHardwareEnable</Name>
@@ -71755,7 +71891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491360</BitOffs>
+            <BitOffs>690493152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderULINT</Name>
@@ -71768,7 +71904,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491392</BitOffs>
+            <BitOffs>690493184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderUINT</Name>
@@ -71781,7 +71917,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491456</BitOffs>
+            <BitOffs>690493248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderINT</Name>
@@ -71794,7 +71930,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690491472</BitOffs>
+            <BitOffs>690493264</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -72782,7 +72918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659780864</BitOffs>
+            <BitOffs>659781312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72794,7 +72930,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>660078784</BitOffs>
+            <BitOffs>660079232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -72806,7 +72942,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661643200</BitOffs>
+            <BitOffs>661643648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -72819,7 +72955,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661652184</BitOffs>
+            <BitOffs>661652632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -72831,7 +72967,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661668416</BitOffs>
+            <BitOffs>661668864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -72844,7 +72980,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661677400</BitOffs>
+            <BitOffs>661677848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -72856,7 +72992,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661693632</BitOffs>
+            <BitOffs>661694080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -72869,7 +73005,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661702616</BitOffs>
+            <BitOffs>661703064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72881,7 +73017,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662088000</BitOffs>
+            <BitOffs>662088896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72893,7 +73029,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662385920</BitOffs>
+            <BitOffs>662386816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72905,7 +73041,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662683840</BitOffs>
+            <BitOffs>662684736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72917,7 +73053,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662981760</BitOffs>
+            <BitOffs>662982656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -72929,7 +73065,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663428384</BitOffs>
+            <BitOffs>663429280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72941,7 +73077,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663434688</BitOffs>
+            <BitOffs>663435584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72953,7 +73089,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663732608</BitOffs>
+            <BitOffs>663733504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72965,7 +73101,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664030528</BitOffs>
+            <BitOffs>664031424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -72977,7 +73113,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664328448</BitOffs>
+            <BitOffs>664329344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -72989,7 +73125,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664775072</BitOffs>
+            <BitOffs>664775968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -73001,7 +73137,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664887664</BitOffs>
+            <BitOffs>664888560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -73013,7 +73149,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664887672</BitOffs>
+            <BitOffs>664888568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73025,7 +73161,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664921856</BitOffs>
+            <BitOffs>664922752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73037,7 +73173,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665219776</BitOffs>
+            <BitOffs>665220672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73049,7 +73185,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666237824</BitOffs>
+            <BitOffs>666239168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73061,7 +73197,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666535744</BitOffs>
+            <BitOffs>666537088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73073,7 +73209,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667522944</BitOffs>
+            <BitOffs>667524736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73085,7 +73221,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667820864</BitOffs>
+            <BitOffs>667822656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73097,7 +73233,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668118784</BitOffs>
+            <BitOffs>668120576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73109,7 +73245,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668416704</BitOffs>
+            <BitOffs>668418496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73121,7 +73257,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668714624</BitOffs>
+            <BitOffs>668716416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73133,7 +73269,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669012544</BitOffs>
+            <BitOffs>669014336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73145,7 +73281,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669310464</BitOffs>
+            <BitOffs>669312256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73157,7 +73293,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669608384</BitOffs>
+            <BitOffs>669610176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73169,7 +73305,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669906304</BitOffs>
+            <BitOffs>669908096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73181,7 +73317,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670204224</BitOffs>
+            <BitOffs>670206016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73193,7 +73329,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670502144</BitOffs>
+            <BitOffs>670503936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73205,7 +73341,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670800064</BitOffs>
+            <BitOffs>670801856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73217,7 +73353,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671097984</BitOffs>
+            <BitOffs>671099776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -73229,7 +73365,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>672661568</BitOffs>
+            <BitOffs>672663360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -73242,7 +73378,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>672670552</BitOffs>
+            <BitOffs>672672344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -73254,7 +73390,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>672686784</BitOffs>
+            <BitOffs>672688576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -73267,7 +73403,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>672695768</BitOffs>
+            <BitOffs>672697560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -73279,7 +73415,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>672712000</BitOffs>
+            <BitOffs>672713792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -73292,7 +73428,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>672720984</BitOffs>
+            <BitOffs>672722776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -73304,7 +73440,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674424000</BitOffs>
+            <BitOffs>674425792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -73317,7 +73453,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674432984</BitOffs>
+            <BitOffs>674434776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -73329,7 +73465,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674449216</BitOffs>
+            <BitOffs>674451008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -73342,7 +73478,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674458200</BitOffs>
+            <BitOffs>674459992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -73354,7 +73490,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674474432</BitOffs>
+            <BitOffs>674476224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -73367,7 +73503,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674483416</BitOffs>
+            <BitOffs>674485208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73379,7 +73515,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>674866880</BitOffs>
+            <BitOffs>674868672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73391,7 +73527,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675164800</BitOffs>
+            <BitOffs>675166592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -73403,7 +73539,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676728256</BitOffs>
+            <BitOffs>676730048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -73416,7 +73552,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676737240</BitOffs>
+            <BitOffs>676739032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -73428,7 +73564,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676753472</BitOffs>
+            <BitOffs>676755264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -73441,7 +73577,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676762456</BitOffs>
+            <BitOffs>676764248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -73453,7 +73589,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676778688</BitOffs>
+            <BitOffs>676780480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -73466,7 +73602,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676787672</BitOffs>
+            <BitOffs>676789464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbMotionCF1K4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -73478,7 +73614,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677170688</BitOffs>
+            <BitOffs>677172480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -73490,7 +73626,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678734080</BitOffs>
+            <BitOffs>678735872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -73503,7 +73639,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678743064</BitOffs>
+            <BitOffs>678744856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -73515,7 +73651,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678759296</BitOffs>
+            <BitOffs>678761088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -73528,7 +73664,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678768280</BitOffs>
+            <BitOffs>678770072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -73540,7 +73676,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678784512</BitOffs>
+            <BitOffs>678786304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -73553,7 +73689,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678793496</BitOffs>
+            <BitOffs>678795288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -73572,7 +73708,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>679120632</BitOffs>
+            <BitOffs>679122424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -73588,7 +73724,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679123200</BitOffs>
+            <BitOffs>679124992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -73608,7 +73744,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>686028680</BitOffs>
+            <BitOffs>686030472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -73628,7 +73764,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>687675592</BitOffs>
+            <BitOffs>687677384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -73647,7 +73783,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322240</BitOffs>
+            <BitOffs>689324032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -73659,7 +73795,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689322432</BitOffs>
+            <BitOffs>689324224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -73672,7 +73808,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689331416</BitOffs>
+            <BitOffs>689333208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -73684,7 +73820,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689347648</BitOffs>
+            <BitOffs>689349440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -73697,7 +73833,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689356632</BitOffs>
+            <BitOffs>689358424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -73709,7 +73845,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689372864</BitOffs>
+            <BitOffs>689374656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -73722,7 +73858,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689381848</BitOffs>
+            <BitOffs>689383640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -73734,7 +73870,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689398080</BitOffs>
+            <BitOffs>689399872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -73747,7 +73883,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689407064</BitOffs>
+            <BitOffs>689408856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -73759,7 +73895,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689423296</BitOffs>
+            <BitOffs>689425088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -73772,7 +73908,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689432280</BitOffs>
+            <BitOffs>689434072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -73784,7 +73920,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689448512</BitOffs>
+            <BitOffs>689450304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -73797,7 +73933,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689457496</BitOffs>
+            <BitOffs>689459288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -73809,7 +73945,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689473728</BitOffs>
+            <BitOffs>689475520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -73822,7 +73958,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689482712</BitOffs>
+            <BitOffs>689484504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -73834,7 +73970,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689498944</BitOffs>
+            <BitOffs>689500736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -73847,7 +73983,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689507928</BitOffs>
+            <BitOffs>689509720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -73859,7 +73995,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689524160</BitOffs>
+            <BitOffs>689525952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -73872,7 +74008,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689533144</BitOffs>
+            <BitOffs>689534936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -73884,7 +74020,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689549376</BitOffs>
+            <BitOffs>689551168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -73897,7 +74033,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689558360</BitOffs>
+            <BitOffs>689560152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -73909,7 +74045,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689574592</BitOffs>
+            <BitOffs>689576384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -73922,7 +74058,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689583576</BitOffs>
+            <BitOffs>689585368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -73934,7 +74070,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689599808</BitOffs>
+            <BitOffs>689601600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -73947,7 +74083,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689608792</BitOffs>
+            <BitOffs>689610584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -73959,7 +74095,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689625024</BitOffs>
+            <BitOffs>689626816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -73972,7 +74108,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689634008</BitOffs>
+            <BitOffs>689635800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -73984,7 +74120,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689650240</BitOffs>
+            <BitOffs>689652032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -73997,7 +74133,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689659224</BitOffs>
+            <BitOffs>689661016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -74009,7 +74145,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689675456</BitOffs>
+            <BitOffs>689677248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -74022,7 +74158,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689684440</BitOffs>
+            <BitOffs>689686232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -74034,7 +74170,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689700672</BitOffs>
+            <BitOffs>689702464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -74047,7 +74183,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689709656</BitOffs>
+            <BitOffs>689711448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -74059,7 +74195,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689725888</BitOffs>
+            <BitOffs>689727680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -74072,7 +74208,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689734872</BitOffs>
+            <BitOffs>689736664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -74084,7 +74220,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689751104</BitOffs>
+            <BitOffs>689752896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -74097,7 +74233,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689760088</BitOffs>
+            <BitOffs>689761880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -74109,7 +74245,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689776320</BitOffs>
+            <BitOffs>689778112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -74122,7 +74258,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689785304</BitOffs>
+            <BitOffs>689787096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -74134,7 +74270,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689801536</BitOffs>
+            <BitOffs>689803328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -74147,7 +74283,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689810520</BitOffs>
+            <BitOffs>689812312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -74159,7 +74295,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689826752</BitOffs>
+            <BitOffs>689828544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -74172,7 +74308,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689835736</BitOffs>
+            <BitOffs>689837528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -74184,7 +74320,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689851968</BitOffs>
+            <BitOffs>689853760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -74197,7 +74333,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689860952</BitOffs>
+            <BitOffs>689862744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -74209,7 +74345,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689877184</BitOffs>
+            <BitOffs>689878976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -74222,7 +74358,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689886168</BitOffs>
+            <BitOffs>689887960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -74234,7 +74370,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689902400</BitOffs>
+            <BitOffs>689904192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -74247,7 +74383,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689911384</BitOffs>
+            <BitOffs>689913176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -74259,7 +74395,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689927616</BitOffs>
+            <BitOffs>689929408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -74272,7 +74408,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689936600</BitOffs>
+            <BitOffs>689938392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -74284,7 +74420,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689952832</BitOffs>
+            <BitOffs>689954624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -74297,7 +74433,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689961816</BitOffs>
+            <BitOffs>689963608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -74309,7 +74445,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689978048</BitOffs>
+            <BitOffs>689979840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -74322,7 +74458,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689987032</BitOffs>
+            <BitOffs>689988824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -74334,7 +74470,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690003264</BitOffs>
+            <BitOffs>690005056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -74347,7 +74483,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690012248</BitOffs>
+            <BitOffs>690014040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -74359,7 +74495,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690028480</BitOffs>
+            <BitOffs>690030272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -74372,7 +74508,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690037464</BitOffs>
+            <BitOffs>690039256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -74384,7 +74520,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690053696</BitOffs>
+            <BitOffs>690055488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -74397,7 +74533,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690062680</BitOffs>
+            <BitOffs>690064472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -74409,7 +74545,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690078912</BitOffs>
+            <BitOffs>690080704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -74422,7 +74558,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690087896</BitOffs>
+            <BitOffs>690089688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -74434,7 +74570,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690104128</BitOffs>
+            <BitOffs>690105920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -74447,7 +74583,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690113112</BitOffs>
+            <BitOffs>690114904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -74459,7 +74595,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690129344</BitOffs>
+            <BitOffs>690131136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -74472,7 +74608,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690138328</BitOffs>
+            <BitOffs>690140120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -74484,7 +74620,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690154560</BitOffs>
+            <BitOffs>690156352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -74497,7 +74633,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690163544</BitOffs>
+            <BitOffs>690165336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -74509,7 +74645,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690179776</BitOffs>
+            <BitOffs>690181568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -74522,7 +74658,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690188760</BitOffs>
+            <BitOffs>690190552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -74534,7 +74670,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690204992</BitOffs>
+            <BitOffs>690206784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -74547,7 +74683,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690213976</BitOffs>
+            <BitOffs>690215768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -74559,7 +74695,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690230208</BitOffs>
+            <BitOffs>690232000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -74572,7 +74708,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690239192</BitOffs>
+            <BitOffs>690240984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -74584,7 +74720,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690255424</BitOffs>
+            <BitOffs>690257216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -74597,7 +74733,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690264408</BitOffs>
+            <BitOffs>690266200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -74609,7 +74745,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690280640</BitOffs>
+            <BitOffs>690282432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -74622,7 +74758,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690289624</BitOffs>
+            <BitOffs>690291416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -74634,7 +74770,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690305856</BitOffs>
+            <BitOffs>690307648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -74647,7 +74783,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690314840</BitOffs>
+            <BitOffs>690316632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -74659,7 +74795,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690331072</BitOffs>
+            <BitOffs>690332864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -74672,7 +74808,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690340056</BitOffs>
+            <BitOffs>690341848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -74684,7 +74820,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690356288</BitOffs>
+            <BitOffs>690358080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -74697,7 +74833,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690365272</BitOffs>
+            <BitOffs>690367064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -74709,7 +74845,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690381504</BitOffs>
+            <BitOffs>690383296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -74722,7 +74858,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690390488</BitOffs>
+            <BitOffs>690392280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -74734,7 +74870,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690406720</BitOffs>
+            <BitOffs>690408512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -74747,7 +74883,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690415704</BitOffs>
+            <BitOffs>690417496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.PlcToNc</Name>
@@ -74759,7 +74895,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690431936</BitOffs>
+            <BitOffs>690433728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bBrakeRelease</Name>
@@ -74772,7 +74908,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690440920</BitOffs>
+            <BitOffs>690442712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.PlcToNc</Name>
@@ -74784,7 +74920,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690457152</BitOffs>
+            <BitOffs>690458944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bBrakeRelease</Name>
@@ -74797,7 +74933,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690466136</BitOffs>
+            <BitOffs>690467928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.PlcToNc</Name>
@@ -74809,7 +74945,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690482368</BitOffs>
+            <BitOffs>690484160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bBrakeRelease</Name>
@@ -74822,7 +74958,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690491352</BitOffs>
+            <BitOffs>690493144</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -80149,7 +80285,7 @@ Digital outputs</Comment>
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>3</Value>
+                <Value>4</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
@@ -80165,7 +80301,7 @@ Digital outputs</Comment>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>3.3.0</String>
+                <String>3.4.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -81904,7 +82040,8 @@ Digital outputs</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
-            <BitSize>2239936</BitSize>
+            <Comment> same cooling loop as IM5K4</Comment>
+            <BitSize>2240384</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_WFS</BaseType>
             <Properties>
               <Property>
@@ -81923,7 +82060,8 @@ Digital outputs</Comment>
                               .fbThermoCouple2.bError 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Error;
                               .fbThermoCouple2.bUnderrange 	:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Underrange;
                               .fbThermoCouple2.bOverrange 	:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Status^Overrange;
-                              .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
+                              .fbThermoCouple2.iRaw 		:= TIIB[PF1K4-EL3314-E5]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw             := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
             <BitOffs>657422016</BitOffs>
@@ -81932,7 +82070,7 @@ Digital outputs</Comment>
             <Name>PRG_PF1K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>659661952</BitOffs>
+            <BitOffs>659662400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stDefault</Name>
@@ -81948,11 +82086,12 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>659749760</BitOffs>
+            <BitOffs>659750208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
-            <BitSize>2239936</BitSize>
+            <Comment> same cooling loop as IM6K4</Comment>
+            <BitSize>2240384</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_WFS</BaseType>
             <Properties>
               <Property>
@@ -81971,16 +82110,17 @@ Digital outputs</Comment>
                               .fbThermoCouple2.bError 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Status^Error;
                               .fbThermoCouple2.bUnderrange 	:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Status^Underrange;
                               .fbThermoCouple2.bOverrange 	:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Status^Overrange;
-                              .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value</Value>
+                              .fbThermoCouple2.iRaw 		:= TIIB[PF2K4-EL3314-E5]^TC Inputs Channel 2^Value;
+                              .fbFlowMeter.iRaw             := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>659753408</BitOffs>
+            <BitOffs>659753856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>661993344</BitOffs>
+            <BitOffs>661994240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stDefault</Name>
@@ -82000,7 +82140,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>662081152</BitOffs>
+            <BitOffs>662082048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -82015,7 +82155,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662085440</BitOffs>
+            <BitOffs>662086336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -82026,7 +82166,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663428608</BitOffs>
+            <BitOffs>663429504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
@@ -82036,7 +82176,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663431680</BitOffs>
+            <BitOffs>663432576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -82046,7 +82186,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663431712</BitOffs>
+            <BitOffs>663432608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -82056,7 +82196,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663431744</BitOffs>
+            <BitOffs>663432640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -82066,7 +82206,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663431776</BitOffs>
+            <BitOffs>663432672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -82081,7 +82221,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663432128</BitOffs>
+            <BitOffs>663433024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -82092,7 +82232,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>664775296</BitOffs>
+            <BitOffs>664776192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
@@ -82102,7 +82242,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664778368</BitOffs>
+            <BitOffs>664779264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -82112,7 +82252,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664778400</BitOffs>
+            <BitOffs>664779296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -82122,7 +82262,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664778432</BitOffs>
+            <BitOffs>664779328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -82132,7 +82272,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664778464</BitOffs>
+            <BitOffs>664779360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -82151,23 +82291,24 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664778752</BitOffs>
+            <BitOffs>664779648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>664887680</BitOffs>
+            <BitOffs>664888576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>664889632</BitOffs>
+            <BitOffs>664890528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
-            <BitSize>1322752</BitSize>
+            <Comment> same cooling loop as IM5K4</Comment>
+            <BitSize>1323200</BitSize>
             <BaseType>FB_TM1K4</BaseType>
             <Properties>
               <Property>
@@ -82182,26 +82323,28 @@ Digital outputs</Comment>
                 <Value>.fbThermoCouple1.bError := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Status^Error;
                               .fbThermoCouple1.bUnderrange := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Status^Underrange;
                               .fbThermoCouple1.bOverrange := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Status^Overrange;
-                              .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
+                              .fbThermoCouple1.iRaw := TIIB[TM1K4-EL3314-E5]^TC Inputs Channel 1^Value;
+                              .fbFlowMeter.iRaw := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>664889664</BitOffs>
+            <BitOffs>664890560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>666212896</BitOffs>
+            <BitOffs>666214240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>666212912</BitOffs>
+            <BitOffs>666214256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
-            <BitSize>1308160</BitSize>
+            <Comment> same as IM6K4</Comment>
+            <BitSize>1308608</BitSize>
             <BaseType>FB_TM2K4</BaseType>
             <Properties>
               <Property>
@@ -82216,88 +82359,89 @@ Digital outputs</Comment>
                 <Value>.fbThermoCouple1.bError := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Status^Error;
                               .fbThermoCouple1.bUnderrange := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Status^Underrange;
                               .fbThermoCouple1.bOverrange := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Status^Overrange;
-                              .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value</Value>
+                              .fbThermoCouple1.iRaw := TIIB[TM2K4-EL3314-E5]^TC Inputs Channel 1^Value;
+                              .fbFlowMeter.iRaw := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>666212928</BitOffs>
+            <BitOffs>666214272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667521472</BitOffs>
+            <BitOffs>667523264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667819392</BitOffs>
+            <BitOffs>667821184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668117312</BitOffs>
+            <BitOffs>668119104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668415232</BitOffs>
+            <BitOffs>668417024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668713152</BitOffs>
+            <BitOffs>668714944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669011072</BitOffs>
+            <BitOffs>669012864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669308992</BitOffs>
+            <BitOffs>669310784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669606912</BitOffs>
+            <BitOffs>669608704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669904832</BitOffs>
+            <BitOffs>669906624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670202752</BitOffs>
+            <BitOffs>670204544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670500672</BitOffs>
+            <BitOffs>670502464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670798592</BitOffs>
+            <BitOffs>670800384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671096512</BitOffs>
+            <BitOffs>671098304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -82306,13 +82450,13 @@ Digital outputs</Comment>
             <Default>
               <Value>1</Value>
             </Default>
-            <BitOffs>671394440</BitOffs>
+            <BitOffs>671396232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>671394448</BitOffs>
+            <BitOffs>671396240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -82321,20 +82465,20 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>671394464</BitOffs>
+            <BitOffs>671396256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>671394480</BitOffs>
+            <BitOffs>671396272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bPF1K4Out</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>671394488</BitOffs>
+            <BitOffs>671396280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates</Name>
@@ -82349,7 +82493,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>671394496</BitOffs>
+            <BitOffs>671396288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -82364,7 +82508,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672901312</BitOffs>
+            <BitOffs>672903104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -82379,7 +82523,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672901328</BitOffs>
+            <BitOffs>672903120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumSet</Name>
@@ -82394,7 +82538,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672901344</BitOffs>
+            <BitOffs>672903136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumGet</Name>
@@ -82409,13 +82553,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672901360</BitOffs>
+            <BitOffs>672903152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>672901376</BitOffs>
+            <BitOffs>672903168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -82435,7 +82579,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>672989184</BitOffs>
+            <BitOffs>672990976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -82445,7 +82589,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>672992832</BitOffs>
+            <BitOffs>672994624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -82455,7 +82599,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673047552</BitOffs>
+            <BitOffs>673049344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -82465,7 +82609,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673102272</BitOffs>
+            <BitOffs>673104064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -82480,13 +82624,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673156992</BitOffs>
+            <BitOffs>673158784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>674663744</BitOffs>
+            <BitOffs>674665536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -82506,7 +82650,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>674751552</BitOffs>
+            <BitOffs>674753344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -82516,7 +82660,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>674755200</BitOffs>
+            <BitOffs>674756992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -82526,7 +82670,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>674809920</BitOffs>
+            <BitOffs>674811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01</Name>
@@ -82550,7 +82694,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>674864640</BitOffs>
+            <BitOffs>674866432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02</Name>
@@ -82573,19 +82717,19 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>674864896</BitOffs>
+            <BitOffs>674866688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>674865408</BitOffs>
+            <BitOffs>674867200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>675163328</BitOffs>
+            <BitOffs>675165120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States</Name>
@@ -82600,7 +82744,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675461248</BitOffs>
+            <BitOffs>675463040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
@@ -82615,7 +82759,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>676968000</BitOffs>
+            <BitOffs>676969792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.li2k4_enumGet</Name>
@@ -82630,7 +82774,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>676968016</BitOffs>
+            <BitOffs>676969808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.cf1k4_enumSet</Name>
@@ -82645,7 +82789,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>676968032</BitOffs>
+            <BitOffs>676969824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.cf1k4_enumGet</Name>
@@ -82660,13 +82804,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>676968048</BitOffs>
+            <BitOffs>676969840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbStateSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>676968064</BitOffs>
+            <BitOffs>676969856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.stDefault</Name>
@@ -82686,7 +82830,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>677055872</BitOffs>
+            <BitOffs>677057664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4XStates</Name>
@@ -82696,7 +82840,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>677059520</BitOffs>
+            <BitOffs>677061312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4YStates</Name>
@@ -82706,37 +82850,37 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>677114240</BitOffs>
+            <BitOffs>677116032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Positive</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>677168960</BitOffs>
+            <BitOffs>677170752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Negative</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>677169024</BitOffs>
+            <BitOffs>677170816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Positive</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>677169088</BitOffs>
+            <BitOffs>677170880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Negative</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>677169152</BitOffs>
+            <BitOffs>677170944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbMotionCF1K4</Name>
             <BitSize>297920</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>677169216</BitOffs>
+            <BitOffs>677171008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbCF1K4States</Name>
@@ -82751,13 +82895,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>677467136</BitOffs>
+            <BitOffs>677468928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.fbStateSetup</Name>
             <BitSize>87808</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>678973824</BitOffs>
+            <BitOffs>678975616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.stDefault</Name>
@@ -82781,7 +82925,7 @@ Digital outputs</Comment>
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>679061632</BitOffs>
+            <BitOffs>679063424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_CF1K4_IP1.aCF1K4States</Name>
@@ -82791,43 +82935,43 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>679065280</BitOffs>
+            <BitOffs>679067072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>679120608</BitOffs>
+            <BitOffs>679122400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>679120616</BitOffs>
+            <BitOffs>679122408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>679120624</BitOffs>
+            <BitOffs>679122416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>138368</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>679120640</BitOffs>
+            <BitOffs>679122432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>27168</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>679259008</BitOffs>
+            <BitOffs>679260800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5788736</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>679289856</BitOffs>
+            <BitOffs>679291648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -82846,7 +82990,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685081472</BitOffs>
+            <BitOffs>685083264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -82865,7 +83009,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>685554944</BitOffs>
+            <BitOffs>685556736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -82895,7 +83039,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686028416</BitOffs>
+            <BitOffs>686030208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -82925,7 +83069,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>687675328</BitOffs>
+            <BitOffs>687677120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF1K4State</Name>
@@ -82936,7 +83080,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322256</BitOffs>
+            <BitOffs>689324048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -82947,7 +83091,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322272</BitOffs>
+            <BitOffs>689324064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4ATT</Name>
@@ -82958,7 +83102,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322288</BitOffs>
+            <BitOffs>689324080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4FZP</Name>
@@ -82969,7 +83113,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322304</BitOffs>
+            <BitOffs>689324096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -82984,7 +83128,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322320</BitOffs>
+            <BitOffs>689324112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -82999,7 +83143,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322328</BitOffs>
+            <BitOffs>689324120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -83014,7 +83158,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322336</BitOffs>
+            <BitOffs>689324128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -83029,7 +83173,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322352</BitOffs>
+            <BitOffs>689324144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -83058,7 +83202,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689322368</BitOffs>
+            <BitOffs>689324160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -83070,7 +83214,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689347584</BitOffs>
+            <BitOffs>689349376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -83081,7 +83225,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689372800</BitOffs>
+            <BitOffs>689374592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -83092,7 +83236,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689398016</BitOffs>
+            <BitOffs>689399808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -83103,7 +83247,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689423232</BitOffs>
+            <BitOffs>689425024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -83114,7 +83258,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689448448</BitOffs>
+            <BitOffs>689450240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -83125,7 +83269,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689473664</BitOffs>
+            <BitOffs>689475456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -83136,7 +83280,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689498880</BitOffs>
+            <BitOffs>689500672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -83165,7 +83309,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689524096</BitOffs>
+            <BitOffs>689525888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -83193,7 +83337,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689549312</BitOffs>
+            <BitOffs>689551104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -83220,7 +83364,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689574528</BitOffs>
+            <BitOffs>689576320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -83247,7 +83391,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689599744</BitOffs>
+            <BitOffs>689601536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -83274,7 +83418,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689624960</BitOffs>
+            <BitOffs>689626752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -83286,7 +83430,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689650176</BitOffs>
+            <BitOffs>689651968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -83315,7 +83459,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689675392</BitOffs>
+            <BitOffs>689677184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -83344,7 +83488,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689700608</BitOffs>
+            <BitOffs>689702400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -83373,7 +83517,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689725824</BitOffs>
+            <BitOffs>689727616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -83402,7 +83546,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689751040</BitOffs>
+            <BitOffs>689752832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -83427,7 +83571,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689776256</BitOffs>
+            <BitOffs>689778048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -83456,7 +83600,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689801472</BitOffs>
+            <BitOffs>689803264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -83485,7 +83629,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689826688</BitOffs>
+            <BitOffs>689828480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -83510,7 +83654,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689851904</BitOffs>
+            <BitOffs>689853696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -83538,7 +83682,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689877120</BitOffs>
+            <BitOffs>689878912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -83565,7 +83709,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689902336</BitOffs>
+            <BitOffs>689904128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -83592,7 +83736,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689927552</BitOffs>
+            <BitOffs>689929344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -83619,7 +83763,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689952768</BitOffs>
+            <BitOffs>689954560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -83648,7 +83792,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689977984</BitOffs>
+            <BitOffs>689979776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -83677,7 +83821,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690003200</BitOffs>
+            <BitOffs>690004992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -83702,7 +83846,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690028416</BitOffs>
+            <BitOffs>690030208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -83731,7 +83875,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690053632</BitOffs>
+            <BitOffs>690055424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -83756,7 +83900,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690078848</BitOffs>
+            <BitOffs>690080640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -83793,7 +83937,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690104064</BitOffs>
+            <BitOffs>690105856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -83838,7 +83982,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690129280</BitOffs>
+            <BitOffs>690131072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -83879,7 +84023,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690154496</BitOffs>
+            <BitOffs>690156288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -83920,7 +84064,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690179712</BitOffs>
+            <BitOffs>690181504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -83961,7 +84105,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690204928</BitOffs>
+            <BitOffs>690206720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -84002,7 +84146,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690230144</BitOffs>
+            <BitOffs>690231936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -84043,7 +84187,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690255360</BitOffs>
+            <BitOffs>690257152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -84084,7 +84228,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690280576</BitOffs>
+            <BitOffs>690282368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -84125,7 +84269,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690305792</BitOffs>
+            <BitOffs>690307584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -84161,7 +84305,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690331008</BitOffs>
+            <BitOffs>690332800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -84197,7 +84341,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690356224</BitOffs>
+            <BitOffs>690358016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -84233,7 +84377,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690381440</BitOffs>
+            <BitOffs>690383232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -84278,7 +84422,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690406656</BitOffs>
+            <BitOffs>690408448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45</Name>
@@ -84324,7 +84468,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690431872</BitOffs>
+            <BitOffs>690433664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46</Name>
@@ -84370,7 +84514,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690457088</BitOffs>
+            <BitOffs>690458880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47</Name>
@@ -84414,7 +84558,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690482304</BitOffs>
+            <BitOffs>690484096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -84444,7 +84588,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690507520</BitOffs>
+            <BitOffs>690509312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -84474,7 +84618,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690507584</BitOffs>
+            <BitOffs>690509376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -84488,7 +84632,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690507648</BitOffs>
+            <BitOffs>690509440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -84502,7 +84646,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690507680</BitOffs>
+            <BitOffs>690509472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -84516,7 +84660,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690507712</BitOffs>
+            <BitOffs>690509504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -84530,7 +84674,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690507744</BitOffs>
+            <BitOffs>690509536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -84544,7 +84688,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690509792</BitOffs>
+            <BitOffs>690511584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -84562,7 +84706,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690509824</BitOffs>
+            <BitOffs>690511616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -84576,7 +84720,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690510848</BitOffs>
+            <BitOffs>690512640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -84597,7 +84741,30 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690510880</BitOffs>
+            <BitOffs>690512672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
+            <Comment> ST_LCLSGeneralEventClass</Comment>
+            <BitSize>960</BitSize>
+            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <Properties>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>690556000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -84666,7 +84833,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690524256</BitOffs>
+            <BitOffs>690565024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -84735,7 +84902,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690524384</BitOffs>
+            <BitOffs>690565152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -84804,7 +84971,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690524512</BitOffs>
+            <BitOffs>690565280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -84873,7 +85040,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690524640</BitOffs>
+            <BitOffs>690565408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -84942,7 +85109,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690524768</BitOffs>
+            <BitOffs>690565536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -85011,30 +85178,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690524896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
-            <Comment> ST_LCLSGeneralEventClass</Comment>
-            <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
-            <Properties>
-              <Property>
-                <Name>tc_no_symbol</Name>
-                <Value>unused</Value>
-              </Property>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>suppress_warning_0</Name>
-                <Value>C0228</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>690555232</BitOffs>
+            <BitOffs>690565664</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -85096,6 +85240,9 @@ Digital outputs</Comment>
       <Deployment/>
       <EventClasses>
         <EventClass>
+          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
+        </EventClass>
+        <EventClass>
           <Type GUID="{11F7FC20-DBF4-4DAF-96C7-1FD6B6156B31}">TcSystemEventClass</Type>
         </EventClass>
         <EventClass>
@@ -85110,9 +85257,6 @@ Digital outputs</Comment>
         <EventClass>
           <Type GUID="{1D0C4BAC-ECF3-4F33-8F20-A12E77AB6387}">Win32EventClass</Type>
         </EventClass>
-        <EventClass>
-          <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
-        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -85121,7 +85265,7 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-03-21T15:15:57</Value>
+          <Value>2024-03-25T15:58:54</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Upgrades lcls-twincat-common-components, 3.3.0 (SLAC) ---> lcls-twincat-common-components, 3.4.0 (SLAC)
- Makes variables for PF1/2K4 and TM1/2K4 cooling flow rate read outs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- FDQ sensors installed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Checked readouts on PLC and in Typhos screens.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-1248
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
