### PR TITLE
IM5K4 PMPS with SP1K4 FZP and SP1K4 ATT removing two targets

### DIFF
--- a/plc-tmo-motion/_Config/NC/Axes/ZonePlateY.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/ZonePlateY.xti
@@ -1324,7 +1324,7 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-05" Offset="-214733.3875" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-9.6"/>
+				<SoftEndMinControl Enable="true" Range="-10.6"/>
 				<SoftEndMaxControl Enable="true" Range="3.8"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1260,7 +1260,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{9DD0BA81-4A92-4D5E-8BD9-E101C02702D4}" Name="tmo_motion" PrjFilePath="..\..\tmo_motion\tmo_motion.plcproj" TmcFilePath="..\..\tmo_motion\tmo_motion.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{FBF78C76-40D4-5363-3BB3-055FDA220D21}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{F34E3290-FEC3-F202-8049-D17B82E29D39}">
 			<Name>tmo_motion Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1260,7 +1260,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{9DD0BA81-4A92-4D5E-8BD9-E101C02702D4}" Name="tmo_motion" PrjFilePath="..\..\tmo_motion\tmo_motion.plcproj" TmcFilePath="..\..\tmo_motion\tmo_motion.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{74DFB229-AB88-4FB7-FECB-9680DBA754CE}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{FBF78C76-40D4-5363-3BB3-055FDA220D21}">
 			<Name>tmo_motion Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/plc-tmo-motion/plc-tmo-motion.tsproj
+++ b/plc-tmo-motion/plc-tmo-motion.tsproj
@@ -9,8 +9,8 @@
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
-					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<TargetSelect TargetId="2">{E008E3C8-6BD9-491C-B673-DC45CC7AA4F1}</TargetSelect>
+					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020003" DongleLevel="50" DongleSystemId="{48EB253C-818D-610A-0B70-DC68309EB817}"/>
 				</Target>
 			</Licenses>

--- a/plc-tmo-motion/tmo_motion/DUTs/ENUM_SolidAttenuator_States.TcDUT
+++ b/plc-tmo-motion/tmo_motion/DUTs/ENUM_SolidAttenuator_States.TcDUT
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <DUT Name="ENUM_SolidAttenuator_States" Id="{a9b56f49-37af-4519-bf3c-f4ee10056eb1}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}
@@ -9,9 +9,9 @@ TYPE ENUM_SolidAttenuator_States :
     OUT := 1,
     Target1 := 2,
     Target2 := 3,
-    Target3 := 4,
-    Target4 := 5,
-    Target5 := 6
+    Target3 := 4
+//    Target4 := 5,
+//   Target5 := 6
 
 )UINT;
 END_TYPE

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -38,34 +38,7 @@ fbStateSetup(StPositionState:=fbIM5K4.stPower, fposition:=-44.23, sPmpsState := 
 fbStateSetup(StPositionState:=fbIM5K4.stYag1, fposition:=-68.23, sPmpsState := 'IM5K4:PPM-YAG1');
 fbStateSetup(StPositionState:=fbIM5K4.stYag2, fposition:=-94.24, sPmpsState := 'IM5K4:PPM-YAG2');
 
-{*//fbIM5K4.stOut.fPosition := -5.13;
-fbIM5K4.stOut.fVelocity := fStartupVelo;
-fbIM5K4.stOut.bUseRawCounts := FALSE;
-fbIM5K4.stOut.bValid := TRUE;
-fbIM5K4.stOut.bMoveOk := TRUE;
-fbIM5K4.stOut.stPMPS.sPmpsState := 'IM5K4:PPM-OUT';
-
-//fbIM5K4.stPower.fPosition := -44.23;
-fbIM5K4.stPower.fVelocity := fStartupVelo;
-fbIM5K4.stPower.bUseRawCounts := FALSE;
-fbIM5K4.stPower.bValid := TRUE;
-fbIM5K4.stPower.bMoveOk := TRUE;
-fbIM5K4.stPower.stPMPS.sPmpsState := 'IM5K4:PPM-POWERMETER';
-
-//fbIM5K4.stYag1.fPosition := -68.23;
-fbIM5K4.stYag1.fVelocity := fStartupVelo;
-fbIM5K4.stYag1.bUseRawCounts := FALSE;
-fbIM5K4.stYag1.bMoveOk := TRUE;
-fbIM5K4.stYag1.bValid := TRUE;
-
-
-//fbIM5K4.stYag2.fPosition := -94.24;
-fbIM5K4.stYag2.fVelocity := fStartupVelo;
-fbIM5K4.stYag2.bUseRawCounts := FALSE;
-fbIM5K4.stYag2.bMoveOk := TRUE;
-fbIM5K4.stYag2.bValid := TRUE;
-
-*}
+//IM5K4 is vetoed by PF1K4
 CASE GVL_TcGVL.ePF1K4State OF
     E_WFS_STATES.TARGET1, E_WFS_STATES.TARGET2, E_WFS_STATES.TARGET3, E_WFS_STATES.TARGET4, E_WFS_STATES.TARGET5 :
         // Known state targets: allow less strict pmps
@@ -76,15 +49,18 @@ ELSE
     fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1';
     fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2';
 END_CASE
-{*
-IF NOT bInit THEN
-   bInit := TRUE;
-   fbIM5K4.stOut.fPosition := -5.13;
-   fbIM5K4.stPower.fPosition := -44.23;
-   fbIM5K4.stYag1.fPosition := -68.23;
-   fbIM5K4.stYag2.fPosition := -94.24;
-END_IF
-*}
+//IM5K4 is vetoed by SP1K4-FZP
+CASE GVL_TcGVL.eSP1K4FZP OF
+    ENUM_ZonePlate_States.FZP290_1, ENUM_ZonePlate_States.FZP290_2, ENUM_ZonePlate_States.FZP410_1, ENUM_ZonePlate_States.FZP410_2, ENUM_ZonePlate_States.FZP460_1, ENUM_ZonePlate_States.FZP460_2, ENUM_ZonePlate_States.FZP530_1,
+    ENUM_ZonePlate_States.FZP530_2, ENUM_ZonePlate_States.FZP750_1, ENUM_ZonePlate_States.FZP750_2, ENUM_ZonePlate_States.FZP860_1, ENUM_ZonePlate_States.FZP860_2, ENUM_ZonePlate_States.FZP860_3:
+        // Known state targets: allow less strict pmps
+        fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1_SP1K4_IN';
+        fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2_SP1K4_IN';
+ELSE
+    // Out, Unknown, or an unexpected state: full pmps
+    fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1';
+    fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2';
+END_CASE
 
 fbIM5K4(
     fbArbiter := fbArbiter,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_IM5K4_PPM.TcPOU
@@ -52,7 +52,7 @@ END_CASE
 //IM5K4 is vetoed by SP1K4-FZP
 CASE GVL_TcGVL.eSP1K4FZP OF
     ENUM_ZonePlate_States.FZP290_1, ENUM_ZonePlate_States.FZP290_2, ENUM_ZonePlate_States.FZP410_1, ENUM_ZonePlate_States.FZP410_2, ENUM_ZonePlate_States.FZP460_1, ENUM_ZonePlate_States.FZP460_2, ENUM_ZonePlate_States.FZP530_1,
-    ENUM_ZonePlate_States.FZP530_2, ENUM_ZonePlate_States.FZP750_1, ENUM_ZonePlate_States.FZP750_2, ENUM_ZonePlate_States.FZP860_1, ENUM_ZonePlate_States.FZP860_2, ENUM_ZonePlate_States.FZP860_3:
+    ENUM_ZonePlate_States.FZP530_2, ENUM_ZonePlate_States.FZP750_1, ENUM_ZonePlate_States.FZP750_2, ENUM_ZonePlate_States.FZP860_1, ENUM_ZonePlate_States.FZP860_2, ENUM_ZonePlate_States.FZP860_3, ENUM_ZonePlate_States.Yag:
         // Known state targets: allow less strict pmps
         fbIM5K4.stYag1.stPMPS.sPmpsState := 'IM5K4:PPM-YAG1_SP1K4_IN';
         fbIM5K4.stYag2.stPMPS.sPmpsState := 'IM5K4:PPM-YAG2_SP1K4_IN';

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
@@ -54,8 +54,8 @@ fbMotionLI2K4X(stMotionStage:=Main.M46);
 //LI2K4 2DPMPS
 fbStateSetup(stPositionState:=stDefault, bSetDefault:=TRUE);
 fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.OUT], fDelta := 0.5, sName := 'OUT', fPosition:=-0.75);
-
-{*aLI2K4XStates[ENUM_LaserCoupling_States.OUT].nMoveOrder := 1;
+{*
+aLI2K4XStates[ENUM_LaserCoupling_States.OUT].nMoveOrder := 1;
 aLI2K4YStates[ENUM_LaserCoupling_States.OUT].nMoveOrder := 2;
 aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1].nMoveOrder := 2;
 aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1].nMoveOrder := 1; *}

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -86,7 +86,7 @@ VAR
     att_enumGet: ENUM_SolidAttenuator_States;
     fbATTSetup: FB_StateSetupHelper;
     fbATTDefault: ST_PositionState := (
-        fDelta:=0.5,
+        fDelta:=1.5,
         fVelocity:=1,
 //        bMoveOk:=TRUE,
         bValid:=TRUE
@@ -345,28 +345,31 @@ fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target2], sN
 
 fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target3], sName:='TARGET3', fPosition:=71);
 fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target3], sName:='TARGET3', fPosition:=-1.9);
-
+{*
 fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target4], sName:='TARGET4', fPosition:=88);
 fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target4], sName:='TARGET4', fPosition:=-1.9);
 
 fbATTSetup(stPositionState:=aATTXStates[ENUM_SolidAttenuator_States.Target5], sName:='TARGET5', fPosition:=107);
-fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target5], sName:='TARGET5', fPosition:=-1.9);
+fbATTSetup(stPositionState:=aATTYStates[ENUM_SolidAttenuator_States.Target5], sName:='TARGET5', fPosition:=-1.9); *}
 
 aATTXStates[ENUM_SolidAttenuator_States.OUT].bMoveOk := TRUE;
 aATTXStates[ENUM_SolidAttenuator_States.Target1].bMoveOk := bPF1K4Out;
 aATTXStates[ENUM_SolidAttenuator_States.Target2].bMoveOk := bPF1K4Out;
 aATTXStates[ENUM_SolidAttenuator_States.Target3].bMoveOk := bPF1K4Out;
+{*
 aATTXStates[ENUM_SolidAttenuator_States.Target4].bMoveOk := bPF1K4Out;
 aATTXStates[ENUM_SolidAttenuator_States.Target5].bMoveOk := bPF1K4Out;
+*}
 
 aATTYStates[ENUM_SolidAttenuator_States.OUT].bMoveOk := TRUE;
 aATTYStates[ENUM_SolidAttenuator_States.Target1].bMoveOk := bPF1K4Out;
 aATTYStates[ENUM_SolidAttenuator_States.Target2].bMoveOk := bPF1K4Out;
 aATTYStates[ENUM_SolidAttenuator_States.Target3].bMoveOk := bPF1K4Out;
+{*
 aATTYStates[ENUM_SolidAttenuator_States.Target4].bMoveOk := bPF1K4Out;
 aATTYStates[ENUM_SolidAttenuator_States.Target5].bMoveOk := bPF1K4Out;
 
-
+*}
 
 
 
@@ -374,8 +377,8 @@ aATTXStates[ENUM_SolidAttenuator_States.OUT].stPMPS.sPmpsState := 'SP1K4:ATT-OUT
 aATTXStates[ENUM_SolidAttenuator_States.Target1].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET1';
 aATTXStates[ENUM_SolidAttenuator_States.Target2].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET2';
 aATTXStates[ENUM_SolidAttenuator_States.Target3].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET3';
-aATTXStates[ENUM_SolidAttenuator_States.Target4].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET4';
-aATTXStates[ENUM_SolidAttenuator_States.Target5].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET5';
+//aATTXStates[ENUM_SolidAttenuator_States.Target4].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET4';
+//aATTXStates[ENUM_SolidAttenuator_States.Target5].stPMPS.sPmpsState := 'SP1K4:ATT-TARGET5';
 
 fbATTStates(
     stMotionStage1:=Main.M33,

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -216,7 +216,7 @@
       <Resolution>lcls-twincat-common-components, 3.4.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 4.0.9 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, 4.1.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.2.1 (SLAC - LCLS)</Resolution>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{74DFB229-AB88-4FB7-FECB-9680DBA754CE}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FBF78C76-40D4-5363-3BB3-055FDA220D21}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -181,31 +181,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86538800</GetCodeOffs>
+        <GetCodeOffs>86539112</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86538864</GetCodeOffs>
+        <GetCodeOffs>86539176</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86538880</GetCodeOffs>
+        <GetCodeOffs>86539192</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86538848</GetCodeOffs>
+        <GetCodeOffs>86539160</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86538872</GetCodeOffs>
+        <GetCodeOffs>86539184</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1427,15 +1427,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86538680</GetCodeOffs>
-        <SetCodeOffs>86538728</SetCodeOffs>
+        <GetCodeOffs>86538992</GetCodeOffs>
+        <SetCodeOffs>86539040</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86538752</GetCodeOffs>
-        <SetCodeOffs>86538776</SetCodeOffs>
+        <GetCodeOffs>86539064</GetCodeOffs>
+        <SetCodeOffs>86539088</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1698,25 +1698,25 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>86538976</GetCodeOffs>
+        <GetCodeOffs>86539288</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86538936</GetCodeOffs>
+        <GetCodeOffs>86539248</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539112</GetCodeOffs>
+        <GetCodeOffs>86539424</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539032</GetCodeOffs>
+        <GetCodeOffs>86539344</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1728,7 +1728,7 @@
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539120</GetCodeOffs>
+        <GetCodeOffs>86539432</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -2299,7 +2299,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86539176</GetCodeOffs>
+        <GetCodeOffs>86539488</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -19640,14 +19640,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86544992</GetCodeOffs>
+        <GetCodeOffs>86545304</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86544896</GetCodeOffs>
+        <GetCodeOffs>86545208</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -20743,7 +20743,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86545144</GetCodeOffs>
+        <GetCodeOffs>86545456</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -21402,7 +21402,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86545256</GetCodeOffs>
+        <GetCodeOffs>86545568</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -48810,7 +48810,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Name>
-      <BitSize>27456</BitSize>
+      <BitSize>27520</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -48988,6 +48988,18 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>25920</BitSize>
         <BitOffs>1536</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>bLockBounds</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>27456</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bErrorMsg</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>27464</BitOffs>
+      </SubItem>
       <Action>
         <Name>SetEnables</Name>
       </Action>
@@ -49009,7 +49021,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Name>
-      <BitSize>135360</BitSize>
+      <BitSize>135552</BitSize>
       <SubItem>
         <Name>astMotionStage</Name>
         <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
@@ -49241,26 +49253,26 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>3</Elements>
         </ArrayInfo>
         <Comment> The individual state limit function blocks</Comment>
-        <BitSize>82368</BitSize>
+        <BitSize>82560</BitSize>
         <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffMaint</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>83456</BitOffs>
+        <BitOffs>83648</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffProgrammerError</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>109376</BitOffs>
+        <BitOffs>109568</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nIter</Name>
         <Type>DINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>135296</BitOffs>
+        <BitOffs>135488</BitOffs>
       </SubItem>
       <Action>
         <Name>DoLimits</Name>
@@ -49812,7 +49824,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Name>
-      <BitSize>682752</BitSize>
+      <BitSize>682944</BitSize>
       <SubItem>
         <Name>astMotionStageMax</Name>
         <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
@@ -50054,26 +50066,26 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbStatePMPSEnables</Name>
         <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Type>
-        <BitSize>135360</BitSize>
+        <BitSize>135552</BitSize>
         <BitOffs>326336</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMiscStatesErrorFFO</Name>
         <Type Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Type>
         <BitSize>106944</BitSize>
-        <BitOffs>461696</BitOffs>
+        <BitOffs>461888</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbPerMotorFFO</Name>
         <Type Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Type>
         <BitSize>114048</BitSize>
-        <BitOffs>568640</BitOffs>
+        <BitOffs>568832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>eStatePMPSStatus</Name>
         <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
         <BitSize>16</BitSize>
-        <BitOffs>682688</BitOffs>
+        <BitOffs>682880</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -50084,7 +50096,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
-      <BitSize>1548160</BitSize>
+      <BitSize>1548352</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -50343,7 +50355,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbPMPSCore</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
-        <BitSize>682752</BitSize>
+        <BitSize>682944</BitSize>
         <BitOffs>620608</BitOffs>
       </SubItem>
       <SubItem>
@@ -50354,7 +50366,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>3</Elements>
         </ArrayInfo>
         <BitSize>77760</BitSize>
-        <BitOffs>1303360</BitOffs>
+        <BitOffs>1303552</BitOffs>
       </SubItem>
       <SubItem>
         <Name>astPositionStateMax</Name>
@@ -50368,7 +50380,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>167040</BitSize>
-        <BitOffs>1381120</BitOffs>
+        <BitOffs>1381312</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -50779,7 +50791,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_common_components">FB_REF</Name>
-      <BitSize>2001024</BitSize>
+      <BitSize>2001216</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -50997,7 +51009,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbStates</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
-        <BitSize>1548160</BitSize>
+        <BitSize>1548352</BitSize>
         <BitOffs>339776</BitOffs>
         <Properties>
           <Property>
@@ -51017,19 +51029,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>55680</BitSize>
-        <BitOffs>1887936</BitOffs>
+        <BitOffs>1888128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbArrCheckWrite</Name>
         <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
         <BitSize>55936</BitSize>
-        <BitOffs>1943616</BitOffs>
+        <BitOffs>1943808</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbLaser</Name>
         <Type Namespace="lcls_twincat_common_components">FB_REF_Laser</Type>
         <BitSize>1344</BitSize>
-        <BitOffs>1999552</BitOffs>
+        <BitOffs>1999744</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -51041,7 +51053,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fDelta</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2000896</BitOffs>
+        <BitOffs>2001088</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -51050,7 +51062,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2000960</BitOffs>
+        <BitOffs>2001152</BitOffs>
         <Default>
           <Value>10</Value>
         </Default>
@@ -51965,7 +51977,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_common_components">FB_PPM</Name>
-      <BitSize>2588864</BitSize>
+      <BitSize>2589056</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -52225,7 +52237,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbStates</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
-        <BitSize>1548160</BitSize>
+        <BitSize>1548352</BitSize>
         <BitOffs>347264</BitOffs>
         <Properties>
           <Property>
@@ -52245,19 +52257,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>55680</BitSize>
-        <BitOffs>1895424</BitOffs>
+        <BitOffs>1895616</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbArrCheckWrite</Name>
         <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
         <BitSize>55936</BitSize>
-        <BitOffs>1951104</BitOffs>
+        <BitOffs>1951296</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbPowerMeter</Name>
         <Type Namespace="lcls_twincat_common_components">FB_PPM_PowerMeter</Type>
         <BitSize>579392</BitSize>
-        <BitOffs>2007040</BitOffs>
+        <BitOffs>2007232</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -52269,7 +52281,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbGige</Name>
         <Type Namespace="lcls_twincat_common_components">FB_PPM_Gige</Type>
         <BitSize>1344</BitSize>
-        <BitOffs>2586432</BitOffs>
+        <BitOffs>2586624</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -52281,7 +52293,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbFlowMeter</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
         <BitSize>512</BitSize>
-        <BitOffs>2587776</BitOffs>
+        <BitOffs>2587968</BitOffs>
         <Default>
           <SubItem>
             <Name>.iTermBits</Name>
@@ -52307,7 +52319,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbYagThermoCouple</Name>
         <Type Namespace="LCLS_General">FB_ThermoCouple</Type>
         <BitSize>256</BitSize>
-        <BitOffs>2588288</BitOffs>
+        <BitOffs>2588480</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -52319,7 +52331,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbFlowSwitch</Name>
         <Type Namespace="lcls_twincat_common_components">FB_XTES_Flowswitch</Type>
         <BitSize>128</BitSize>
-        <BitOffs>2588544</BitOffs>
+        <BitOffs>2588736</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -52332,7 +52344,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Type>LREAL</Type>
         <Comment> State defaults if not provided</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>2588672</BitOffs>
+        <BitOffs>2588864</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -52341,7 +52353,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2588736</BitOffs>
+        <BitOffs>2588928</BitOffs>
         <Default>
           <Value>200</Value>
         </Default>
@@ -52350,7 +52362,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDecel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2588800</BitOffs>
+        <BitOffs>2588992</BitOffs>
         <Default>
           <Value>25</Value>
         </Default>
@@ -52394,7 +52406,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_common_components">FB_LIC</Name>
-      <BitSize>2007168</BitSize>
+      <BitSize>2007360</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -52638,7 +52650,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbStates</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
-        <BitSize>1548160</BitSize>
+        <BitSize>1548352</BitSize>
         <BitOffs>347200</BitOffs>
         <Properties>
           <Property>
@@ -52658,20 +52670,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>55680</BitSize>
-        <BitOffs>1895360</BitOffs>
+        <BitOffs>1895552</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbArrCheckWrite</Name>
         <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
         <BitSize>55936</BitSize>
-        <BitOffs>1951040</BitOffs>
+        <BitOffs>1951232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fDelta</Name>
         <Type>LREAL</Type>
         <Comment> State defaults if not provided</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>2006976</BitOffs>
+        <BitOffs>2007168</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -52680,7 +52692,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2007040</BitOffs>
+        <BitOffs>2007232</BitOffs>
         <Default>
           <Value>200</Value>
         </Default>
@@ -52689,7 +52701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDecel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2007104</BitOffs>
+        <BitOffs>2007296</BitOffs>
         <Default>
           <Value>25</Value>
         </Default>
@@ -52881,7 +52893,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_common_components">FB_WFS</Name>
-      <BitSize>2342848</BitSize>
+      <BitSize>2343040</BitSize>
       <SubItem>
         <Name>stYStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -53170,7 +53182,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbStates</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Type>
-        <BitSize>1548160</BitSize>
+        <BitSize>1548352</BitSize>
         <BitOffs>681728</BitOffs>
         <Properties>
           <Property>
@@ -53190,19 +53202,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>55680</BitSize>
-        <BitOffs>2229888</BitOffs>
+        <BitOffs>2230080</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbArrCheckWrite</Name>
         <Type Namespace="lcls_twincat_common_components">FB_CheckPositionStateWrite</Type>
         <BitSize>55936</BitSize>
-        <BitOffs>2285568</BitOffs>
+        <BitOffs>2285760</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbThermoCouple1</Name>
         <Type Namespace="LCLS_General">FB_TempSensor</Type>
         <BitSize>256</BitSize>
-        <BitOffs>2341504</BitOffs>
+        <BitOffs>2341696</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -53214,7 +53226,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbThermoCouple2</Name>
         <Type Namespace="LCLS_General">FB_TempSensor</Type>
         <BitSize>256</BitSize>
-        <BitOffs>2341760</BitOffs>
+        <BitOffs>2341952</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -53226,7 +53238,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbFlowSwitch</Name>
         <Type Namespace="lcls_twincat_common_components">FB_XTES_Flowswitch</Type>
         <BitSize>128</BitSize>
-        <BitOffs>2342016</BitOffs>
+        <BitOffs>2342208</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -53238,7 +53250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbFlowMeter</Name>
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
         <BitSize>512</BitSize>
-        <BitOffs>2342144</BitOffs>
+        <BitOffs>2342336</BitOffs>
         <Default>
           <SubItem>
             <Name>.iTermBits</Name>
@@ -53265,7 +53277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Type>LREAL</Type>
         <Comment> State defaults if not provided</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>2342656</BitOffs>
+        <BitOffs>2342848</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -53274,7 +53286,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2342720</BitOffs>
+        <BitOffs>2342912</BitOffs>
         <Default>
           <Value>200</Value>
         </Default>
@@ -53283,7 +53295,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDecel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>2342784</BitOffs>
+        <BitOffs>2342976</BitOffs>
         <Default>
           <Value>25</Value>
         </Default>
@@ -58514,7 +58526,7 @@ Digital outputs</Comment>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</Name>
-      <BitSize>1548416</BitSize>
+      <BitSize>1548608</BitSize>
       <SubItem>
         <Name>stMotionStage1</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -58849,7 +58861,7 @@ Digital outputs</Comment>
       <SubItem>
         <Name>fbPMPSCore</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
-        <BitSize>682752</BitSize>
+        <BitSize>682944</BitSize>
         <BitOffs>620864</BitOffs>
       </SubItem>
       <SubItem>
@@ -58860,7 +58872,7 @@ Digital outputs</Comment>
           <Elements>3</Elements>
         </ArrayInfo>
         <BitSize>77760</BitSize>
-        <BitOffs>1303616</BitOffs>
+        <BitOffs>1303808</BitOffs>
       </SubItem>
       <SubItem>
         <Name>astPositionStateMax</Name>
@@ -58874,7 +58886,7 @@ Digital outputs</Comment>
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>167040</BitSize>
-        <BitOffs>1381376</BitOffs>
+        <BitOffs>1381568</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -58906,14 +58918,8 @@ Digital outputs</Comment>
       <EnumInfo>
         <Text>Target3</Text>
         <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
+        <Comment>    Target4 := 5,
+   Target5 := 6</Comment>
       </EnumInfo>
       <Properties>
         <Property>
@@ -58957,7 +58963,7 @@ Digital outputs</Comment>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</Name>
-      <BitSize>1548288</BitSize>
+      <BitSize>1548480</BitSize>
       <SubItem>
         <Name>stMotionStage1</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -59254,7 +59260,7 @@ Digital outputs</Comment>
       <SubItem>
         <Name>fbPMPSCore</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
-        <BitSize>682752</BitSize>
+        <BitSize>682944</BitSize>
         <BitOffs>620736</BitOffs>
       </SubItem>
       <SubItem>
@@ -59265,7 +59271,7 @@ Digital outputs</Comment>
           <Elements>3</Elements>
         </ArrayInfo>
         <BitSize>77760</BitSize>
-        <BitOffs>1303488</BitOffs>
+        <BitOffs>1303680</BitOffs>
       </SubItem>
       <SubItem>
         <Name>astPositionStateMax</Name>
@@ -59279,7 +59285,7 @@ Digital outputs</Comment>
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>167040</BitSize>
-        <BitOffs>1381248</BitOffs>
+        <BitOffs>1381440</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -60162,8 +60168,8 @@ Digital outputs</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86554200</GetCodeOffs>
-        <SetCodeOffs>86554216</SetCodeOffs>
+        <GetCodeOffs>86554512</GetCodeOffs>
+        <SetCodeOffs>86554528</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -61340,31 +61346,31 @@ Digital outputs</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86553328</GetCodeOffs>
+        <GetCodeOffs>86553640</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86553392</GetCodeOffs>
+        <GetCodeOffs>86553704</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86553400</GetCodeOffs>
+        <GetCodeOffs>86553712</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86553376</GetCodeOffs>
+        <GetCodeOffs>86553688</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86553416</GetCodeOffs>
+        <GetCodeOffs>86553728</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -78205,7 +78211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641165248</BitOffs>
+            <BitOffs>641165440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -78218,7 +78224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173184</BitOffs>
+            <BitOffs>641173376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -78231,7 +78237,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173192</BitOffs>
+            <BitOffs>641173384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -78244,7 +78250,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173200</BitOffs>
+            <BitOffs>641173392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -78267,7 +78273,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173216</BitOffs>
+            <BitOffs>641173408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -78280,7 +78286,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173248</BitOffs>
+            <BitOffs>641173440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -78293,7 +78299,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173312</BitOffs>
+            <BitOffs>641173504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -78306,7 +78312,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173328</BitOffs>
+            <BitOffs>641173520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -78318,7 +78324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641191168</BitOffs>
+            <BitOffs>641191360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -78331,7 +78337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199104</BitOffs>
+            <BitOffs>641199296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -78344,7 +78350,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199112</BitOffs>
+            <BitOffs>641199304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -78357,7 +78363,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199120</BitOffs>
+            <BitOffs>641199312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -78380,7 +78386,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199136</BitOffs>
+            <BitOffs>641199328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -78393,7 +78399,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199168</BitOffs>
+            <BitOffs>641199360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -78406,7 +78412,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199232</BitOffs>
+            <BitOffs>641199424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -78419,7 +78425,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199248</BitOffs>
+            <BitOffs>641199440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -78431,7 +78437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641217088</BitOffs>
+            <BitOffs>641217280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -78444,7 +78450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225024</BitOffs>
+            <BitOffs>641225216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -78457,7 +78463,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225032</BitOffs>
+            <BitOffs>641225224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -78470,7 +78476,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225040</BitOffs>
+            <BitOffs>641225232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -78493,7 +78499,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225056</BitOffs>
+            <BitOffs>641225248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -78506,7 +78512,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225088</BitOffs>
+            <BitOffs>641225280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -78519,7 +78525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225152</BitOffs>
+            <BitOffs>641225344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -78532,7 +78538,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225168</BitOffs>
+            <BitOffs>641225360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -78545,7 +78551,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641520896</BitOffs>
+            <BitOffs>641521088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78557,7 +78563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641641856</BitOffs>
+            <BitOffs>641642048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -78569,7 +78575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643271808</BitOffs>
+            <BitOffs>643272192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -78582,7 +78588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279744</BitOffs>
+            <BitOffs>643280128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -78595,7 +78601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279752</BitOffs>
+            <BitOffs>643280136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -78608,7 +78614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279760</BitOffs>
+            <BitOffs>643280144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -78631,7 +78637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279776</BitOffs>
+            <BitOffs>643280160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -78644,7 +78650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279808</BitOffs>
+            <BitOffs>643280192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -78657,7 +78663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279872</BitOffs>
+            <BitOffs>643280256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -78670,7 +78676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643279888</BitOffs>
+            <BitOffs>643280272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -78682,7 +78688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643297728</BitOffs>
+            <BitOffs>643298112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -78695,7 +78701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305664</BitOffs>
+            <BitOffs>643306048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -78708,7 +78714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305672</BitOffs>
+            <BitOffs>643306056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -78721,7 +78727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305680</BitOffs>
+            <BitOffs>643306064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -78744,7 +78750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305696</BitOffs>
+            <BitOffs>643306080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -78757,7 +78763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305728</BitOffs>
+            <BitOffs>643306112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -78770,7 +78776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305792</BitOffs>
+            <BitOffs>643306176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -78783,7 +78789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643305808</BitOffs>
+            <BitOffs>643306192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -78795,7 +78801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643323648</BitOffs>
+            <BitOffs>643324032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -78808,7 +78814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331584</BitOffs>
+            <BitOffs>643331968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -78821,7 +78827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331592</BitOffs>
+            <BitOffs>643331976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -78834,7 +78840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331600</BitOffs>
+            <BitOffs>643331984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -78857,7 +78863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331616</BitOffs>
+            <BitOffs>643332000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -78870,7 +78876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331648</BitOffs>
+            <BitOffs>643332032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -78883,7 +78889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331712</BitOffs>
+            <BitOffs>643332096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -78896,7 +78902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331728</BitOffs>
+            <BitOffs>643332112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -78908,7 +78914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643627200</BitOffs>
+            <BitOffs>643627584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -78927,7 +78933,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643819656</BitOffs>
+            <BitOffs>643820040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -78939,7 +78945,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643819664</BitOffs>
+            <BitOffs>643820048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -78951,7 +78957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643819672</BitOffs>
+            <BitOffs>643820056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -78963,7 +78969,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643819680</BitOffs>
+            <BitOffs>643820064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -78976,7 +78982,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643819968</BitOffs>
+            <BitOffs>643820352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -78989,7 +78995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644206784</BitOffs>
+            <BitOffs>644207168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
@@ -79002,7 +79008,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644207936</BitOffs>
+            <BitOffs>644208320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -79021,7 +79027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208584</BitOffs>
+            <BitOffs>644208968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -79033,7 +79039,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208592</BitOffs>
+            <BitOffs>644208976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -79045,7 +79051,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208600</BitOffs>
+            <BitOffs>644208984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -79057,7 +79063,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208608</BitOffs>
+            <BitOffs>644208992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowSwitch.bFlowOk</Name>
@@ -79077,7 +79083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208704</BitOffs>
+            <BitOffs>644209088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79089,7 +79095,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644326464</BitOffs>
+            <BitOffs>644326848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -79101,7 +79107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645956416</BitOffs>
+            <BitOffs>645956992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -79114,7 +79120,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964352</BitOffs>
+            <BitOffs>645964928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -79127,7 +79133,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964360</BitOffs>
+            <BitOffs>645964936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -79140,7 +79146,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964368</BitOffs>
+            <BitOffs>645964944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -79163,7 +79169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964384</BitOffs>
+            <BitOffs>645964960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -79176,7 +79182,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964416</BitOffs>
+            <BitOffs>645964992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -79189,7 +79195,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964480</BitOffs>
+            <BitOffs>645965056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -79202,7 +79208,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964496</BitOffs>
+            <BitOffs>645965072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -79214,7 +79220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645982336</BitOffs>
+            <BitOffs>645982912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -79227,7 +79233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990272</BitOffs>
+            <BitOffs>645990848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -79240,7 +79246,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990280</BitOffs>
+            <BitOffs>645990856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -79253,7 +79259,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990288</BitOffs>
+            <BitOffs>645990864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -79276,7 +79282,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990304</BitOffs>
+            <BitOffs>645990880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -79289,7 +79295,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990336</BitOffs>
+            <BitOffs>645990912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -79302,7 +79308,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990400</BitOffs>
+            <BitOffs>645990976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -79315,7 +79321,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990416</BitOffs>
+            <BitOffs>645990992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -79327,7 +79333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646008256</BitOffs>
+            <BitOffs>646008832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -79340,7 +79346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016192</BitOffs>
+            <BitOffs>646016768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -79353,7 +79359,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016200</BitOffs>
+            <BitOffs>646016776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -79366,7 +79372,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016208</BitOffs>
+            <BitOffs>646016784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -79389,7 +79395,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016224</BitOffs>
+            <BitOffs>646016800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -79402,7 +79408,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016256</BitOffs>
+            <BitOffs>646016832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -79415,7 +79421,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016320</BitOffs>
+            <BitOffs>646016896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -79428,7 +79434,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016336</BitOffs>
+            <BitOffs>646016912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -79440,7 +79446,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646311808</BitOffs>
+            <BitOffs>646312384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -79459,7 +79465,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504264</BitOffs>
+            <BitOffs>646504840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -79471,7 +79477,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504272</BitOffs>
+            <BitOffs>646504848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -79483,7 +79489,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504280</BitOffs>
+            <BitOffs>646504856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -79495,7 +79501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504288</BitOffs>
+            <BitOffs>646504864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -79508,7 +79514,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504576</BitOffs>
+            <BitOffs>646505152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -79521,7 +79527,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646891392</BitOffs>
+            <BitOffs>646891968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
@@ -79534,7 +79540,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646892544</BitOffs>
+            <BitOffs>646893120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -79553,7 +79559,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893192</BitOffs>
+            <BitOffs>646893768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -79565,7 +79571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893200</BitOffs>
+            <BitOffs>646893776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -79577,7 +79583,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893208</BitOffs>
+            <BitOffs>646893784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -79589,7 +79595,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893216</BitOffs>
+            <BitOffs>646893792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowSwitch.bFlowOk</Name>
@@ -79609,7 +79615,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893312</BitOffs>
+            <BitOffs>646893888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79621,7 +79627,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647011072</BitOffs>
+            <BitOffs>647011648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -79633,7 +79639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648641024</BitOffs>
+            <BitOffs>648641792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -79646,7 +79652,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648648960</BitOffs>
+            <BitOffs>648649728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -79659,7 +79665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648648968</BitOffs>
+            <BitOffs>648649736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -79672,7 +79678,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648648976</BitOffs>
+            <BitOffs>648649744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -79695,7 +79701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648648992</BitOffs>
+            <BitOffs>648649760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -79708,7 +79714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649024</BitOffs>
+            <BitOffs>648649792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -79721,7 +79727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649088</BitOffs>
+            <BitOffs>648649856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -79734,7 +79740,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649104</BitOffs>
+            <BitOffs>648649872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -79746,7 +79752,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648666944</BitOffs>
+            <BitOffs>648667712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -79759,7 +79765,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648674880</BitOffs>
+            <BitOffs>648675648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -79772,7 +79778,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648674888</BitOffs>
+            <BitOffs>648675656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -79785,7 +79791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648674896</BitOffs>
+            <BitOffs>648675664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -79808,7 +79814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648674912</BitOffs>
+            <BitOffs>648675680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -79821,7 +79827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648674944</BitOffs>
+            <BitOffs>648675712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -79834,7 +79840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675008</BitOffs>
+            <BitOffs>648675776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -79847,7 +79853,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675024</BitOffs>
+            <BitOffs>648675792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -79859,7 +79865,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648692864</BitOffs>
+            <BitOffs>648693632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -79872,7 +79878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700800</BitOffs>
+            <BitOffs>648701568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -79885,7 +79891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700808</BitOffs>
+            <BitOffs>648701576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -79898,7 +79904,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700816</BitOffs>
+            <BitOffs>648701584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -79921,7 +79927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700832</BitOffs>
+            <BitOffs>648701600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -79934,7 +79940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700864</BitOffs>
+            <BitOffs>648701632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -79947,7 +79953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700928</BitOffs>
+            <BitOffs>648701696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -79960,7 +79966,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648700944</BitOffs>
+            <BitOffs>648701712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -79972,7 +79978,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648996416</BitOffs>
+            <BitOffs>648997184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -79991,7 +79997,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649188872</BitOffs>
+            <BitOffs>649189640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -80003,7 +80009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649188880</BitOffs>
+            <BitOffs>649189648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -80015,7 +80021,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649188888</BitOffs>
+            <BitOffs>649189656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -80027,7 +80033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649188896</BitOffs>
+            <BitOffs>649189664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -80040,7 +80046,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189184</BitOffs>
+            <BitOffs>649189952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -80053,7 +80059,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649576000</BitOffs>
+            <BitOffs>649576768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
@@ -80066,7 +80072,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577152</BitOffs>
+            <BitOffs>649577920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -80085,7 +80091,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577800</BitOffs>
+            <BitOffs>649578568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -80097,7 +80103,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577808</BitOffs>
+            <BitOffs>649578576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -80109,7 +80115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577816</BitOffs>
+            <BitOffs>649578584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -80121,7 +80127,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577824</BitOffs>
+            <BitOffs>649578592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowSwitch.bFlowOk</Name>
@@ -80141,7 +80147,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577920</BitOffs>
+            <BitOffs>649578688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80153,7 +80159,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649695680</BitOffs>
+            <BitOffs>649696448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -80165,7 +80171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651325632</BitOffs>
+            <BitOffs>651326592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -80178,7 +80184,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333568</BitOffs>
+            <BitOffs>651334528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -80191,7 +80197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333576</BitOffs>
+            <BitOffs>651334536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -80204,7 +80210,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333584</BitOffs>
+            <BitOffs>651334544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -80227,7 +80233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333600</BitOffs>
+            <BitOffs>651334560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -80240,7 +80246,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333632</BitOffs>
+            <BitOffs>651334592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -80253,7 +80259,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333696</BitOffs>
+            <BitOffs>651334656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -80266,7 +80272,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651333712</BitOffs>
+            <BitOffs>651334672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -80278,7 +80284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651351552</BitOffs>
+            <BitOffs>651352512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -80291,7 +80297,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359488</BitOffs>
+            <BitOffs>651360448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -80304,7 +80310,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359496</BitOffs>
+            <BitOffs>651360456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -80317,7 +80323,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359504</BitOffs>
+            <BitOffs>651360464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -80340,7 +80346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359520</BitOffs>
+            <BitOffs>651360480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -80353,7 +80359,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359552</BitOffs>
+            <BitOffs>651360512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -80366,7 +80372,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359616</BitOffs>
+            <BitOffs>651360576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -80379,7 +80385,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651359632</BitOffs>
+            <BitOffs>651360592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -80391,7 +80397,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651377472</BitOffs>
+            <BitOffs>651378432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -80404,7 +80410,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385408</BitOffs>
+            <BitOffs>651386368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -80417,7 +80423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385416</BitOffs>
+            <BitOffs>651386376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -80430,7 +80436,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385424</BitOffs>
+            <BitOffs>651386384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -80453,7 +80459,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385440</BitOffs>
+            <BitOffs>651386400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -80466,7 +80472,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385472</BitOffs>
+            <BitOffs>651386432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -80479,7 +80485,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385536</BitOffs>
+            <BitOffs>651386496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -80492,7 +80498,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651385552</BitOffs>
+            <BitOffs>651386512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -80504,7 +80510,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651681024</BitOffs>
+            <BitOffs>651681984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -80523,7 +80529,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651873480</BitOffs>
+            <BitOffs>651874440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -80535,7 +80541,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651873488</BitOffs>
+            <BitOffs>651874448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -80547,7 +80553,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651873496</BitOffs>
+            <BitOffs>651874456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -80559,7 +80565,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651873504</BitOffs>
+            <BitOffs>651874464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -80572,7 +80578,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651873792</BitOffs>
+            <BitOffs>651874752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -80585,7 +80591,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652260608</BitOffs>
+            <BitOffs>652261568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
@@ -80598,7 +80604,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652261760</BitOffs>
+            <BitOffs>652262720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -80617,7 +80623,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262408</BitOffs>
+            <BitOffs>652263368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -80629,7 +80635,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262416</BitOffs>
+            <BitOffs>652263376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -80641,7 +80647,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262424</BitOffs>
+            <BitOffs>652263384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -80653,7 +80659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262432</BitOffs>
+            <BitOffs>652263392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowSwitch.bFlowOk</Name>
@@ -80673,7 +80679,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262528</BitOffs>
+            <BitOffs>652263488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80685,7 +80691,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652380288</BitOffs>
+            <BitOffs>652381248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -80697,7 +80703,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654010240</BitOffs>
+            <BitOffs>654011392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -80710,7 +80716,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018176</BitOffs>
+            <BitOffs>654019328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -80723,7 +80729,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018184</BitOffs>
+            <BitOffs>654019336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -80736,7 +80742,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018192</BitOffs>
+            <BitOffs>654019344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -80759,7 +80765,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018208</BitOffs>
+            <BitOffs>654019360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -80772,7 +80778,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018240</BitOffs>
+            <BitOffs>654019392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -80785,7 +80791,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018304</BitOffs>
+            <BitOffs>654019456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -80798,7 +80804,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654018320</BitOffs>
+            <BitOffs>654019472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -80810,7 +80816,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654036160</BitOffs>
+            <BitOffs>654037312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -80823,7 +80829,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044096</BitOffs>
+            <BitOffs>654045248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -80836,7 +80842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044104</BitOffs>
+            <BitOffs>654045256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -80849,7 +80855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044112</BitOffs>
+            <BitOffs>654045264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -80872,7 +80878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044128</BitOffs>
+            <BitOffs>654045280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -80885,7 +80891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044160</BitOffs>
+            <BitOffs>654045312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -80898,7 +80904,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044224</BitOffs>
+            <BitOffs>654045376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -80911,7 +80917,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654044240</BitOffs>
+            <BitOffs>654045392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -80923,7 +80929,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654062080</BitOffs>
+            <BitOffs>654063232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -80936,7 +80942,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070016</BitOffs>
+            <BitOffs>654071168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -80949,7 +80955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070024</BitOffs>
+            <BitOffs>654071176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -80962,7 +80968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070032</BitOffs>
+            <BitOffs>654071184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -80985,7 +80991,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070048</BitOffs>
+            <BitOffs>654071200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -80998,7 +81004,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070080</BitOffs>
+            <BitOffs>654071232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81011,7 +81017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070144</BitOffs>
+            <BitOffs>654071296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81024,7 +81030,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654070160</BitOffs>
+            <BitOffs>654071312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -81036,7 +81042,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654365632</BitOffs>
+            <BitOffs>654366784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -81055,7 +81061,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654558088</BitOffs>
+            <BitOffs>654559240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -81067,7 +81073,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654558096</BitOffs>
+            <BitOffs>654559248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -81079,7 +81085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654558104</BitOffs>
+            <BitOffs>654559256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -81091,7 +81097,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654558112</BitOffs>
+            <BitOffs>654559264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -81104,7 +81110,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654558400</BitOffs>
+            <BitOffs>654559552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -81117,7 +81123,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654945216</BitOffs>
+            <BitOffs>654946368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
@@ -81130,7 +81136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654946368</BitOffs>
+            <BitOffs>654947520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -81149,7 +81155,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947016</BitOffs>
+            <BitOffs>654948168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -81161,7 +81167,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947024</BitOffs>
+            <BitOffs>654948176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -81173,7 +81179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947032</BitOffs>
+            <BitOffs>654948184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -81185,7 +81191,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947040</BitOffs>
+            <BitOffs>654948192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowSwitch.bFlowOk</Name>
@@ -81205,7 +81211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947136</BitOffs>
+            <BitOffs>654948288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81217,7 +81223,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655065216</BitOffs>
+            <BitOffs>655066368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -81229,7 +81235,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656695168</BitOffs>
+            <BitOffs>656696512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -81242,7 +81248,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703104</BitOffs>
+            <BitOffs>656704448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -81255,7 +81261,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703112</BitOffs>
+            <BitOffs>656704456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -81268,7 +81274,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703120</BitOffs>
+            <BitOffs>656704464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -81291,7 +81297,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703136</BitOffs>
+            <BitOffs>656704480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -81304,7 +81310,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703168</BitOffs>
+            <BitOffs>656704512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -81317,7 +81323,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703232</BitOffs>
+            <BitOffs>656704576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -81330,7 +81336,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656703248</BitOffs>
+            <BitOffs>656704592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -81342,7 +81348,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656721088</BitOffs>
+            <BitOffs>656722432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -81355,7 +81361,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729024</BitOffs>
+            <BitOffs>656730368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -81368,7 +81374,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729032</BitOffs>
+            <BitOffs>656730376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -81381,7 +81387,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729040</BitOffs>
+            <BitOffs>656730384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -81404,7 +81410,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729056</BitOffs>
+            <BitOffs>656730400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -81417,7 +81423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729088</BitOffs>
+            <BitOffs>656730432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -81430,7 +81436,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729152</BitOffs>
+            <BitOffs>656730496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -81443,7 +81449,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656729168</BitOffs>
+            <BitOffs>656730512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -81455,7 +81461,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656747008</BitOffs>
+            <BitOffs>656748352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -81468,7 +81474,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656754944</BitOffs>
+            <BitOffs>656756288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -81481,7 +81487,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656754952</BitOffs>
+            <BitOffs>656756296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -81494,7 +81500,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656754960</BitOffs>
+            <BitOffs>656756304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -81517,7 +81523,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656754976</BitOffs>
+            <BitOffs>656756320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -81530,7 +81536,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656755008</BitOffs>
+            <BitOffs>656756352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81543,7 +81549,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656755072</BitOffs>
+            <BitOffs>656756416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81556,7 +81562,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656755088</BitOffs>
+            <BitOffs>656756432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81568,7 +81574,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657176320</BitOffs>
+            <BitOffs>657177664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81580,7 +81586,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657503360</BitOffs>
+            <BitOffs>657504704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -81592,7 +81598,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659133312</BitOffs>
+            <BitOffs>659134848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -81605,7 +81611,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141248</BitOffs>
+            <BitOffs>659142784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -81618,7 +81624,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141256</BitOffs>
+            <BitOffs>659142792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -81631,7 +81637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141264</BitOffs>
+            <BitOffs>659142800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -81654,7 +81660,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141280</BitOffs>
+            <BitOffs>659142816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -81667,7 +81673,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141312</BitOffs>
+            <BitOffs>659142848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -81680,7 +81686,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141376</BitOffs>
+            <BitOffs>659142912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -81693,7 +81699,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659141392</BitOffs>
+            <BitOffs>659142928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -81705,7 +81711,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659159232</BitOffs>
+            <BitOffs>659160768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -81718,7 +81724,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167168</BitOffs>
+            <BitOffs>659168704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -81731,7 +81737,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167176</BitOffs>
+            <BitOffs>659168712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -81744,7 +81750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167184</BitOffs>
+            <BitOffs>659168720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -81767,7 +81773,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167200</BitOffs>
+            <BitOffs>659168736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -81780,7 +81786,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167232</BitOffs>
+            <BitOffs>659168768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -81793,7 +81799,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167296</BitOffs>
+            <BitOffs>659168832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -81806,7 +81812,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659167312</BitOffs>
+            <BitOffs>659168848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -81818,7 +81824,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659185152</BitOffs>
+            <BitOffs>659186688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -81831,7 +81837,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193088</BitOffs>
+            <BitOffs>659194624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -81844,7 +81850,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193096</BitOffs>
+            <BitOffs>659194632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -81857,7 +81863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193104</BitOffs>
+            <BitOffs>659194640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -81880,7 +81886,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193120</BitOffs>
+            <BitOffs>659194656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -81893,7 +81899,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193152</BitOffs>
+            <BitOffs>659194688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81906,7 +81912,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193216</BitOffs>
+            <BitOffs>659194752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81919,7 +81925,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659193232</BitOffs>
+            <BitOffs>659194768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -81943,7 +81949,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659488840</BitOffs>
+            <BitOffs>659490376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -81955,7 +81961,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659488848</BitOffs>
+            <BitOffs>659490384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -81967,7 +81973,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659488856</BitOffs>
+            <BitOffs>659490392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -81979,7 +81985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659488864</BitOffs>
+            <BitOffs>659490400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -82003,7 +82009,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659489096</BitOffs>
+            <BitOffs>659490632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -82015,7 +82021,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659489104</BitOffs>
+            <BitOffs>659490640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -82027,7 +82033,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659489112</BitOffs>
+            <BitOffs>659490648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -82039,7 +82045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659489120</BitOffs>
+            <BitOffs>659490656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowSwitch.bFlowOk</Name>
@@ -82059,7 +82065,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659489216</BitOffs>
+            <BitOffs>659490752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowMeter.iRaw</Name>
@@ -82072,7 +82078,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659489344</BitOffs>
+            <BitOffs>659490880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82084,7 +82090,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659614912</BitOffs>
+            <BitOffs>659616448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82096,7 +82102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659941952</BitOffs>
+            <BitOffs>659943488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -82108,7 +82114,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661571904</BitOffs>
+            <BitOffs>661573632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -82121,7 +82127,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579840</BitOffs>
+            <BitOffs>661581568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -82134,7 +82140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579848</BitOffs>
+            <BitOffs>661581576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -82147,7 +82153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579856</BitOffs>
+            <BitOffs>661581584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -82170,7 +82176,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579872</BitOffs>
+            <BitOffs>661581600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -82183,7 +82189,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579904</BitOffs>
+            <BitOffs>661581632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -82196,7 +82202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579968</BitOffs>
+            <BitOffs>661581696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -82209,7 +82215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661579984</BitOffs>
+            <BitOffs>661581712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -82221,7 +82227,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661597824</BitOffs>
+            <BitOffs>661599552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -82234,7 +82240,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605760</BitOffs>
+            <BitOffs>661607488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -82247,7 +82253,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605768</BitOffs>
+            <BitOffs>661607496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -82260,7 +82266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605776</BitOffs>
+            <BitOffs>661607504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -82283,7 +82289,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605792</BitOffs>
+            <BitOffs>661607520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -82296,7 +82302,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605824</BitOffs>
+            <BitOffs>661607552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -82309,7 +82315,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605888</BitOffs>
+            <BitOffs>661607616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -82322,7 +82328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661605904</BitOffs>
+            <BitOffs>661607632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -82334,7 +82340,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661623744</BitOffs>
+            <BitOffs>661625472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -82347,7 +82353,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631680</BitOffs>
+            <BitOffs>661633408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -82360,7 +82366,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631688</BitOffs>
+            <BitOffs>661633416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -82373,7 +82379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631696</BitOffs>
+            <BitOffs>661633424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -82396,7 +82402,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631712</BitOffs>
+            <BitOffs>661633440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -82409,7 +82415,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631744</BitOffs>
+            <BitOffs>661633472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -82422,7 +82428,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631808</BitOffs>
+            <BitOffs>661633536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -82435,7 +82441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661631824</BitOffs>
+            <BitOffs>661633552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -82459,7 +82465,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927432</BitOffs>
+            <BitOffs>661929160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -82471,7 +82477,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927440</BitOffs>
+            <BitOffs>661929168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -82483,7 +82489,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927448</BitOffs>
+            <BitOffs>661929176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -82495,7 +82501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927456</BitOffs>
+            <BitOffs>661929184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -82519,7 +82525,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927688</BitOffs>
+            <BitOffs>661929416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -82531,7 +82537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927696</BitOffs>
+            <BitOffs>661929424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -82543,7 +82549,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927704</BitOffs>
+            <BitOffs>661929432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -82555,7 +82561,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927712</BitOffs>
+            <BitOffs>661929440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowSwitch.bFlowOk</Name>
@@ -82575,7 +82581,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927808</BitOffs>
+            <BitOffs>661929536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowMeter.iRaw</Name>
@@ -82588,7 +82594,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661927936</BitOffs>
+            <BitOffs>661929664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82600,7 +82606,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662029632</BitOffs>
+            <BitOffs>662031360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82612,7 +82618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662356672</BitOffs>
+            <BitOffs>662358400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82624,7 +82630,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662683712</BitOffs>
+            <BitOffs>662685440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82636,7 +82642,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663010752</BitOffs>
+            <BitOffs>663012480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -82648,7 +82654,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663493056</BitOffs>
+            <BitOffs>663494784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82660,7 +82666,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663501760</BitOffs>
+            <BitOffs>663503488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82672,7 +82678,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663828800</BitOffs>
+            <BitOffs>663830528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82684,7 +82690,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664155840</BitOffs>
+            <BitOffs>664157568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82696,7 +82702,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664482880</BitOffs>
+            <BitOffs>664484608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
@@ -82708,7 +82714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664965184</BitOffs>
+            <BitOffs>664966912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -82724,7 +82730,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664965336</BitOffs>
+            <BitOffs>664967064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput2</Name>
@@ -82740,7 +82746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664969312</BitOffs>
+            <BitOffs>664971040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1High</Name>
@@ -82756,7 +82762,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664969320</BitOffs>
+            <BitOffs>664971048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -82769,7 +82775,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665084224</BitOffs>
+            <BitOffs>665085952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -82781,7 +82787,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665084232</BitOffs>
+            <BitOffs>665085960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82793,7 +82799,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665122240</BitOffs>
+            <BitOffs>665123968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82805,7 +82811,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665449280</BitOffs>
+            <BitOffs>665451008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -82829,7 +82835,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666490312</BitOffs>
+            <BitOffs>666492040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -82841,7 +82847,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666490320</BitOffs>
+            <BitOffs>666492048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -82853,7 +82859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666490328</BitOffs>
+            <BitOffs>666492056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -82865,7 +82871,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666490336</BitOffs>
+            <BitOffs>666492064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbFlowMeter.iRaw</Name>
@@ -82878,7 +82884,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666490432</BitOffs>
+            <BitOffs>666492160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82890,7 +82896,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666518528</BitOffs>
+            <BitOffs>666520256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82902,7 +82908,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666845568</BitOffs>
+            <BitOffs>666847296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -82926,7 +82932,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667879176</BitOffs>
+            <BitOffs>667880904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -82938,7 +82944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667879184</BitOffs>
+            <BitOffs>667880912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -82950,7 +82956,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667879192</BitOffs>
+            <BitOffs>667880920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -82962,7 +82968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667879200</BitOffs>
+            <BitOffs>667880928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbFlowMeter.iRaw</Name>
@@ -82975,7 +82981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667879296</BitOffs>
+            <BitOffs>667881024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82987,7 +82993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667883136</BitOffs>
+            <BitOffs>667884864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82999,7 +83005,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668210176</BitOffs>
+            <BitOffs>668211904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83011,7 +83017,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668537216</BitOffs>
+            <BitOffs>668538944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83023,7 +83029,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668864256</BitOffs>
+            <BitOffs>668865984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83035,7 +83041,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669191296</BitOffs>
+            <BitOffs>669193024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83047,7 +83053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669518336</BitOffs>
+            <BitOffs>669520064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83059,7 +83065,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669845376</BitOffs>
+            <BitOffs>669847104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83071,7 +83077,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670172416</BitOffs>
+            <BitOffs>670174144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83083,7 +83089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670499456</BitOffs>
+            <BitOffs>670501184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83095,7 +83101,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670826496</BitOffs>
+            <BitOffs>670828224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83107,7 +83113,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671153536</BitOffs>
+            <BitOffs>671155264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83119,7 +83125,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671480576</BitOffs>
+            <BitOffs>671482304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83131,7 +83137,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671807616</BitOffs>
+            <BitOffs>671809344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1Low</Name>
@@ -83147,7 +83153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672132032</BitOffs>
+            <BitOffs>672133760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2High</Name>
@@ -83163,7 +83169,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672132040</BitOffs>
+            <BitOffs>672133768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2Low</Name>
@@ -83179,7 +83185,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672132080</BitOffs>
+            <BitOffs>672133808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -83191,7 +83197,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673436864</BitOffs>
+            <BitOffs>673438784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83204,7 +83210,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444800</BitOffs>
+            <BitOffs>673446720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83217,7 +83223,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444808</BitOffs>
+            <BitOffs>673446728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -83230,7 +83236,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444816</BitOffs>
+            <BitOffs>673446736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83253,7 +83259,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444832</BitOffs>
+            <BitOffs>673446752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83266,7 +83272,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444864</BitOffs>
+            <BitOffs>673446784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83279,7 +83285,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444928</BitOffs>
+            <BitOffs>673446848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83292,7 +83298,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673444944</BitOffs>
+            <BitOffs>673446864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83304,7 +83310,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673462784</BitOffs>
+            <BitOffs>673464704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83317,7 +83323,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470720</BitOffs>
+            <BitOffs>673472640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83330,7 +83336,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470728</BitOffs>
+            <BitOffs>673472648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -83343,7 +83349,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470736</BitOffs>
+            <BitOffs>673472656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83366,7 +83372,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470752</BitOffs>
+            <BitOffs>673472672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83379,7 +83385,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470784</BitOffs>
+            <BitOffs>673472704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83392,7 +83398,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470848</BitOffs>
+            <BitOffs>673472768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83405,7 +83411,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673470864</BitOffs>
+            <BitOffs>673472784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83417,7 +83423,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673488704</BitOffs>
+            <BitOffs>673490624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83430,7 +83436,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496640</BitOffs>
+            <BitOffs>673498560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83443,7 +83449,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496648</BitOffs>
+            <BitOffs>673498568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -83456,7 +83462,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496656</BitOffs>
+            <BitOffs>673498576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83479,7 +83485,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496672</BitOffs>
+            <BitOffs>673498592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83492,7 +83498,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496704</BitOffs>
+            <BitOffs>673498624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83505,7 +83511,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496768</BitOffs>
+            <BitOffs>673498688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83518,7 +83524,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673496784</BitOffs>
+            <BitOffs>673498704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -83530,7 +83536,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675248000</BitOffs>
+            <BitOffs>675250112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83543,7 +83549,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675255936</BitOffs>
+            <BitOffs>675258048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83556,7 +83562,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675255944</BitOffs>
+            <BitOffs>675258056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -83569,7 +83575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675255952</BitOffs>
+            <BitOffs>675258064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83592,7 +83598,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675255968</BitOffs>
+            <BitOffs>675258080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83605,7 +83611,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675256000</BitOffs>
+            <BitOffs>675258112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83618,7 +83624,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675256064</BitOffs>
+            <BitOffs>675258176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83631,7 +83637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675256080</BitOffs>
+            <BitOffs>675258192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83643,7 +83649,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675273920</BitOffs>
+            <BitOffs>675276032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83656,7 +83662,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675281856</BitOffs>
+            <BitOffs>675283968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83669,7 +83675,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675281864</BitOffs>
+            <BitOffs>675283976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -83682,7 +83688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675281872</BitOffs>
+            <BitOffs>675283984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83705,7 +83711,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675281888</BitOffs>
+            <BitOffs>675284000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83718,7 +83724,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675281920</BitOffs>
+            <BitOffs>675284032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83731,7 +83737,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675281984</BitOffs>
+            <BitOffs>675284096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83744,7 +83750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675282000</BitOffs>
+            <BitOffs>675284112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83756,7 +83762,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675299840</BitOffs>
+            <BitOffs>675301952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83769,7 +83775,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307776</BitOffs>
+            <BitOffs>675309888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83782,7 +83788,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307784</BitOffs>
+            <BitOffs>675309896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -83795,7 +83801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307792</BitOffs>
+            <BitOffs>675309904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83818,7 +83824,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307808</BitOffs>
+            <BitOffs>675309920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83831,7 +83837,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307840</BitOffs>
+            <BitOffs>675309952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83844,7 +83850,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307904</BitOffs>
+            <BitOffs>675310016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83857,7 +83863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675307920</BitOffs>
+            <BitOffs>675310032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bError</Name>
@@ -83881,7 +83887,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699016</BitOffs>
+            <BitOffs>675701128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange</Name>
@@ -83893,7 +83899,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699024</BitOffs>
+            <BitOffs>675701136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange</Name>
@@ -83905,7 +83911,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699032</BitOffs>
+            <BitOffs>675701144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw</Name>
@@ -83917,7 +83923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699040</BitOffs>
+            <BitOffs>675701152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bError</Name>
@@ -83941,7 +83947,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699272</BitOffs>
+            <BitOffs>675701384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange</Name>
@@ -83953,7 +83959,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699280</BitOffs>
+            <BitOffs>675701392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange</Name>
@@ -83965,7 +83971,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699288</BitOffs>
+            <BitOffs>675701400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw</Name>
@@ -83977,7 +83983,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675699296</BitOffs>
+            <BitOffs>675701408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83989,7 +83995,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675702464</BitOffs>
+            <BitOffs>675704576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84001,7 +84007,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676029504</BitOffs>
+            <BitOffs>676031616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -84013,7 +84019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677658496</BitOffs>
+            <BitOffs>677660800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -84026,7 +84032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666432</BitOffs>
+            <BitOffs>677668736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -84039,7 +84045,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666440</BitOffs>
+            <BitOffs>677668744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHome</Name>
@@ -84052,7 +84058,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666448</BitOffs>
+            <BitOffs>677668752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -84075,7 +84081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666464</BitOffs>
+            <BitOffs>677668768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -84088,7 +84094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666496</BitOffs>
+            <BitOffs>677668800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -84101,7 +84107,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666560</BitOffs>
+            <BitOffs>677668864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -84114,7 +84120,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677666576</BitOffs>
+            <BitOffs>677668880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -84126,7 +84132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677684416</BitOffs>
+            <BitOffs>677686720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -84139,7 +84145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692352</BitOffs>
+            <BitOffs>677694656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -84152,7 +84158,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692360</BitOffs>
+            <BitOffs>677694664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHome</Name>
@@ -84165,7 +84171,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692368</BitOffs>
+            <BitOffs>677694672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -84188,7 +84194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692384</BitOffs>
+            <BitOffs>677694688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -84201,7 +84207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692416</BitOffs>
+            <BitOffs>677694720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -84214,7 +84220,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692480</BitOffs>
+            <BitOffs>677694784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -84227,7 +84233,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677692496</BitOffs>
+            <BitOffs>677694800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -84239,7 +84245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677710336</BitOffs>
+            <BitOffs>677712640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -84252,7 +84258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718272</BitOffs>
+            <BitOffs>677720576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -84265,7 +84271,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718280</BitOffs>
+            <BitOffs>677720584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHome</Name>
@@ -84278,7 +84284,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718288</BitOffs>
+            <BitOffs>677720592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -84301,7 +84307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718304</BitOffs>
+            <BitOffs>677720608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -84314,7 +84320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718336</BitOffs>
+            <BitOffs>677720640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -84327,7 +84333,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718400</BitOffs>
+            <BitOffs>677720704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -84340,7 +84346,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677718416</BitOffs>
+            <BitOffs>677720720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84352,7 +84358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678112512</BitOffs>
+            <BitOffs>678114816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -84364,7 +84370,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679741376</BitOffs>
+            <BitOffs>679743872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -84377,7 +84383,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749312</BitOffs>
+            <BitOffs>679751808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -84390,7 +84396,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749320</BitOffs>
+            <BitOffs>679751816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHome</Name>
@@ -84403,7 +84409,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749328</BitOffs>
+            <BitOffs>679751824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -84426,7 +84432,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749344</BitOffs>
+            <BitOffs>679751840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -84439,7 +84445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749376</BitOffs>
+            <BitOffs>679751872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -84452,7 +84458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749440</BitOffs>
+            <BitOffs>679751936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -84465,7 +84471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679749456</BitOffs>
+            <BitOffs>679751952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -84477,7 +84483,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679767296</BitOffs>
+            <BitOffs>679769792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -84490,7 +84496,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775232</BitOffs>
+            <BitOffs>679777728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -84503,7 +84509,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775240</BitOffs>
+            <BitOffs>679777736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHome</Name>
@@ -84516,7 +84522,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775248</BitOffs>
+            <BitOffs>679777744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -84539,7 +84545,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775264</BitOffs>
+            <BitOffs>679777760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -84552,7 +84558,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775296</BitOffs>
+            <BitOffs>679777792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -84565,7 +84571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775360</BitOffs>
+            <BitOffs>679777856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -84578,7 +84584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679775376</BitOffs>
+            <BitOffs>679777872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -84590,7 +84596,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679793216</BitOffs>
+            <BitOffs>679795712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -84603,7 +84609,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801152</BitOffs>
+            <BitOffs>679803648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -84616,7 +84622,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801160</BitOffs>
+            <BitOffs>679803656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHome</Name>
@@ -84629,7 +84635,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801168</BitOffs>
+            <BitOffs>679803664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -84652,7 +84658,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801184</BitOffs>
+            <BitOffs>679803680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -84665,7 +84671,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801216</BitOffs>
+            <BitOffs>679803712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -84678,7 +84684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801280</BitOffs>
+            <BitOffs>679803776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -84691,7 +84697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679801296</BitOffs>
+            <BitOffs>679803792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -84707,7 +84713,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680138688</BitOffs>
+            <BitOffs>680141184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -84728,7 +84734,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680142208</BitOffs>
+            <BitOffs>680144704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -84749,7 +84755,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680142209</BitOffs>
+            <BitOffs>680144705</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -84761,7 +84767,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690807552</BitOffs>
+            <BitOffs>690810048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -84774,7 +84780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815488</BitOffs>
+            <BitOffs>690817984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -84787,7 +84793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815496</BitOffs>
+            <BitOffs>690817992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -84800,7 +84806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815504</BitOffs>
+            <BitOffs>690818000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -84823,7 +84829,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815520</BitOffs>
+            <BitOffs>690818016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -84836,7 +84842,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815552</BitOffs>
+            <BitOffs>690818048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -84849,7 +84855,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815616</BitOffs>
+            <BitOffs>690818112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -84862,7 +84868,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690815632</BitOffs>
+            <BitOffs>690818128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -84874,7 +84880,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690833472</BitOffs>
+            <BitOffs>690835968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -84887,7 +84893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841408</BitOffs>
+            <BitOffs>690843904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -84900,7 +84906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841416</BitOffs>
+            <BitOffs>690843912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -84913,7 +84919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841424</BitOffs>
+            <BitOffs>690843920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -84936,7 +84942,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841440</BitOffs>
+            <BitOffs>690843936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -84949,7 +84955,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841472</BitOffs>
+            <BitOffs>690843968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -84962,7 +84968,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841536</BitOffs>
+            <BitOffs>690844032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -84975,7 +84981,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690841552</BitOffs>
+            <BitOffs>690844048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -84987,7 +84993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690859392</BitOffs>
+            <BitOffs>690861888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -85000,7 +85006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867328</BitOffs>
+            <BitOffs>690869824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -85013,7 +85019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867336</BitOffs>
+            <BitOffs>690869832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -85026,7 +85032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867344</BitOffs>
+            <BitOffs>690869840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -85049,7 +85055,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867360</BitOffs>
+            <BitOffs>690869856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -85062,7 +85068,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867392</BitOffs>
+            <BitOffs>690869888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -85075,7 +85081,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867456</BitOffs>
+            <BitOffs>690869952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -85088,7 +85094,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690867472</BitOffs>
+            <BitOffs>690869968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -85100,7 +85106,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690885312</BitOffs>
+            <BitOffs>690887808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -85113,7 +85119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893248</BitOffs>
+            <BitOffs>690895744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -85126,7 +85132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893256</BitOffs>
+            <BitOffs>690895752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -85139,7 +85145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893264</BitOffs>
+            <BitOffs>690895760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -85162,7 +85168,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893280</BitOffs>
+            <BitOffs>690895776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -85175,7 +85181,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893312</BitOffs>
+            <BitOffs>690895808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -85188,7 +85194,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893376</BitOffs>
+            <BitOffs>690895872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -85201,7 +85207,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690893392</BitOffs>
+            <BitOffs>690895888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -85213,7 +85219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690911232</BitOffs>
+            <BitOffs>690913728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -85226,7 +85232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919168</BitOffs>
+            <BitOffs>690921664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -85239,7 +85245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919176</BitOffs>
+            <BitOffs>690921672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -85252,7 +85258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919184</BitOffs>
+            <BitOffs>690921680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -85275,7 +85281,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919200</BitOffs>
+            <BitOffs>690921696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -85288,7 +85294,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919232</BitOffs>
+            <BitOffs>690921728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -85301,7 +85307,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919296</BitOffs>
+            <BitOffs>690921792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -85314,7 +85320,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690919312</BitOffs>
+            <BitOffs>690921808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -85326,7 +85332,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690937152</BitOffs>
+            <BitOffs>690939648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -85339,7 +85345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945088</BitOffs>
+            <BitOffs>690947584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -85352,7 +85358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945096</BitOffs>
+            <BitOffs>690947592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -85365,7 +85371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945104</BitOffs>
+            <BitOffs>690947600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -85388,7 +85394,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945120</BitOffs>
+            <BitOffs>690947616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -85401,7 +85407,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945152</BitOffs>
+            <BitOffs>690947648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -85414,7 +85420,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945216</BitOffs>
+            <BitOffs>690947712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -85427,7 +85433,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690945232</BitOffs>
+            <BitOffs>690947728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -85439,7 +85445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690963072</BitOffs>
+            <BitOffs>690965568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -85452,7 +85458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971008</BitOffs>
+            <BitOffs>690973504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -85465,7 +85471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971016</BitOffs>
+            <BitOffs>690973512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -85478,7 +85484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971024</BitOffs>
+            <BitOffs>690973520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -85501,7 +85507,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971040</BitOffs>
+            <BitOffs>690973536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -85514,7 +85520,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971072</BitOffs>
+            <BitOffs>690973568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -85527,7 +85533,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971136</BitOffs>
+            <BitOffs>690973632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -85540,7 +85546,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690971152</BitOffs>
+            <BitOffs>690973648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -85552,7 +85558,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690988992</BitOffs>
+            <BitOffs>690991488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -85565,7 +85571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690996928</BitOffs>
+            <BitOffs>690999424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -85578,7 +85584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690996936</BitOffs>
+            <BitOffs>690999432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -85591,7 +85597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690996944</BitOffs>
+            <BitOffs>690999440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -85614,7 +85620,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690996960</BitOffs>
+            <BitOffs>690999456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -85627,7 +85633,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690996992</BitOffs>
+            <BitOffs>690999488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -85640,7 +85646,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690997056</BitOffs>
+            <BitOffs>690999552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -85653,7 +85659,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690997072</BitOffs>
+            <BitOffs>690999568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -85665,7 +85671,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691014912</BitOffs>
+            <BitOffs>691017408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -85678,7 +85684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022848</BitOffs>
+            <BitOffs>691025344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -85691,7 +85697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022856</BitOffs>
+            <BitOffs>691025352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -85704,7 +85710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022864</BitOffs>
+            <BitOffs>691025360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -85727,7 +85733,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022880</BitOffs>
+            <BitOffs>691025376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -85740,7 +85746,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022912</BitOffs>
+            <BitOffs>691025408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -85753,7 +85759,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022976</BitOffs>
+            <BitOffs>691025472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -85766,7 +85772,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691022992</BitOffs>
+            <BitOffs>691025488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -85778,7 +85784,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691040832</BitOffs>
+            <BitOffs>691043328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -85791,7 +85797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048768</BitOffs>
+            <BitOffs>691051264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -85804,7 +85810,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048776</BitOffs>
+            <BitOffs>691051272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -85817,7 +85823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048784</BitOffs>
+            <BitOffs>691051280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -85840,7 +85846,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048800</BitOffs>
+            <BitOffs>691051296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -85853,7 +85859,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048832</BitOffs>
+            <BitOffs>691051328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -85866,7 +85872,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048896</BitOffs>
+            <BitOffs>691051392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -85879,7 +85885,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691048912</BitOffs>
+            <BitOffs>691051408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -85891,7 +85897,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691066752</BitOffs>
+            <BitOffs>691069248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -85904,7 +85910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074688</BitOffs>
+            <BitOffs>691077184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -85917,7 +85923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074696</BitOffs>
+            <BitOffs>691077192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -85930,7 +85936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074704</BitOffs>
+            <BitOffs>691077200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -85953,7 +85959,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074720</BitOffs>
+            <BitOffs>691077216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -85966,7 +85972,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074752</BitOffs>
+            <BitOffs>691077248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -85979,7 +85985,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074816</BitOffs>
+            <BitOffs>691077312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -85992,7 +85998,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691074832</BitOffs>
+            <BitOffs>691077328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -86004,7 +86010,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691092672</BitOffs>
+            <BitOffs>691095168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -86017,7 +86023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100608</BitOffs>
+            <BitOffs>691103104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -86030,7 +86036,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100616</BitOffs>
+            <BitOffs>691103112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -86043,7 +86049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100624</BitOffs>
+            <BitOffs>691103120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -86066,7 +86072,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100640</BitOffs>
+            <BitOffs>691103136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -86079,7 +86085,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100672</BitOffs>
+            <BitOffs>691103168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -86092,7 +86098,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100736</BitOffs>
+            <BitOffs>691103232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -86105,7 +86111,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691100752</BitOffs>
+            <BitOffs>691103248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -86117,7 +86123,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691118592</BitOffs>
+            <BitOffs>691121088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -86130,7 +86136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126528</BitOffs>
+            <BitOffs>691129024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -86143,7 +86149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126536</BitOffs>
+            <BitOffs>691129032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -86156,7 +86162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126544</BitOffs>
+            <BitOffs>691129040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -86179,7 +86185,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126560</BitOffs>
+            <BitOffs>691129056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -86192,7 +86198,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126592</BitOffs>
+            <BitOffs>691129088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -86205,7 +86211,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126656</BitOffs>
+            <BitOffs>691129152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -86218,7 +86224,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691126672</BitOffs>
+            <BitOffs>691129168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -86230,7 +86236,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691144512</BitOffs>
+            <BitOffs>691147008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -86243,7 +86249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152448</BitOffs>
+            <BitOffs>691154944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -86256,7 +86262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152456</BitOffs>
+            <BitOffs>691154952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -86269,7 +86275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152464</BitOffs>
+            <BitOffs>691154960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -86292,7 +86298,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152480</BitOffs>
+            <BitOffs>691154976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -86305,7 +86311,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152512</BitOffs>
+            <BitOffs>691155008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -86318,7 +86324,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152576</BitOffs>
+            <BitOffs>691155072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -86331,7 +86337,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691152592</BitOffs>
+            <BitOffs>691155088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -86343,7 +86349,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691170432</BitOffs>
+            <BitOffs>691172928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -86356,7 +86362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178368</BitOffs>
+            <BitOffs>691180864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -86369,7 +86375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178376</BitOffs>
+            <BitOffs>691180872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -86382,7 +86388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178384</BitOffs>
+            <BitOffs>691180880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -86405,7 +86411,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178400</BitOffs>
+            <BitOffs>691180896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -86418,7 +86424,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178432</BitOffs>
+            <BitOffs>691180928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -86431,7 +86437,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178496</BitOffs>
+            <BitOffs>691180992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -86444,7 +86450,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691178512</BitOffs>
+            <BitOffs>691181008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -86456,7 +86462,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691196352</BitOffs>
+            <BitOffs>691198848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -86469,7 +86475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204288</BitOffs>
+            <BitOffs>691206784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -86482,7 +86488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204296</BitOffs>
+            <BitOffs>691206792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -86495,7 +86501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204304</BitOffs>
+            <BitOffs>691206800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -86518,7 +86524,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204320</BitOffs>
+            <BitOffs>691206816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -86531,7 +86537,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204352</BitOffs>
+            <BitOffs>691206848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -86544,7 +86550,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204416</BitOffs>
+            <BitOffs>691206912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -86557,7 +86563,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691204432</BitOffs>
+            <BitOffs>691206928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -86569,7 +86575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691222272</BitOffs>
+            <BitOffs>691224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -86582,7 +86588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230208</BitOffs>
+            <BitOffs>691232704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -86595,7 +86601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230216</BitOffs>
+            <BitOffs>691232712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -86608,7 +86614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230224</BitOffs>
+            <BitOffs>691232720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -86631,7 +86637,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230240</BitOffs>
+            <BitOffs>691232736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -86644,7 +86650,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230272</BitOffs>
+            <BitOffs>691232768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -86657,7 +86663,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230336</BitOffs>
+            <BitOffs>691232832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -86670,7 +86676,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691230352</BitOffs>
+            <BitOffs>691232848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -86682,7 +86688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691248192</BitOffs>
+            <BitOffs>691250688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -86695,7 +86701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256128</BitOffs>
+            <BitOffs>691258624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -86708,7 +86714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256136</BitOffs>
+            <BitOffs>691258632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -86721,7 +86727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256144</BitOffs>
+            <BitOffs>691258640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -86744,7 +86750,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256160</BitOffs>
+            <BitOffs>691258656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -86757,7 +86763,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256192</BitOffs>
+            <BitOffs>691258688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -86770,7 +86776,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256256</BitOffs>
+            <BitOffs>691258752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -86783,7 +86789,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691256272</BitOffs>
+            <BitOffs>691258768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -86795,7 +86801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691274112</BitOffs>
+            <BitOffs>691276608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -86808,7 +86814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282048</BitOffs>
+            <BitOffs>691284544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -86821,7 +86827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282056</BitOffs>
+            <BitOffs>691284552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -86834,7 +86840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282064</BitOffs>
+            <BitOffs>691284560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -86857,7 +86863,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282080</BitOffs>
+            <BitOffs>691284576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -86870,7 +86876,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282112</BitOffs>
+            <BitOffs>691284608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -86883,7 +86889,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282176</BitOffs>
+            <BitOffs>691284672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -86896,7 +86902,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691282192</BitOffs>
+            <BitOffs>691284688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -86908,7 +86914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691300032</BitOffs>
+            <BitOffs>691302528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -86921,7 +86927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691307968</BitOffs>
+            <BitOffs>691310464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -86934,7 +86940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691307976</BitOffs>
+            <BitOffs>691310472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -86947,7 +86953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691307984</BitOffs>
+            <BitOffs>691310480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -86970,7 +86976,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691308000</BitOffs>
+            <BitOffs>691310496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -86983,7 +86989,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691308032</BitOffs>
+            <BitOffs>691310528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -86996,7 +87002,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691308096</BitOffs>
+            <BitOffs>691310592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -87009,7 +87015,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691308112</BitOffs>
+            <BitOffs>691310608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -87021,7 +87027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691325952</BitOffs>
+            <BitOffs>691328448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -87034,7 +87040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691333888</BitOffs>
+            <BitOffs>691336384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -87047,7 +87053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691333896</BitOffs>
+            <BitOffs>691336392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -87060,7 +87066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691333904</BitOffs>
+            <BitOffs>691336400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -87083,7 +87089,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691333920</BitOffs>
+            <BitOffs>691336416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -87096,7 +87102,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691333952</BitOffs>
+            <BitOffs>691336448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -87109,7 +87115,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691334016</BitOffs>
+            <BitOffs>691336512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -87122,7 +87128,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691334032</BitOffs>
+            <BitOffs>691336528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -87134,7 +87140,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691351872</BitOffs>
+            <BitOffs>691354368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -87147,7 +87153,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359808</BitOffs>
+            <BitOffs>691362304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -87160,7 +87166,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359816</BitOffs>
+            <BitOffs>691362312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -87173,7 +87179,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359824</BitOffs>
+            <BitOffs>691362320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -87196,7 +87202,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359840</BitOffs>
+            <BitOffs>691362336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -87209,7 +87215,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359872</BitOffs>
+            <BitOffs>691362368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -87222,7 +87228,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359936</BitOffs>
+            <BitOffs>691362432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -87235,7 +87241,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691359952</BitOffs>
+            <BitOffs>691362448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -87247,7 +87253,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691377792</BitOffs>
+            <BitOffs>691380288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -87260,7 +87266,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385728</BitOffs>
+            <BitOffs>691388224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -87273,7 +87279,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385736</BitOffs>
+            <BitOffs>691388232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -87286,7 +87292,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385744</BitOffs>
+            <BitOffs>691388240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -87309,7 +87315,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385760</BitOffs>
+            <BitOffs>691388256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -87322,7 +87328,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385792</BitOffs>
+            <BitOffs>691388288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -87335,7 +87341,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385856</BitOffs>
+            <BitOffs>691388352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -87348,7 +87354,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691385872</BitOffs>
+            <BitOffs>691388368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -87360,7 +87366,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691403712</BitOffs>
+            <BitOffs>691406208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -87373,7 +87379,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411648</BitOffs>
+            <BitOffs>691414144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -87386,7 +87392,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411656</BitOffs>
+            <BitOffs>691414152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -87399,7 +87405,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411664</BitOffs>
+            <BitOffs>691414160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -87422,7 +87428,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411680</BitOffs>
+            <BitOffs>691414176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -87435,7 +87441,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411712</BitOffs>
+            <BitOffs>691414208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -87448,7 +87454,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411776</BitOffs>
+            <BitOffs>691414272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -87461,7 +87467,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691411792</BitOffs>
+            <BitOffs>691414288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -87473,7 +87479,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691429632</BitOffs>
+            <BitOffs>691432128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -87486,7 +87492,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437568</BitOffs>
+            <BitOffs>691440064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -87499,7 +87505,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437576</BitOffs>
+            <BitOffs>691440072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -87512,7 +87518,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437584</BitOffs>
+            <BitOffs>691440080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -87535,7 +87541,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437600</BitOffs>
+            <BitOffs>691440096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -87548,7 +87554,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437632</BitOffs>
+            <BitOffs>691440128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -87561,7 +87567,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437696</BitOffs>
+            <BitOffs>691440192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -87574,7 +87580,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691437712</BitOffs>
+            <BitOffs>691440208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -87586,7 +87592,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691455552</BitOffs>
+            <BitOffs>691458048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -87599,7 +87605,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463488</BitOffs>
+            <BitOffs>691465984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -87612,7 +87618,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463496</BitOffs>
+            <BitOffs>691465992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -87625,7 +87631,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463504</BitOffs>
+            <BitOffs>691466000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -87648,7 +87654,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463520</BitOffs>
+            <BitOffs>691466016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -87661,7 +87667,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463552</BitOffs>
+            <BitOffs>691466048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -87674,7 +87680,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463616</BitOffs>
+            <BitOffs>691466112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -87687,7 +87693,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691463632</BitOffs>
+            <BitOffs>691466128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -87699,7 +87705,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691481472</BitOffs>
+            <BitOffs>691483968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -87712,7 +87718,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489408</BitOffs>
+            <BitOffs>691491904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -87725,7 +87731,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489416</BitOffs>
+            <BitOffs>691491912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -87738,7 +87744,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489424</BitOffs>
+            <BitOffs>691491920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -87761,7 +87767,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489440</BitOffs>
+            <BitOffs>691491936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -87774,7 +87780,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489472</BitOffs>
+            <BitOffs>691491968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -87787,7 +87793,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489536</BitOffs>
+            <BitOffs>691492032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -87800,7 +87806,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691489552</BitOffs>
+            <BitOffs>691492048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -87812,7 +87818,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691507392</BitOffs>
+            <BitOffs>691509888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -87825,7 +87831,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515328</BitOffs>
+            <BitOffs>691517824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -87838,7 +87844,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515336</BitOffs>
+            <BitOffs>691517832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -87851,7 +87857,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515344</BitOffs>
+            <BitOffs>691517840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -87874,7 +87880,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515360</BitOffs>
+            <BitOffs>691517856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -87887,7 +87893,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515392</BitOffs>
+            <BitOffs>691517888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -87900,7 +87906,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515456</BitOffs>
+            <BitOffs>691517952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -87913,7 +87919,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691515472</BitOffs>
+            <BitOffs>691517968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -87925,7 +87931,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691533312</BitOffs>
+            <BitOffs>691535808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -87938,7 +87944,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541248</BitOffs>
+            <BitOffs>691543744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -87951,7 +87957,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541256</BitOffs>
+            <BitOffs>691543752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -87964,7 +87970,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541264</BitOffs>
+            <BitOffs>691543760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -87987,7 +87993,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541280</BitOffs>
+            <BitOffs>691543776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -88000,7 +88006,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541312</BitOffs>
+            <BitOffs>691543808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -88013,7 +88019,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541376</BitOffs>
+            <BitOffs>691543872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -88026,7 +88032,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691541392</BitOffs>
+            <BitOffs>691543888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -88038,7 +88044,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691559232</BitOffs>
+            <BitOffs>691561728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -88051,7 +88057,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567168</BitOffs>
+            <BitOffs>691569664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -88064,7 +88070,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567176</BitOffs>
+            <BitOffs>691569672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -88077,7 +88083,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567184</BitOffs>
+            <BitOffs>691569680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -88100,7 +88106,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567200</BitOffs>
+            <BitOffs>691569696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -88113,7 +88119,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567232</BitOffs>
+            <BitOffs>691569728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -88126,7 +88132,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567296</BitOffs>
+            <BitOffs>691569792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -88139,7 +88145,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691567312</BitOffs>
+            <BitOffs>691569808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -88151,7 +88157,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691585152</BitOffs>
+            <BitOffs>691587648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -88164,7 +88170,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593088</BitOffs>
+            <BitOffs>691595584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -88177,7 +88183,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593096</BitOffs>
+            <BitOffs>691595592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -88190,7 +88196,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593104</BitOffs>
+            <BitOffs>691595600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -88213,7 +88219,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593120</BitOffs>
+            <BitOffs>691595616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -88226,7 +88232,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593152</BitOffs>
+            <BitOffs>691595648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -88239,7 +88245,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593216</BitOffs>
+            <BitOffs>691595712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -88252,7 +88258,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691593232</BitOffs>
+            <BitOffs>691595728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -88264,7 +88270,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691611072</BitOffs>
+            <BitOffs>691613568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -88277,7 +88283,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619008</BitOffs>
+            <BitOffs>691621504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -88290,7 +88296,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619016</BitOffs>
+            <BitOffs>691621512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -88303,7 +88309,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619024</BitOffs>
+            <BitOffs>691621520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -88326,7 +88332,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619040</BitOffs>
+            <BitOffs>691621536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -88339,7 +88345,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619072</BitOffs>
+            <BitOffs>691621568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -88352,7 +88358,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619136</BitOffs>
+            <BitOffs>691621632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -88365,7 +88371,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691619152</BitOffs>
+            <BitOffs>691621648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -88377,7 +88383,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691636992</BitOffs>
+            <BitOffs>691639488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -88390,7 +88396,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691644928</BitOffs>
+            <BitOffs>691647424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -88403,7 +88409,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691644936</BitOffs>
+            <BitOffs>691647432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -88416,7 +88422,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691644944</BitOffs>
+            <BitOffs>691647440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -88439,7 +88445,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691644960</BitOffs>
+            <BitOffs>691647456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -88452,7 +88458,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691644992</BitOffs>
+            <BitOffs>691647488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -88465,7 +88471,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691645056</BitOffs>
+            <BitOffs>691647552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -88478,7 +88484,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691645072</BitOffs>
+            <BitOffs>691647568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -88490,7 +88496,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691662912</BitOffs>
+            <BitOffs>691665408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -88503,7 +88509,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670848</BitOffs>
+            <BitOffs>691673344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -88516,7 +88522,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670856</BitOffs>
+            <BitOffs>691673352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -88529,7 +88535,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670864</BitOffs>
+            <BitOffs>691673360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -88552,7 +88558,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670880</BitOffs>
+            <BitOffs>691673376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -88565,7 +88571,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670912</BitOffs>
+            <BitOffs>691673408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -88578,7 +88584,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670976</BitOffs>
+            <BitOffs>691673472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -88591,7 +88597,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691670992</BitOffs>
+            <BitOffs>691673488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -88603,7 +88609,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691688832</BitOffs>
+            <BitOffs>691691328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -88616,7 +88622,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696768</BitOffs>
+            <BitOffs>691699264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -88629,7 +88635,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696776</BitOffs>
+            <BitOffs>691699272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -88642,7 +88648,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696784</BitOffs>
+            <BitOffs>691699280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -88665,7 +88671,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696800</BitOffs>
+            <BitOffs>691699296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -88678,7 +88684,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696832</BitOffs>
+            <BitOffs>691699328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -88691,7 +88697,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696896</BitOffs>
+            <BitOffs>691699392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -88704,7 +88710,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691696912</BitOffs>
+            <BitOffs>691699408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -88716,7 +88722,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691714752</BitOffs>
+            <BitOffs>691717248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -88729,7 +88735,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722688</BitOffs>
+            <BitOffs>691725184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -88742,7 +88748,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722696</BitOffs>
+            <BitOffs>691725192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -88755,7 +88761,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722704</BitOffs>
+            <BitOffs>691725200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -88778,7 +88784,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722720</BitOffs>
+            <BitOffs>691725216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -88791,7 +88797,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722752</BitOffs>
+            <BitOffs>691725248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -88804,7 +88810,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722816</BitOffs>
+            <BitOffs>691725312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -88817,7 +88823,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691722832</BitOffs>
+            <BitOffs>691725328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -88829,7 +88835,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691740672</BitOffs>
+            <BitOffs>691743168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -88842,7 +88848,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748608</BitOffs>
+            <BitOffs>691751104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -88855,7 +88861,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748616</BitOffs>
+            <BitOffs>691751112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -88868,7 +88874,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748624</BitOffs>
+            <BitOffs>691751120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -88891,7 +88897,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748640</BitOffs>
+            <BitOffs>691751136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -88904,7 +88910,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748672</BitOffs>
+            <BitOffs>691751168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -88917,7 +88923,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748736</BitOffs>
+            <BitOffs>691751232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -88930,7 +88936,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691748752</BitOffs>
+            <BitOffs>691751248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -88942,7 +88948,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691766592</BitOffs>
+            <BitOffs>691769088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -88955,7 +88961,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774528</BitOffs>
+            <BitOffs>691777024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -88968,7 +88974,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774536</BitOffs>
+            <BitOffs>691777032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -88981,7 +88987,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774544</BitOffs>
+            <BitOffs>691777040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -89004,7 +89010,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774560</BitOffs>
+            <BitOffs>691777056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -89017,7 +89023,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774592</BitOffs>
+            <BitOffs>691777088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -89030,7 +89036,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774656</BitOffs>
+            <BitOffs>691777152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -89043,7 +89049,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691774672</BitOffs>
+            <BitOffs>691777168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -89055,7 +89061,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691792512</BitOffs>
+            <BitOffs>691795008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -89068,7 +89074,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800448</BitOffs>
+            <BitOffs>691802944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -89081,7 +89087,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800456</BitOffs>
+            <BitOffs>691802952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -89094,7 +89100,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800464</BitOffs>
+            <BitOffs>691802960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -89117,7 +89123,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800480</BitOffs>
+            <BitOffs>691802976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -89130,7 +89136,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800512</BitOffs>
+            <BitOffs>691803008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -89143,7 +89149,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800576</BitOffs>
+            <BitOffs>691803072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -89156,7 +89162,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691800592</BitOffs>
+            <BitOffs>691803088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -89168,7 +89174,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691818432</BitOffs>
+            <BitOffs>691820928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -89181,7 +89187,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826368</BitOffs>
+            <BitOffs>691828864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -89194,7 +89200,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826376</BitOffs>
+            <BitOffs>691828872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -89207,7 +89213,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826384</BitOffs>
+            <BitOffs>691828880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -89230,7 +89236,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826400</BitOffs>
+            <BitOffs>691828896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -89243,7 +89249,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826432</BitOffs>
+            <BitOffs>691828928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -89256,7 +89262,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826496</BitOffs>
+            <BitOffs>691828992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -89269,7 +89275,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691826512</BitOffs>
+            <BitOffs>691829008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -89281,7 +89287,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691844352</BitOffs>
+            <BitOffs>691846848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -89294,7 +89300,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852288</BitOffs>
+            <BitOffs>691854784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -89307,7 +89313,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852296</BitOffs>
+            <BitOffs>691854792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -89320,7 +89326,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852304</BitOffs>
+            <BitOffs>691854800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -89343,7 +89349,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852320</BitOffs>
+            <BitOffs>691854816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -89356,7 +89362,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852352</BitOffs>
+            <BitOffs>691854848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -89369,7 +89375,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852416</BitOffs>
+            <BitOffs>691854912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -89382,7 +89388,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691852432</BitOffs>
+            <BitOffs>691854928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -89394,7 +89400,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691870272</BitOffs>
+            <BitOffs>691872768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -89407,7 +89413,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878208</BitOffs>
+            <BitOffs>691880704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -89420,7 +89426,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878216</BitOffs>
+            <BitOffs>691880712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -89433,7 +89439,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878224</BitOffs>
+            <BitOffs>691880720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -89456,7 +89462,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878240</BitOffs>
+            <BitOffs>691880736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -89469,7 +89475,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878272</BitOffs>
+            <BitOffs>691880768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -89482,7 +89488,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878336</BitOffs>
+            <BitOffs>691880832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -89495,7 +89501,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691878352</BitOffs>
+            <BitOffs>691880848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -89507,7 +89513,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691896192</BitOffs>
+            <BitOffs>691898688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -89520,7 +89526,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904128</BitOffs>
+            <BitOffs>691906624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -89533,7 +89539,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904136</BitOffs>
+            <BitOffs>691906632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -89546,7 +89552,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904144</BitOffs>
+            <BitOffs>691906640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -89569,7 +89575,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904160</BitOffs>
+            <BitOffs>691906656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -89582,7 +89588,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904192</BitOffs>
+            <BitOffs>691906688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -89595,7 +89601,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904256</BitOffs>
+            <BitOffs>691906752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -89608,7 +89614,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691904272</BitOffs>
+            <BitOffs>691906768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -89620,7 +89626,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691922112</BitOffs>
+            <BitOffs>691924608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -89633,7 +89639,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930048</BitOffs>
+            <BitOffs>691932544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -89646,7 +89652,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930056</BitOffs>
+            <BitOffs>691932552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -89659,7 +89665,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930064</BitOffs>
+            <BitOffs>691932560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -89682,7 +89688,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930080</BitOffs>
+            <BitOffs>691932576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -89695,7 +89701,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930112</BitOffs>
+            <BitOffs>691932608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -89708,7 +89714,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930176</BitOffs>
+            <BitOffs>691932672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -89721,7 +89727,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691930192</BitOffs>
+            <BitOffs>691932688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.NcToPlc</Name>
@@ -89733,7 +89739,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691948032</BitOffs>
+            <BitOffs>691950528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitForwardEnable</Name>
@@ -89746,7 +89752,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691955968</BitOffs>
+            <BitOffs>691958464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitBackwardEnable</Name>
@@ -89759,7 +89765,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691955976</BitOffs>
+            <BitOffs>691958472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHome</Name>
@@ -89772,7 +89778,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691955984</BitOffs>
+            <BitOffs>691958480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHardwareEnable</Name>
@@ -89795,7 +89801,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691956000</BitOffs>
+            <BitOffs>691958496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderULINT</Name>
@@ -89808,7 +89814,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691956032</BitOffs>
+            <BitOffs>691958528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderUINT</Name>
@@ -89821,7 +89827,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691956096</BitOffs>
+            <BitOffs>691958592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderINT</Name>
@@ -89834,7 +89840,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691956112</BitOffs>
+            <BitOffs>691958608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.NcToPlc</Name>
@@ -89846,7 +89852,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691973952</BitOffs>
+            <BitOffs>691976448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitForwardEnable</Name>
@@ -89859,7 +89865,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691981888</BitOffs>
+            <BitOffs>691984384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitBackwardEnable</Name>
@@ -89872,7 +89878,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691981896</BitOffs>
+            <BitOffs>691984392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHome</Name>
@@ -89885,7 +89891,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691981904</BitOffs>
+            <BitOffs>691984400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHardwareEnable</Name>
@@ -89908,7 +89914,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691981920</BitOffs>
+            <BitOffs>691984416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderULINT</Name>
@@ -89921,7 +89927,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691981952</BitOffs>
+            <BitOffs>691984448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderUINT</Name>
@@ -89934,7 +89940,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691982016</BitOffs>
+            <BitOffs>691984512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderINT</Name>
@@ -89947,7 +89953,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691982032</BitOffs>
+            <BitOffs>691984528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.NcToPlc</Name>
@@ -89959,7 +89965,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691999872</BitOffs>
+            <BitOffs>692002368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitForwardEnable</Name>
@@ -89972,7 +89978,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007808</BitOffs>
+            <BitOffs>692010304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitBackwardEnable</Name>
@@ -89985,7 +89991,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007816</BitOffs>
+            <BitOffs>692010312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHome</Name>
@@ -89998,7 +90004,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007824</BitOffs>
+            <BitOffs>692010320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHardwareEnable</Name>
@@ -90021,7 +90027,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007840</BitOffs>
+            <BitOffs>692010336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderULINT</Name>
@@ -90034,7 +90040,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007872</BitOffs>
+            <BitOffs>692010368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderUINT</Name>
@@ -90047,7 +90053,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007936</BitOffs>
+            <BitOffs>692010432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderINT</Name>
@@ -90060,7 +90066,7 @@ Digital outputs</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692007952</BitOffs>
+            <BitOffs>692010448</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -90090,7 +90096,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641164224</BitOffs>
+            <BitOffs>641164416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90103,7 +90109,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641173208</BitOffs>
+            <BitOffs>641173400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90115,7 +90121,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641190144</BitOffs>
+            <BitOffs>641190336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90128,7 +90134,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641199128</BitOffs>
+            <BitOffs>641199320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90140,7 +90146,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641216064</BitOffs>
+            <BitOffs>641216256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90153,7 +90159,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641225048</BitOffs>
+            <BitOffs>641225240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -90165,7 +90171,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641520768</BitOffs>
+            <BitOffs>641520960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -90177,7 +90183,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641520784</BitOffs>
+            <BitOffs>641520976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -90190,7 +90196,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641521792</BitOffs>
+            <BitOffs>641521984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90202,7 +90208,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641640832</BitOffs>
+            <BitOffs>641641024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90214,7 +90220,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643270784</BitOffs>
+            <BitOffs>643271168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90227,7 +90233,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643279768</BitOffs>
+            <BitOffs>643280152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90239,7 +90245,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643296704</BitOffs>
+            <BitOffs>643297088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90252,7 +90258,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643305688</BitOffs>
+            <BitOffs>643306072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90264,7 +90270,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643322624</BitOffs>
+            <BitOffs>643323008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90277,7 +90283,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643331608</BitOffs>
+            <BitOffs>643331992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -90289,7 +90295,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644206592</BitOffs>
+            <BitOffs>644206976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -90309,7 +90315,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644206608</BitOffs>
+            <BitOffs>644206992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90322,7 +90328,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644207680</BitOffs>
+            <BitOffs>644208064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90334,7 +90340,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644325440</BitOffs>
+            <BitOffs>644325824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90346,7 +90352,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645955392</BitOffs>
+            <BitOffs>645955968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90359,7 +90365,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645964376</BitOffs>
+            <BitOffs>645964952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90371,7 +90377,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645981312</BitOffs>
+            <BitOffs>645981888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90384,7 +90390,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645990296</BitOffs>
+            <BitOffs>645990872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90396,7 +90402,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646007232</BitOffs>
+            <BitOffs>646007808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90409,7 +90415,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646016216</BitOffs>
+            <BitOffs>646016792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -90421,7 +90427,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646891200</BitOffs>
+            <BitOffs>646891776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -90441,7 +90447,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646891216</BitOffs>
+            <BitOffs>646891792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90454,7 +90460,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646892288</BitOffs>
+            <BitOffs>646892864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90466,7 +90472,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647010048</BitOffs>
+            <BitOffs>647010624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90478,7 +90484,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648640000</BitOffs>
+            <BitOffs>648640768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90491,7 +90497,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648648984</BitOffs>
+            <BitOffs>648649752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90503,7 +90509,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648665920</BitOffs>
+            <BitOffs>648666688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90516,7 +90522,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648674904</BitOffs>
+            <BitOffs>648675672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90528,7 +90534,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648691840</BitOffs>
+            <BitOffs>648692608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90541,7 +90547,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648700824</BitOffs>
+            <BitOffs>648701592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -90553,7 +90559,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649575808</BitOffs>
+            <BitOffs>649576576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -90573,7 +90579,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649575824</BitOffs>
+            <BitOffs>649576592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90586,7 +90592,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649576896</BitOffs>
+            <BitOffs>649577664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90598,7 +90604,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649694656</BitOffs>
+            <BitOffs>649695424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90610,7 +90616,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651324608</BitOffs>
+            <BitOffs>651325568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90623,7 +90629,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651333592</BitOffs>
+            <BitOffs>651334552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90635,7 +90641,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651350528</BitOffs>
+            <BitOffs>651351488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90648,7 +90654,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651359512</BitOffs>
+            <BitOffs>651360472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90660,7 +90666,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651376448</BitOffs>
+            <BitOffs>651377408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90673,7 +90679,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651385432</BitOffs>
+            <BitOffs>651386392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -90685,7 +90691,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652260416</BitOffs>
+            <BitOffs>652261376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -90705,7 +90711,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652260432</BitOffs>
+            <BitOffs>652261392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90718,7 +90724,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652261504</BitOffs>
+            <BitOffs>652262464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90730,7 +90736,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652379264</BitOffs>
+            <BitOffs>652380224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90742,7 +90748,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654009216</BitOffs>
+            <BitOffs>654010368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90755,7 +90761,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654018200</BitOffs>
+            <BitOffs>654019352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90767,7 +90773,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654035136</BitOffs>
+            <BitOffs>654036288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90780,7 +90786,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654044120</BitOffs>
+            <BitOffs>654045272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90792,7 +90798,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654061056</BitOffs>
+            <BitOffs>654062208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90805,7 +90811,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654070040</BitOffs>
+            <BitOffs>654071192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -90817,7 +90823,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654945024</BitOffs>
+            <BitOffs>654946176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -90837,7 +90843,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654945040</BitOffs>
+            <BitOffs>654946192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90850,7 +90856,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654946112</BitOffs>
+            <BitOffs>654947264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90862,7 +90868,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655064192</BitOffs>
+            <BitOffs>655065344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90874,7 +90880,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656694144</BitOffs>
+            <BitOffs>656695488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90887,7 +90893,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656703128</BitOffs>
+            <BitOffs>656704472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90899,7 +90905,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656720064</BitOffs>
+            <BitOffs>656721408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90912,7 +90918,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656729048</BitOffs>
+            <BitOffs>656730392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90924,7 +90930,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656745984</BitOffs>
+            <BitOffs>656747328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90937,7 +90943,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656754968</BitOffs>
+            <BitOffs>656756312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90949,7 +90955,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657175296</BitOffs>
+            <BitOffs>657176640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90961,7 +90967,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657502336</BitOffs>
+            <BitOffs>657503680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90973,7 +90979,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659132288</BitOffs>
+            <BitOffs>659133824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90986,7 +90992,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659141272</BitOffs>
+            <BitOffs>659142808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90998,7 +91004,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659158208</BitOffs>
+            <BitOffs>659159744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91011,7 +91017,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659167192</BitOffs>
+            <BitOffs>659168728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91023,7 +91029,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659184128</BitOffs>
+            <BitOffs>659185664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91036,7 +91042,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659193112</BitOffs>
+            <BitOffs>659194648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91048,7 +91054,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659613888</BitOffs>
+            <BitOffs>659615424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91060,7 +91066,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659940928</BitOffs>
+            <BitOffs>659942464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91072,7 +91078,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661570880</BitOffs>
+            <BitOffs>661572608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91085,7 +91091,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661579864</BitOffs>
+            <BitOffs>661581592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91097,7 +91103,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661596800</BitOffs>
+            <BitOffs>661598528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91110,7 +91116,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661605784</BitOffs>
+            <BitOffs>661607512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91122,7 +91128,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661622720</BitOffs>
+            <BitOffs>661624448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91135,7 +91141,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661631704</BitOffs>
+            <BitOffs>661633432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91147,7 +91153,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662028608</BitOffs>
+            <BitOffs>662030336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91159,7 +91165,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662355648</BitOffs>
+            <BitOffs>662357376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91171,7 +91177,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662682688</BitOffs>
+            <BitOffs>662684416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91183,7 +91189,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663009728</BitOffs>
+            <BitOffs>663011456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -91195,7 +91201,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663492960</BitOffs>
+            <BitOffs>663494688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91207,7 +91213,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663500736</BitOffs>
+            <BitOffs>663502464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91219,7 +91225,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663827776</BitOffs>
+            <BitOffs>663829504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91231,7 +91237,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664154816</BitOffs>
+            <BitOffs>664156544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91243,7 +91249,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664481856</BitOffs>
+            <BitOffs>664483584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -91255,7 +91261,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664965088</BitOffs>
+            <BitOffs>664966816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -91267,7 +91273,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665084240</BitOffs>
+            <BitOffs>665085968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -91279,7 +91285,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665084248</BitOffs>
+            <BitOffs>665085976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91291,7 +91297,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665121216</BitOffs>
+            <BitOffs>665122944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91303,7 +91309,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665448256</BitOffs>
+            <BitOffs>665449984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91315,7 +91321,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666517504</BitOffs>
+            <BitOffs>666519232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91327,7 +91333,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666844544</BitOffs>
+            <BitOffs>666846272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91339,7 +91345,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667882112</BitOffs>
+            <BitOffs>667883840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91351,7 +91357,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668209152</BitOffs>
+            <BitOffs>668210880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91363,7 +91369,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668536192</BitOffs>
+            <BitOffs>668537920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91375,7 +91381,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668863232</BitOffs>
+            <BitOffs>668864960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91387,7 +91393,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669190272</BitOffs>
+            <BitOffs>669192000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91399,7 +91405,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669517312</BitOffs>
+            <BitOffs>669519040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91411,7 +91417,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669844352</BitOffs>
+            <BitOffs>669846080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91423,7 +91429,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670171392</BitOffs>
+            <BitOffs>670173120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91435,7 +91441,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670498432</BitOffs>
+            <BitOffs>670500160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91447,7 +91453,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670825472</BitOffs>
+            <BitOffs>670827200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91459,7 +91465,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671152512</BitOffs>
+            <BitOffs>671154240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91471,7 +91477,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671479552</BitOffs>
+            <BitOffs>671481280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91483,7 +91489,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671806592</BitOffs>
+            <BitOffs>671808320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91495,7 +91501,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673435840</BitOffs>
+            <BitOffs>673437760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91508,7 +91514,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673444824</BitOffs>
+            <BitOffs>673446744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91520,7 +91526,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673461760</BitOffs>
+            <BitOffs>673463680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91533,7 +91539,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673470744</BitOffs>
+            <BitOffs>673472664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91545,7 +91551,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673487680</BitOffs>
+            <BitOffs>673489600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91558,7 +91564,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673496664</BitOffs>
+            <BitOffs>673498584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91570,7 +91576,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675246976</BitOffs>
+            <BitOffs>675249088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91583,7 +91589,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675255960</BitOffs>
+            <BitOffs>675258072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91595,7 +91601,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675272896</BitOffs>
+            <BitOffs>675275008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91608,7 +91614,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675281880</BitOffs>
+            <BitOffs>675283992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91620,7 +91626,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675298816</BitOffs>
+            <BitOffs>675300928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91633,7 +91639,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675307800</BitOffs>
+            <BitOffs>675309912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91645,7 +91651,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675701440</BitOffs>
+            <BitOffs>675703552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91657,7 +91663,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676028480</BitOffs>
+            <BitOffs>676030592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91669,7 +91675,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677657472</BitOffs>
+            <BitOffs>677659776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91682,7 +91688,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677666456</BitOffs>
+            <BitOffs>677668760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91694,7 +91700,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677683392</BitOffs>
+            <BitOffs>677685696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91707,7 +91713,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677692376</BitOffs>
+            <BitOffs>677694680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91719,7 +91725,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677709312</BitOffs>
+            <BitOffs>677711616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91732,7 +91738,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677718296</BitOffs>
+            <BitOffs>677720600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91744,7 +91750,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678111488</BitOffs>
+            <BitOffs>678113792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91756,7 +91762,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679740352</BitOffs>
+            <BitOffs>679742848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91769,7 +91775,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679749336</BitOffs>
+            <BitOffs>679751832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91781,7 +91787,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679766272</BitOffs>
+            <BitOffs>679768768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91794,7 +91800,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679775256</BitOffs>
+            <BitOffs>679777752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91806,7 +91812,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679792192</BitOffs>
+            <BitOffs>679794688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91819,7 +91825,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679801176</BitOffs>
+            <BitOffs>679803672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -91835,7 +91841,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>680140448</BitOffs>
+            <BitOffs>680142944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -91854,7 +91860,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680310728</BitOffs>
+            <BitOffs>680313224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -91873,7 +91879,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680310736</BitOffs>
+            <BitOffs>680313232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -91893,7 +91899,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>687320360</BitOffs>
+            <BitOffs>687322856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -91913,7 +91919,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689063528</BitOffs>
+            <BitOffs>689066024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -91925,7 +91931,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690806528</BitOffs>
+            <BitOffs>690809024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -91938,7 +91944,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690815512</BitOffs>
+            <BitOffs>690818008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -91950,7 +91956,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690832448</BitOffs>
+            <BitOffs>690834944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -91963,7 +91969,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690841432</BitOffs>
+            <BitOffs>690843928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -91975,7 +91981,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690858368</BitOffs>
+            <BitOffs>690860864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -91988,7 +91994,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690867352</BitOffs>
+            <BitOffs>690869848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -92000,7 +92006,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690884288</BitOffs>
+            <BitOffs>690886784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -92013,7 +92019,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690893272</BitOffs>
+            <BitOffs>690895768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -92025,7 +92031,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690910208</BitOffs>
+            <BitOffs>690912704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -92038,7 +92044,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690919192</BitOffs>
+            <BitOffs>690921688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -92050,7 +92056,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690936128</BitOffs>
+            <BitOffs>690938624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -92063,7 +92069,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690945112</BitOffs>
+            <BitOffs>690947608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -92075,7 +92081,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690962048</BitOffs>
+            <BitOffs>690964544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -92088,7 +92094,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690971032</BitOffs>
+            <BitOffs>690973528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -92100,7 +92106,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690987968</BitOffs>
+            <BitOffs>690990464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -92113,7 +92119,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690996952</BitOffs>
+            <BitOffs>690999448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -92125,7 +92131,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691013888</BitOffs>
+            <BitOffs>691016384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -92138,7 +92144,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691022872</BitOffs>
+            <BitOffs>691025368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -92150,7 +92156,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691039808</BitOffs>
+            <BitOffs>691042304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -92163,7 +92169,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691048792</BitOffs>
+            <BitOffs>691051288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -92175,7 +92181,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691065728</BitOffs>
+            <BitOffs>691068224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -92188,7 +92194,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691074712</BitOffs>
+            <BitOffs>691077208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -92200,7 +92206,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691091648</BitOffs>
+            <BitOffs>691094144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -92213,7 +92219,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691100632</BitOffs>
+            <BitOffs>691103128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -92225,7 +92231,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691117568</BitOffs>
+            <BitOffs>691120064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -92238,7 +92244,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691126552</BitOffs>
+            <BitOffs>691129048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -92250,7 +92256,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691143488</BitOffs>
+            <BitOffs>691145984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -92263,7 +92269,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691152472</BitOffs>
+            <BitOffs>691154968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -92275,7 +92281,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691169408</BitOffs>
+            <BitOffs>691171904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -92288,7 +92294,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691178392</BitOffs>
+            <BitOffs>691180888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -92300,7 +92306,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691195328</BitOffs>
+            <BitOffs>691197824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -92313,7 +92319,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691204312</BitOffs>
+            <BitOffs>691206808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -92325,7 +92331,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691221248</BitOffs>
+            <BitOffs>691223744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -92338,7 +92344,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691230232</BitOffs>
+            <BitOffs>691232728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -92350,7 +92356,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691247168</BitOffs>
+            <BitOffs>691249664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -92363,7 +92369,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691256152</BitOffs>
+            <BitOffs>691258648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -92375,7 +92381,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691273088</BitOffs>
+            <BitOffs>691275584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -92388,7 +92394,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691282072</BitOffs>
+            <BitOffs>691284568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -92400,7 +92406,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691299008</BitOffs>
+            <BitOffs>691301504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -92413,7 +92419,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691307992</BitOffs>
+            <BitOffs>691310488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -92425,7 +92431,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691324928</BitOffs>
+            <BitOffs>691327424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -92438,7 +92444,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691333912</BitOffs>
+            <BitOffs>691336408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -92450,7 +92456,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691350848</BitOffs>
+            <BitOffs>691353344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -92463,7 +92469,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691359832</BitOffs>
+            <BitOffs>691362328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -92475,7 +92481,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691376768</BitOffs>
+            <BitOffs>691379264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -92488,7 +92494,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691385752</BitOffs>
+            <BitOffs>691388248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -92500,7 +92506,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691402688</BitOffs>
+            <BitOffs>691405184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -92513,7 +92519,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691411672</BitOffs>
+            <BitOffs>691414168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -92525,7 +92531,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691428608</BitOffs>
+            <BitOffs>691431104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -92538,7 +92544,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691437592</BitOffs>
+            <BitOffs>691440088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -92550,7 +92556,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691454528</BitOffs>
+            <BitOffs>691457024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -92563,7 +92569,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691463512</BitOffs>
+            <BitOffs>691466008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -92575,7 +92581,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691480448</BitOffs>
+            <BitOffs>691482944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -92588,7 +92594,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691489432</BitOffs>
+            <BitOffs>691491928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -92600,7 +92606,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691506368</BitOffs>
+            <BitOffs>691508864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -92613,7 +92619,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691515352</BitOffs>
+            <BitOffs>691517848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -92625,7 +92631,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691532288</BitOffs>
+            <BitOffs>691534784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -92638,7 +92644,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691541272</BitOffs>
+            <BitOffs>691543768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -92650,7 +92656,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691558208</BitOffs>
+            <BitOffs>691560704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -92663,7 +92669,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691567192</BitOffs>
+            <BitOffs>691569688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -92675,7 +92681,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691584128</BitOffs>
+            <BitOffs>691586624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -92688,7 +92694,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691593112</BitOffs>
+            <BitOffs>691595608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -92700,7 +92706,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691610048</BitOffs>
+            <BitOffs>691612544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -92713,7 +92719,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691619032</BitOffs>
+            <BitOffs>691621528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -92725,7 +92731,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691635968</BitOffs>
+            <BitOffs>691638464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -92738,7 +92744,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691644952</BitOffs>
+            <BitOffs>691647448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -92750,7 +92756,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691661888</BitOffs>
+            <BitOffs>691664384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -92763,7 +92769,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691670872</BitOffs>
+            <BitOffs>691673368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -92775,7 +92781,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691687808</BitOffs>
+            <BitOffs>691690304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -92788,7 +92794,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691696792</BitOffs>
+            <BitOffs>691699288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -92800,7 +92806,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691713728</BitOffs>
+            <BitOffs>691716224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -92813,7 +92819,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691722712</BitOffs>
+            <BitOffs>691725208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -92825,7 +92831,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691739648</BitOffs>
+            <BitOffs>691742144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -92838,7 +92844,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691748632</BitOffs>
+            <BitOffs>691751128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -92850,7 +92856,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691765568</BitOffs>
+            <BitOffs>691768064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -92863,7 +92869,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691774552</BitOffs>
+            <BitOffs>691777048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -92875,7 +92881,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691791488</BitOffs>
+            <BitOffs>691793984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -92888,7 +92894,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691800472</BitOffs>
+            <BitOffs>691802968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -92900,7 +92906,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691817408</BitOffs>
+            <BitOffs>691819904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -92913,7 +92919,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691826392</BitOffs>
+            <BitOffs>691828888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -92925,7 +92931,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691843328</BitOffs>
+            <BitOffs>691845824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -92938,7 +92944,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691852312</BitOffs>
+            <BitOffs>691854808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -92950,7 +92956,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691869248</BitOffs>
+            <BitOffs>691871744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -92963,7 +92969,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691878232</BitOffs>
+            <BitOffs>691880728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -92975,7 +92981,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691895168</BitOffs>
+            <BitOffs>691897664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -92988,7 +92994,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691904152</BitOffs>
+            <BitOffs>691906648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -93000,7 +93006,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691921088</BitOffs>
+            <BitOffs>691923584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -93013,7 +93019,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691930072</BitOffs>
+            <BitOffs>691932568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.PlcToNc</Name>
@@ -93025,7 +93031,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691947008</BitOffs>
+            <BitOffs>691949504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bBrakeRelease</Name>
@@ -93038,7 +93044,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691955992</BitOffs>
+            <BitOffs>691958488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.PlcToNc</Name>
@@ -93050,7 +93056,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691972928</BitOffs>
+            <BitOffs>691975424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bBrakeRelease</Name>
@@ -93063,7 +93069,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691981912</BitOffs>
+            <BitOffs>691984408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.PlcToNc</Name>
@@ -93075,7 +93081,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691998848</BitOffs>
+            <BitOffs>692001344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bBrakeRelease</Name>
@@ -93088,7 +93094,7 @@ Digital outputs</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692007832</BitOffs>
+            <BitOffs>692010328</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -98501,11 +98507,11 @@ Digital outputs</Comment>
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>0</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>9</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -98517,7 +98523,7 @@ Digital outputs</Comment>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>4.0.9</String>
+                <String>4.1.1</String>
               </SubItem>
             </Default>
             <Properties>
@@ -99839,7 +99845,7 @@ Digital outputs</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
-            <BitSize>2001024</BitSize>
+            <BitSize>2001216</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_REF</BaseType>
             <Properties>
               <Property>
@@ -99861,7 +99867,7 @@ Digital outputs</Comment>
             <Name>PRG_AL1K4_L2SI.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>641522048</BitOffs>
+            <BitOffs>641522240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.stDefault</Name>
@@ -99881,11 +99887,11 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>641614080</BitOffs>
+            <BitOffs>641614272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
-            <BitSize>2588864</BitSize>
+            <BitSize>2589056</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -99911,14 +99917,14 @@ Digital outputs</Comment>
                               .fbFlowSwitch.bFlowOk := TIIB[IM2K4-EL1004-E8]^Channel 1^Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641620096</BitOffs>
+            <BitOffs>641620288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbStateSetup</Name>
             <Comment>    fStartupVelo: LREAL := 13;</Comment>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>644208960</BitOffs>
+            <BitOffs>644209344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.stDefault</Name>
@@ -99938,12 +99944,12 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>644300992</BitOffs>
+            <BitOffs>644301376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
             <Comment>IM3K4 and IM4K4 share the same flow meter</Comment>
-            <BitSize>2588864</BitSize>
+            <BitSize>2589056</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -99969,13 +99975,13 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>644304704</BitOffs>
+            <BitOffs>644305088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>646893568</BitOffs>
+            <BitOffs>646894144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.stDefault</Name>
@@ -99995,11 +100001,11 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>646985600</BitOffs>
+            <BitOffs>646986176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
-            <BitSize>2588864</BitSize>
+            <BitSize>2589056</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -100025,13 +100031,13 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>646989312</BitOffs>
+            <BitOffs>646989888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>649578176</BitOffs>
+            <BitOffs>649578944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.stDefault</Name>
@@ -100051,11 +100057,11 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>649670208</BitOffs>
+            <BitOffs>649670976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
-            <BitSize>2588864</BitSize>
+            <BitSize>2589056</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -100081,13 +100087,13 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649673920</BitOffs>
+            <BitOffs>649674688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>652262784</BitOffs>
+            <BitOffs>652263744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.stDefault</Name>
@@ -100107,11 +100113,11 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>652354816</BitOffs>
+            <BitOffs>652355776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
-            <BitSize>2588864</BitSize>
+            <BitSize>2589056</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_PPM</BaseType>
             <Properties>
               <Property>
@@ -100137,13 +100143,13 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>652358528</BitOffs>
+            <BitOffs>652359488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>654947392</BitOffs>
+            <BitOffs>654948544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.stDefault</Name>
@@ -100163,11 +100169,11 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>655039424</BitOffs>
+            <BitOffs>655040576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
-            <BitSize>2007168</BitSize>
+            <BitSize>2007360</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_LIC</BaseType>
             <Properties>
               <Property>
@@ -100178,13 +100184,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>655043520</BitOffs>
+            <BitOffs>655044672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>657050688</BitOffs>
+            <BitOffs>657052032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stDefault</Name>
@@ -100204,12 +100210,12 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>657142720</BitOffs>
+            <BitOffs>657144064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
             <Comment> same cooling loop as IM5K4</Comment>
-            <BitSize>2342848</BitSize>
+            <BitSize>2343040</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_WFS</BaseType>
             <Properties>
               <Property>
@@ -100232,13 +100238,13 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw             := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>657147136</BitOffs>
+            <BitOffs>657148480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>659489984</BitOffs>
+            <BitOffs>659491520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stDefault</Name>
@@ -100254,12 +100260,12 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>659582016</BitOffs>
+            <BitOffs>659583552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
             <Comment> same cooling loop as IM6K4</Comment>
-            <BitSize>2342848</BitSize>
+            <BitSize>2343040</BitSize>
             <BaseType Namespace="lcls_twincat_common_components">FB_WFS</BaseType>
             <Properties>
               <Property>
@@ -100282,13 +100288,13 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw             := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>659585728</BitOffs>
+            <BitOffs>659587264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>661928576</BitOffs>
+            <BitOffs>661930304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stDefault</Name>
@@ -100308,7 +100314,7 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>662020608</BitOffs>
+            <BitOffs>662022336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -100323,7 +100329,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662025664</BitOffs>
+            <BitOffs>662027392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -100334,7 +100340,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663493184</BitOffs>
+            <BitOffs>663494912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
@@ -100344,7 +100350,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663497024</BitOffs>
+            <BitOffs>663498752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -100354,7 +100360,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663497056</BitOffs>
+            <BitOffs>663498784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -100364,7 +100370,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663497088</BitOffs>
+            <BitOffs>663498816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -100374,7 +100380,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663497120</BitOffs>
+            <BitOffs>663498848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
@@ -100389,7 +100395,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>663497792</BitOffs>
+            <BitOffs>663499520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
@@ -100409,7 +100415,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664965312</BitOffs>
+            <BitOffs>664967040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bTest</Name>
@@ -100418,13 +100424,13 @@ Digital outputs</Comment>
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>664965320</BitOffs>
+            <BitOffs>664967048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>664965328</BitOffs>
+            <BitOffs>664967056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
@@ -100434,7 +100440,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664965344</BitOffs>
+            <BitOffs>664967072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -100445,7 +100451,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>664965376</BitOffs>
+            <BitOffs>664967104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -100455,7 +100461,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664969216</BitOffs>
+            <BitOffs>664970944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -100465,7 +100471,7 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664969248</BitOffs>
+            <BitOffs>664970976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -100475,13 +100481,13 @@ Digital outputs</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664969280</BitOffs>
+            <BitOffs>664971008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>664969328</BitOffs>
+            <BitOffs>664971056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -100500,7 +100506,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664969856</BitOffs>
+            <BitOffs>664971584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -100524,7 +100530,7 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>665088256</BitOffs>
+            <BitOffs>665089984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -100548,97 +100554,97 @@ Digital outputs</Comment>
                               .fbFlowMeter.iRaw := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>666491968</BitOffs>
+            <BitOffs>666493696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667880512</BitOffs>
+            <BitOffs>667882240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668207552</BitOffs>
+            <BitOffs>668209280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668534592</BitOffs>
+            <BitOffs>668536320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668861632</BitOffs>
+            <BitOffs>668863360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669188672</BitOffs>
+            <BitOffs>669190400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669515712</BitOffs>
+            <BitOffs>669517440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669842752</BitOffs>
+            <BitOffs>669844480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670169792</BitOffs>
+            <BitOffs>670171520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670496832</BitOffs>
+            <BitOffs>670498560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670823872</BitOffs>
+            <BitOffs>670825600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671150912</BitOffs>
+            <BitOffs>671152640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671477952</BitOffs>
+            <BitOffs>671479680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671804992</BitOffs>
+            <BitOffs>671806720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672132048</BitOffs>
+            <BitOffs>672133776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672132064</BitOffs>
+            <BitOffs>672133792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -100647,13 +100653,13 @@ Digital outputs</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>672132088</BitOffs>
+            <BitOffs>672133816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672132096</BitOffs>
+            <BitOffs>672133824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -100662,20 +100668,20 @@ Digital outputs</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>672132112</BitOffs>
+            <BitOffs>672133840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>672132128</BitOffs>
+            <BitOffs>672133856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bPF1K4Out</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>672132136</BitOffs>
+            <BitOffs>672133864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -100690,12 +100696,12 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672132144</BitOffs>
+            <BitOffs>672133872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates</Name>
             <Comment>/ZP states start</Comment>
-            <BitSize>1548416</BitSize>
+            <BitSize>1548608</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
             <Properties>
               <Property>
@@ -100705,7 +100711,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672132160</BitOffs>
+            <BitOffs>672133888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -100720,7 +100726,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673680576</BitOffs>
+            <BitOffs>673682496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumSet</Name>
@@ -100735,7 +100741,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673680592</BitOffs>
+            <BitOffs>673682512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumGet</Name>
@@ -100750,7 +100756,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673680608</BitOffs>
+            <BitOffs>673682528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
@@ -100765,13 +100771,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673680624</BitOffs>
+            <BitOffs>673682544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>673680640</BitOffs>
+            <BitOffs>673682560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -100791,7 +100797,7 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>673772672</BitOffs>
+            <BitOffs>673774592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -100801,7 +100807,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673776384</BitOffs>
+            <BitOffs>673778304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -100811,7 +100817,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673832064</BitOffs>
+            <BitOffs>673833984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -100821,12 +100827,12 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673887744</BitOffs>
+            <BitOffs>673889664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
             <Comment>/Solid-ATT states start</Comment>
-            <BitSize>1548288</BitSize>
+            <BitSize>1548480</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</BaseType>
             <Properties>
               <Property>
@@ -100836,13 +100842,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673943424</BitOffs>
+            <BitOffs>673945344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>675491712</BitOffs>
+            <BitOffs>675493824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -100851,7 +100857,7 @@ Digital outputs</Comment>
             <Default>
               <SubItem>
                 <Name>.fDelta</Name>
-                <Value>0.5</Value>
+                <Value>1.5</Value>
               </SubItem>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -100862,7 +100868,7 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>675583744</BitOffs>
+            <BitOffs>675585856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -100872,7 +100878,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>675587456</BitOffs>
+            <BitOffs>675589568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -100882,7 +100888,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>675643136</BitOffs>
+            <BitOffs>675645248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01</Name>
@@ -100906,7 +100912,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675698816</BitOffs>
+            <BitOffs>675700928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02</Name>
@@ -100929,23 +100935,23 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675699072</BitOffs>
+            <BitOffs>675701184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>675699840</BitOffs>
+            <BitOffs>675701952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>676026880</BitOffs>
+            <BitOffs>676028992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States</Name>
-            <BitSize>1548288</BitSize>
+            <BitSize>1548480</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</BaseType>
             <Properties>
               <Property>
@@ -100956,7 +100962,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>676353920</BitOffs>
+            <BitOffs>676356032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.li2k4_enumGet</Name>
@@ -100971,7 +100977,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>677902208</BitOffs>
+            <BitOffs>677904512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.at2k4_enumSet</Name>
@@ -100986,7 +100992,7 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>677902224</BitOffs>
+            <BitOffs>677904528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.at2k4_enumGet</Name>
@@ -101001,25 +101007,25 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>677902240</BitOffs>
+            <BitOffs>677904544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>677902256</BitOffs>
+            <BitOffs>677904560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>677902264</BitOffs>
+            <BitOffs>677904568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>677902272</BitOffs>
+            <BitOffs>677904576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.stDefault</Name>
@@ -101039,7 +101045,7 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>677994304</BitOffs>
+            <BitOffs>677996608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4XStates</Name>
@@ -101049,7 +101055,7 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>677998016</BitOffs>
+            <BitOffs>678000320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4YStates</Name>
@@ -101059,41 +101065,41 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>678053696</BitOffs>
+            <BitOffs>678056000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678109376</BitOffs>
+            <BitOffs>678111680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678109504</BitOffs>
+            <BitOffs>678111808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678109632</BitOffs>
+            <BitOffs>678111936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678109760</BitOffs>
+            <BitOffs>678112064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>678109888</BitOffs>
+            <BitOffs>678112192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States</Name>
-            <BitSize>1548160</BitSize>
+            <BitSize>1548352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
             <Properties>
               <Property>
@@ -101104,13 +101110,13 @@ Digital outputs</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>678436928</BitOffs>
+            <BitOffs>678439232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>679985088</BitOffs>
+            <BitOffs>679987584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.stDefault</Name>
@@ -101134,7 +101140,7 @@ Digital outputs</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>680077120</BitOffs>
+            <BitOffs>680079616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.aAT2K4States</Name>
@@ -101144,25 +101150,25 @@ Digital outputs</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>680080832</BitOffs>
+            <BitOffs>680083328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>144640</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>680137728</BitOffs>
+            <BitOffs>680140224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>680282368</BitOffs>
+            <BitOffs>680284864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>680310720</BitOffs>
+            <BitOffs>680313216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF1K4State</Name>
@@ -101173,7 +101179,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680310752</BitOffs>
+            <BitOffs>680313248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -101184,13 +101190,13 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680310768</BitOffs>
+            <BitOffs>680313264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5802176</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>680318144</BitOffs>
+            <BitOffs>680320640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -101209,7 +101215,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686126080</BitOffs>
+            <BitOffs>686128576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -101228,7 +101234,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686723072</BitOffs>
+            <BitOffs>686725568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -101258,7 +101264,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>687320064</BitOffs>
+            <BitOffs>687322560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -101288,7 +101294,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689063232</BitOffs>
+            <BitOffs>689065728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4ATT</Name>
@@ -101299,7 +101305,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690806400</BitOffs>
+            <BitOffs>690808896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4FZP</Name>
@@ -101310,7 +101316,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690806416</BitOffs>
+            <BitOffs>690808912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -101325,7 +101331,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690806432</BitOffs>
+            <BitOffs>690808928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -101340,7 +101346,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690806440</BitOffs>
+            <BitOffs>690808936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -101355,7 +101361,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690806448</BitOffs>
+            <BitOffs>690808944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -101384,7 +101390,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690806464</BitOffs>
+            <BitOffs>690808960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -101396,7 +101402,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690832384</BitOffs>
+            <BitOffs>690834880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -101407,7 +101413,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690858304</BitOffs>
+            <BitOffs>690860800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -101418,7 +101424,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690884224</BitOffs>
+            <BitOffs>690886720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -101429,7 +101435,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690910144</BitOffs>
+            <BitOffs>690912640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -101440,7 +101446,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690936064</BitOffs>
+            <BitOffs>690938560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -101451,7 +101457,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690961984</BitOffs>
+            <BitOffs>690964480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -101462,7 +101468,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690987904</BitOffs>
+            <BitOffs>690990400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -101491,7 +101497,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691013824</BitOffs>
+            <BitOffs>691016320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -101519,7 +101525,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691039744</BitOffs>
+            <BitOffs>691042240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -101546,7 +101552,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691065664</BitOffs>
+            <BitOffs>691068160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -101573,7 +101579,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691091584</BitOffs>
+            <BitOffs>691094080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -101600,7 +101606,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691117504</BitOffs>
+            <BitOffs>691120000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -101612,7 +101618,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691143424</BitOffs>
+            <BitOffs>691145920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -101641,7 +101647,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691169344</BitOffs>
+            <BitOffs>691171840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -101670,7 +101676,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691195264</BitOffs>
+            <BitOffs>691197760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -101699,7 +101705,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691221184</BitOffs>
+            <BitOffs>691223680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -101728,7 +101734,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691247104</BitOffs>
+            <BitOffs>691249600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -101753,7 +101759,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691273024</BitOffs>
+            <BitOffs>691275520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -101782,7 +101788,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691298944</BitOffs>
+            <BitOffs>691301440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -101811,7 +101817,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691324864</BitOffs>
+            <BitOffs>691327360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -101836,7 +101842,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691350784</BitOffs>
+            <BitOffs>691353280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -101864,7 +101870,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691376704</BitOffs>
+            <BitOffs>691379200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -101891,7 +101897,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691402624</BitOffs>
+            <BitOffs>691405120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -101918,7 +101924,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691428544</BitOffs>
+            <BitOffs>691431040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -101945,7 +101951,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691454464</BitOffs>
+            <BitOffs>691456960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -101974,7 +101980,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691480384</BitOffs>
+            <BitOffs>691482880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -102003,7 +102009,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691506304</BitOffs>
+            <BitOffs>691508800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -102028,7 +102034,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691532224</BitOffs>
+            <BitOffs>691534720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -102057,7 +102063,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691558144</BitOffs>
+            <BitOffs>691560640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -102082,7 +102088,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691584064</BitOffs>
+            <BitOffs>691586560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -102119,7 +102125,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691609984</BitOffs>
+            <BitOffs>691612480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -102164,7 +102170,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691635904</BitOffs>
+            <BitOffs>691638400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -102205,7 +102211,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691661824</BitOffs>
+            <BitOffs>691664320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -102246,7 +102252,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691687744</BitOffs>
+            <BitOffs>691690240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -102287,7 +102293,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691713664</BitOffs>
+            <BitOffs>691716160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -102328,7 +102334,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691739584</BitOffs>
+            <BitOffs>691742080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -102369,7 +102375,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691765504</BitOffs>
+            <BitOffs>691768000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -102410,7 +102416,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691791424</BitOffs>
+            <BitOffs>691793920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -102451,7 +102457,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691817344</BitOffs>
+            <BitOffs>691819840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -102487,7 +102493,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691843264</BitOffs>
+            <BitOffs>691845760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -102523,7 +102529,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691869184</BitOffs>
+            <BitOffs>691871680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -102559,7 +102565,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691895104</BitOffs>
+            <BitOffs>691897600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -102604,7 +102610,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691921024</BitOffs>
+            <BitOffs>691923520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45</Name>
@@ -102650,7 +102656,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691946944</BitOffs>
+            <BitOffs>691949440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46</Name>
@@ -102696,7 +102702,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691972864</BitOffs>
+            <BitOffs>691975360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47</Name>
@@ -102740,7 +102746,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691998784</BitOffs>
+            <BitOffs>692001280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -102770,7 +102776,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024704</BitOffs>
+            <BitOffs>692027200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -102800,7 +102806,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024768</BitOffs>
+            <BitOffs>692027264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -102815,7 +102821,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024832</BitOffs>
+            <BitOffs>692027328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -102830,7 +102836,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024848</BitOffs>
+            <BitOffs>692027344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -102844,7 +102850,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024856</BitOffs>
+            <BitOffs>692027352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -102859,7 +102865,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024864</BitOffs>
+            <BitOffs>692027360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -102874,7 +102880,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024896</BitOffs>
+            <BitOffs>692027392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -102888,7 +102894,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024928</BitOffs>
+            <BitOffs>692027424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -102902,7 +102908,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692024960</BitOffs>
+            <BitOffs>692027456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -102920,7 +102926,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027008</BitOffs>
+            <BitOffs>692029504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -102934,7 +102940,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692028032</BitOffs>
+            <BitOffs>692030528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -102955,7 +102961,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692028096</BitOffs>
+            <BitOffs>692030592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -103027,7 +103033,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692044480</BitOffs>
+            <BitOffs>692046976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -103099,7 +103105,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692044608</BitOffs>
+            <BitOffs>692047104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -103171,7 +103177,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692044736</BitOffs>
+            <BitOffs>692047232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -103243,7 +103249,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692044864</BitOffs>
+            <BitOffs>692047360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -103315,7 +103321,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692044992</BitOffs>
+            <BitOffs>692047488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -103387,7 +103393,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692045120</BitOffs>
+            <BitOffs>692047616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -103459,7 +103465,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692045248</BitOffs>
+            <BitOffs>692047744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -103531,7 +103537,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692045376</BitOffs>
+            <BitOffs>692047872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -103557,7 +103563,7 @@ Digital outputs</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692078400</BitOffs>
+            <BitOffs>692080896</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -103650,11 +103656,11 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-06-04T11:27:59</Value>
+          <Value>2024-06-04T16:31:24</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1273856</Value>
+          <Value>1277952</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FBF78C76-40D4-5363-3BB3-055FDA220D21}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{F34E3290-FEC3-F202-8049-D17B82E29D39}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -1457,9 +1457,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-      </Method>
-      <Method>
         <Name>ExtendName</Name>
         <Comment> extends the source name on the right side of the string by the given extension.
  If the source name string size is exceeded nothing more is extended.
@@ -1515,19 +1512,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Name>Clear</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1571,6 +1556,21 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1795,7 +1795,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1994,9 +1994,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2157,6 +2154,9 @@
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -2680,7 +2680,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T#1ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2696,7 +2696,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T#100ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2712,7 +2712,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T#10m</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -3633,7 +3633,7 @@
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#300MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -4132,6 +4132,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <Comment> String format argument types </Comment>
       <BitSize>16</BitSize>
@@ -4614,69 +4677,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4707,15 +4707,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -5000,12 +5000,91 @@
         <BitOffs>8224416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -5054,53 +5133,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5315,44 +5347,12 @@
         </Properties>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -5669,6 +5669,14 @@
         <BitOffs>4240416</BitOffs>
       </SubItem>
       <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5708,46 +5716,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5944,7 +5912,39 @@
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6288,6 +6288,103 @@
         <BitOffs>12701056</BitOffs>
       </SubItem>
       <Method>
+        <Name>AssertArrayEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6529,21 +6626,21 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6699,113 +6796,6 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6942,21 +6932,6 @@
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7345,14 +7320,29 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
         <Comment>
-    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -7366,8 +7356,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -7431,6 +7421,16 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7440,45 +7440,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7518,6 +7479,210 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7724,14 +7889,20 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7740,6 +7911,16 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -7998,40 +8179,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertEquals_REAL</Name>
         <Comment>
     Asserts that two REALs are equal to within a positive delta. If they are not, an assertion error is created.
@@ -8106,37 +8253,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LTIME</Name>
-        <Comment>
-    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8305,341 +8433,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -8737,6 +8530,208 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -8770,14 +8765,14 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -8791,8 +8786,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9293,19 +9288,22 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9353,6 +9351,40 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Comment>
+    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9463,103 +9495,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -9657,11 +9592,48 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9675,8 +9647,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9687,12 +9659,6 @@
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9754,6 +9720,40 @@
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -10067,7 +10067,7 @@
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#50MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -10095,7 +10095,7 @@
         <BitSize>32</BitSize>
         <BitOffs>4129120</BitOffs>
         <Default>
-          <DateTime>T#50MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
@@ -13140,6 +13140,14 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13192,6 +13200,20 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13205,25 +13227,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13248,10 +13260,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13271,23 +13279,36 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13314,20 +13335,6 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13371,22 +13378,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13438,36 +13429,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13480,20 +13443,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
+        <Name>AddRawObject</Name>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -13503,11 +13455,22 @@
             </Property>
           </Properties>
         </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13516,6 +13479,22 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13539,7 +13518,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
+        <Name>AddKeyDateTime</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13550,6 +13529,11 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13562,10 +13546,26 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>AddReal</Name>
+        <Name>CopyDocument</Name>
+        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13884,22 +13884,11 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13958,41 +13947,14 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -14030,14 +13992,52 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14305,23 +14305,13 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14407,19 +14397,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14463,32 +14449,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14512,16 +14472,6 @@
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14556,34 +14506,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14623,6 +14562,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14638,7 +14587,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -14648,8 +14597,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14714,16 +14663,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14760,7 +14699,60 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -14770,8 +14762,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14790,9 +14782,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14805,6 +14797,16 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14815,12 +14817,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -14893,36 +14900,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14933,25 +14910,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -15004,9 +14975,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15014,7 +14985,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -15113,7 +15084,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -15122,15 +15093,9 @@
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15150,21 +15115,6 @@
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -15212,6 +15162,38 @@
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15248,39 +15230,46 @@
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15314,34 +15303,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15404,9 +15368,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15414,7 +15378,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -15423,26 +15397,9 @@
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -15476,9 +15433,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15578,14 +15535,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15668,59 +15617,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15774,6 +15681,42 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15800,13 +15743,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15895,9 +15848,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15915,7 +15868,22 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -15947,17 +15915,28 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -15972,11 +15951,136 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -16014,7 +16118,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -16024,112 +16128,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -19527,12 +19527,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetMDPTableID</Name>
-        <Comment> returns the MDP table id (part of MDP address) </Comment>
-        <ReturnType>BYTE</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>GetMDPSubIndex</Name>
         <ReturnType>BYTE</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19558,6 +19552,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetMDPModuleType</Name>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>IsListParam</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19573,9 +19572,10 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetMDPModuleType</Name>
-        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>GetMDPTableID</Name>
+        <Comment> returns the MDP table id (part of MDP address) </Comment>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetKey</Name>
@@ -21405,112 +21405,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <GetCodeOffs>86545568</GetCodeOffs>
       </PropertyItem>
       <Method>
-        <Name>Clear</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetFreeSpaceOfVol</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
-        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Local>
-          <Name>ipMemMan</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetMDPVersion</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nLen</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetTCVersion</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nLen</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetParameterStrings</Name>
-        <Comment>| access a read string parameter with multiple values.
-| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nStrings</Name>
-          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>ReadFreeSpaceOfVol</Name>
         <Local>
           <Name>nState</Name>
@@ -21578,6 +21472,112 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetFreeSpaceOfVol</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMDPVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTCVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetParameterStrings</Name>
+        <Comment>| access a read string parameter with multiple values.
+| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nStrings</Name>
+          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipMemMan</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>ReadMDPVersion</Name>
@@ -24978,21 +24978,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -25011,22 +25012,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -25225,100 +25225,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -25377,6 +25283,100 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -25580,6 +25580,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -25610,36 +25617,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -25655,9 +25632,29 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -25678,17 +25675,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -26062,6 +26062,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -26073,14 +26079,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -26097,9 +26095,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -26139,15 +26137,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -26432,35 +26432,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -26508,9 +26525,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -26734,47 +26769,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -26920,37 +26920,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -26958,9 +26928,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -27177,7 +27145,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -27745,21 +27745,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -28496,6 +28496,688 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -28805,533 +29487,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -29876,6 +30031,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -30367,56 +30537,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -30487,45 +30625,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -30534,22 +30648,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -30557,124 +30656,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -30948,18 +30929,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31306,7 +31306,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -31325,13 +31325,40 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T#10MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -31368,33 +31395,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -35573,37 +35573,6 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -35648,6 +35617,37 @@ External Setpoint Generation:
     </Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -36263,28 +36263,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -36511,7 +36511,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>339528</BitOffs>
         <Default>
-          <Bool> : u</Bool>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -36545,42 +36545,30 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>511296</BitOffs>
       </SubItem>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>85696</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36711,6 +36699,42 @@ ELSE:
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -36752,44 +36776,20 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>85696</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -44606,7 +44606,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -48369,13 +48369,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -48396,7 +48396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -48554,7 +48554,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>1088</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -49388,7 +49388,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>2720</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -55534,19 +55534,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Motion</Name>
-      </Action>
-      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_CalculatePositions</Name>
+        <Name>ACT_BLOCK</Name>
       </Action>
       <Action>
-        <Name>ACT_BLOCK</Name>
+        <Name>ACT_Motion</Name>
+      </Action>
+      <Action>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -56186,7 +56186,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>27200</BitOffs>
         <Default>
-          <DateTime>T#10S</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -56208,7 +56208,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>27776</BitOffs>
         <Default>
-          <DateTime>T#1S</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -56305,10 +56305,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Properties>
         <Property>
@@ -56587,10 +56587,10 @@ Digital outputs</Comment>
         <BitOffs>258496</BitOffs>
       </SubItem>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Properties>
         <Property>
@@ -56725,7 +56725,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -56978,13 +56978,13 @@ Digital outputs</Comment>
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -57257,10 +57257,10 @@ Digital outputs</Comment>
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -57356,7 +57356,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>260000</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -59295,117 +59295,6 @@ Digital outputs</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name>ENUM_Sample_Calibration_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_EPS</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>eps</Name>
-        <Type Namespace="LCLS_General" ReferenceTo="true">DUT_EPS</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Method>
-        <Name>setBit</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nBits</Name>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bValue</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nMask</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>nBitValue</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>setMessage</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>message</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>setDescription</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>desciption</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
       <BitSize>1760</BitSize>
       <SubItem>
@@ -59606,6 +59495,117 @@ Digital outputs</Comment>
         <Hide GUID="{C9AB5DB1-1B57-42EF-8E17-FBE97768475C}"/>
         <Hide GUID="{43851ABC-CF8A-4AF9-A768-E27D209879D8}"/>
       </Hides>
+    </DataType>
+    <DataType>
+      <Name>ENUM_Sample_Calibration_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_EPS</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>eps</Name>
+        <Type Namespace="LCLS_General" ReferenceTo="true">DUT_EPS</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>setDescription</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>desciption</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>setMessage</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>message</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>setBit</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nBits</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bValue</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nMask</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>nBitValue</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">FB_VetoArbiter</Name>
@@ -59966,8 +59966,7 @@ Digital outputs</Comment>
         <BitSize>8</BitSize>
         <BitOffs>144576</BitOffs>
         <Default>
-          <Bool>,
-  </Bool>
+          <Bool>,</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -60488,47 +60487,6 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -60576,6 +60534,21 @@ Digital outputs</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -60678,19 +60651,45 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -61399,6 +61398,26 @@ Digital outputs</Comment>
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -61441,26 +61460,6 @@ Digital outputs</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -61588,10 +61587,11 @@ Digital outputs</Comment>
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> generates a JSON string from a given symbol (via address/size)</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -61605,29 +61605,27 @@ Digital outputs</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -61710,47 +61708,6 @@ Digital outputs</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -61886,6 +61843,48 @@ Digital outputs</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> generates a JSON string from a given symbol (via address/size)</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -62589,46 +62588,12 @@ Digital outputs</Comment>
         </Parameter>
       </Method>
       <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -62758,6 +62723,40 @@ Digital outputs</Comment>
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -62968,7 +62967,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -63725,7 +63724,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -64147,7 +64146,7 @@ Digital outputs</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1h</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -64159,7 +64158,7 @@ Digital outputs</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -64171,7 +64170,7 @@ Digital outputs</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -78188,7 +78187,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87883776</ByteSize>
+          <ByteSize>87818240</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -90073,7 +90072,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87883776</ByteSize>
+          <ByteSize>87818240</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -93101,7 +93100,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87883776</ByteSize>
+          <ByteSize>87818240</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -93266,7 +93265,7 @@ Digital outputs</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#1ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93281,7 +93280,7 @@ Digital outputs</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#100ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93296,7 +93295,7 @@ Digital outputs</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10s</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93311,7 +93310,7 @@ Digital outputs</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10m</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -99515,7 +99514,7 @@ Digital outputs</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#0MS</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -103570,7 +103569,7 @@ Digital outputs</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87883776</ByteSize>
+          <ByteSize>87818240</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -103656,11 +103655,11 @@ Digital outputs</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-06-04T16:31:24</Value>
+          <Value>2024-06-05T13:49:09</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1277952</Value>
+          <Value>1212416</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add PMPS into IM5K4 with Sp1K4 FZP veto and remove target 4,5 of Sp1K4-ATT

IM5K4: adding IM5K4 is vetoed by SP1K4 FZP all targets
Sp1K4 ATT, remove target 4 and 5 by scientists request because target4 and 5 bumping inside the attenuator
Change Sp1K4 FZP Y negative limit switch

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists request these
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Yes, during last night beam time, all tested. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->

(https://jira.slac.stanford.edu/browse/ECS-5489)
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
