### PR TITLE
fix at2k4 pv error

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1260,7 +1260,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{9DD0BA81-4A92-4D5E-8BD9-E101C02702D4}" Name="tmo_motion" PrjFilePath="..\..\tmo_motion\tmo_motion.plcproj" TmcFilePath="..\..\tmo_motion\tmo_motion.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{71D9AF80-0111-60BD-E642-58E77DBD9A91}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{3F3BEE99-C468-53EE-14E9-A7CFD12D9488}">
 			<Name>tmo_motion Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -2745,6 +2745,10 @@ External Setpoint Generation:
 					<Type GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Type>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.bHallInput1</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
@@ -2763,18 +2767,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
 					<Type GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput1</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -2894,6 +2886,14 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bHallInput2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1High</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K4.bTL1Low</Name>
@@ -5869,16 +5869,16 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
-					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
-				</Var>
-				<Var>
 					<Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
+					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>

--- a/plc-tmo-motion/plc-tmo-motion.tsproj
+++ b/plc-tmo-motion/plc-tmo-motion.tsproj
@@ -9,8 +9,8 @@
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
-					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<TargetSelect TargetId="2">{E008E3C8-6BD9-491C-B673-DC45CC7AA4F1}</TargetSelect>
+					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020003" DongleLevel="50" DongleSystemId="{48EB253C-818D-610A-0B70-DC68309EB817}"/>
 				</Target>
 			</Licenses>

--- a/plc-tmo-motion/tmo_motion/GVLs/Main.TcGVL
+++ b/plc-tmo-motion/tmo_motion/GVLs/Main.TcGVL
@@ -336,8 +336,7 @@ VAR_GLOBAL
         sName := 'LI2K4:IP1:MMS:X');
 
     //AT2K4-MMS-FILT
-    {attribute 'pytmc' := 'pv: AT2K4:MMS:FILT'}
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable  := TIIB[AT2K4-EL7047-E4]^STM Status^Status^Digital input 1;
+     {attribute 'TcLinkTo' := '.bLimitForwardEnable  := TIIB[AT2K4-EL7047-E4]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable := TIIB[AT2K4-EL7047-E4]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT     := TIIB[AT2K4-EL5042-E5]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{71D9AF80-0111-60BD-E642-58E77DBD9A91}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{3F3BEE99-C468-53EE-14E9-A7CFD12D9488}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -181,31 +181,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86539112</GetCodeOffs>
+        <GetCodeOffs>86539144</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86539176</GetCodeOffs>
+        <GetCodeOffs>86539208</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539192</GetCodeOffs>
+        <GetCodeOffs>86539224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539160</GetCodeOffs>
+        <GetCodeOffs>86539192</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539184</GetCodeOffs>
+        <GetCodeOffs>86539216</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1427,15 +1427,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86538992</GetCodeOffs>
-        <SetCodeOffs>86539040</SetCodeOffs>
+        <GetCodeOffs>86539024</GetCodeOffs>
+        <SetCodeOffs>86539072</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539064</GetCodeOffs>
-        <SetCodeOffs>86539088</SetCodeOffs>
+        <GetCodeOffs>86539096</GetCodeOffs>
+        <SetCodeOffs>86539120</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1698,25 +1698,25 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>86539288</GetCodeOffs>
+        <GetCodeOffs>86539320</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86539248</GetCodeOffs>
+        <GetCodeOffs>86539280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539424</GetCodeOffs>
+        <GetCodeOffs>86539456</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539344</GetCodeOffs>
+        <GetCodeOffs>86539376</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1728,7 +1728,7 @@
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539432</GetCodeOffs>
+        <GetCodeOffs>86539464</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -2299,7 +2299,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86539488</GetCodeOffs>
+        <GetCodeOffs>86539520</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -19640,14 +19640,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86545304</GetCodeOffs>
+        <GetCodeOffs>86545336</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86545208</GetCodeOffs>
+        <GetCodeOffs>86545240</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -20743,7 +20743,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86545456</GetCodeOffs>
+        <GetCodeOffs>86545488</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -21402,7 +21402,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86545568</GetCodeOffs>
+        <GetCodeOffs>86545600</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -58513,6 +58513,44 @@ second version of targets paddle 2</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+        <Comment>    Target4 := 5,
+   Target5 := 6</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</Name>
       <BitSize>1548608</BitSize>
       <SubItem>
@@ -58884,72 +58922,6 @@ second version of targets paddle 2</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-        <Comment>    Target4 := 5,
-   Target5 := 6</Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_LaserCoupling_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Mirror1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</Name>
       <BitSize>1548480</BitSize>
       <SubItem>
@@ -59279,6 +59251,34 @@ second version of targets paddle 2</Comment>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>ENUM_LaserCoupling_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Mirror1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
         </Property>
       </Properties>
     </DataType>
@@ -60156,8 +60156,8 @@ second version of targets paddle 2</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86554512</GetCodeOffs>
-        <SetCodeOffs>86554528</SetCodeOffs>
+        <GetCodeOffs>86554544</GetCodeOffs>
+        <SetCodeOffs>86554560</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -61334,31 +61334,31 @@ second version of targets paddle 2</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86553640</GetCodeOffs>
+        <GetCodeOffs>86553672</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86553704</GetCodeOffs>
+        <GetCodeOffs>86553736</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86553712</GetCodeOffs>
+        <GetCodeOffs>86553744</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86553688</GetCodeOffs>
+        <GetCodeOffs>86553720</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86553728</GetCodeOffs>
+        <GetCodeOffs>86553760</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -78176,7 +78176,7 @@ second version of targets paddle 2</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>87883776</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -78187,7 +78187,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639535296</BitOffs>
+            <BitOffs>639535552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -78199,7 +78199,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641165440</BitOffs>
+            <BitOffs>641165696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -78212,7 +78212,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173376</BitOffs>
+            <BitOffs>641173632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -78225,7 +78225,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173384</BitOffs>
+            <BitOffs>641173640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -78238,7 +78238,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173392</BitOffs>
+            <BitOffs>641173648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -78261,7 +78261,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173408</BitOffs>
+            <BitOffs>641173664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -78274,7 +78274,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173440</BitOffs>
+            <BitOffs>641173696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -78287,7 +78287,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173504</BitOffs>
+            <BitOffs>641173760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -78300,7 +78300,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173520</BitOffs>
+            <BitOffs>641173776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -78312,7 +78312,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641191360</BitOffs>
+            <BitOffs>641191616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -78325,7 +78325,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199296</BitOffs>
+            <BitOffs>641199552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -78338,7 +78338,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199304</BitOffs>
+            <BitOffs>641199560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -78351,7 +78351,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199312</BitOffs>
+            <BitOffs>641199568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -78374,7 +78374,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199328</BitOffs>
+            <BitOffs>641199584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -78387,7 +78387,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199360</BitOffs>
+            <BitOffs>641199616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -78400,7 +78400,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199424</BitOffs>
+            <BitOffs>641199680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -78413,7 +78413,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199440</BitOffs>
+            <BitOffs>641199696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -78425,7 +78425,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641217280</BitOffs>
+            <BitOffs>641217536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -78438,7 +78438,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225216</BitOffs>
+            <BitOffs>641225472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -78451,7 +78451,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225224</BitOffs>
+            <BitOffs>641225480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -78464,7 +78464,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225232</BitOffs>
+            <BitOffs>641225488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -78487,7 +78487,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225248</BitOffs>
+            <BitOffs>641225504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -78500,7 +78500,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225280</BitOffs>
+            <BitOffs>641225536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -78513,7 +78513,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225344</BitOffs>
+            <BitOffs>641225600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -78526,7 +78526,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225360</BitOffs>
+            <BitOffs>641225616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -78539,7 +78539,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641521088</BitOffs>
+            <BitOffs>641521344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78551,7 +78551,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641642048</BitOffs>
+            <BitOffs>641642304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -78563,7 +78563,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643272192</BitOffs>
+            <BitOffs>643272448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -78576,7 +78576,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280128</BitOffs>
+            <BitOffs>643280384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -78589,7 +78589,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280136</BitOffs>
+            <BitOffs>643280392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -78602,7 +78602,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280144</BitOffs>
+            <BitOffs>643280400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -78625,7 +78625,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280160</BitOffs>
+            <BitOffs>643280416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -78638,7 +78638,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280192</BitOffs>
+            <BitOffs>643280448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -78651,7 +78651,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280256</BitOffs>
+            <BitOffs>643280512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -78664,7 +78664,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280272</BitOffs>
+            <BitOffs>643280528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -78676,7 +78676,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643298112</BitOffs>
+            <BitOffs>643298368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -78689,7 +78689,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306048</BitOffs>
+            <BitOffs>643306304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -78702,7 +78702,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306056</BitOffs>
+            <BitOffs>643306312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -78715,7 +78715,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306064</BitOffs>
+            <BitOffs>643306320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -78738,7 +78738,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306080</BitOffs>
+            <BitOffs>643306336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -78751,7 +78751,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306112</BitOffs>
+            <BitOffs>643306368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -78764,7 +78764,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306176</BitOffs>
+            <BitOffs>643306432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -78777,7 +78777,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306192</BitOffs>
+            <BitOffs>643306448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -78789,7 +78789,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643324032</BitOffs>
+            <BitOffs>643324288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -78802,7 +78802,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331968</BitOffs>
+            <BitOffs>643332224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -78815,7 +78815,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331976</BitOffs>
+            <BitOffs>643332232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -78828,7 +78828,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331984</BitOffs>
+            <BitOffs>643332240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -78851,7 +78851,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332000</BitOffs>
+            <BitOffs>643332256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -78864,7 +78864,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332032</BitOffs>
+            <BitOffs>643332288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -78877,7 +78877,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332096</BitOffs>
+            <BitOffs>643332352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -78890,7 +78890,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332112</BitOffs>
+            <BitOffs>643332368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -78902,7 +78902,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643627584</BitOffs>
+            <BitOffs>643627840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -78921,7 +78921,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820040</BitOffs>
+            <BitOffs>643820296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -78933,7 +78933,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820048</BitOffs>
+            <BitOffs>643820304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -78945,7 +78945,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820056</BitOffs>
+            <BitOffs>643820312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -78957,7 +78957,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820064</BitOffs>
+            <BitOffs>643820320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -78970,7 +78970,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820352</BitOffs>
+            <BitOffs>643820608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -78983,7 +78983,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644207168</BitOffs>
+            <BitOffs>644207424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
@@ -78996,7 +78996,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208320</BitOffs>
+            <BitOffs>644208576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -79015,7 +79015,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208968</BitOffs>
+            <BitOffs>644209224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -79027,7 +79027,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208976</BitOffs>
+            <BitOffs>644209232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -79039,7 +79039,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208984</BitOffs>
+            <BitOffs>644209240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -79051,7 +79051,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208992</BitOffs>
+            <BitOffs>644209248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowSwitch.bFlowOk</Name>
@@ -79071,7 +79071,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644209088</BitOffs>
+            <BitOffs>644209344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79083,7 +79083,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644326848</BitOffs>
+            <BitOffs>644327104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -79095,7 +79095,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645956992</BitOffs>
+            <BitOffs>645957248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -79108,7 +79108,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964928</BitOffs>
+            <BitOffs>645965184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -79121,7 +79121,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964936</BitOffs>
+            <BitOffs>645965192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -79134,7 +79134,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964944</BitOffs>
+            <BitOffs>645965200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -79157,7 +79157,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964960</BitOffs>
+            <BitOffs>645965216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -79170,7 +79170,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964992</BitOffs>
+            <BitOffs>645965248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -79183,7 +79183,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645965056</BitOffs>
+            <BitOffs>645965312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -79196,7 +79196,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645965072</BitOffs>
+            <BitOffs>645965328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -79208,7 +79208,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645982912</BitOffs>
+            <BitOffs>645983168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -79221,7 +79221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990848</BitOffs>
+            <BitOffs>645991104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -79234,7 +79234,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990856</BitOffs>
+            <BitOffs>645991112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -79247,7 +79247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990864</BitOffs>
+            <BitOffs>645991120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -79270,7 +79270,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990880</BitOffs>
+            <BitOffs>645991136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -79283,7 +79283,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990912</BitOffs>
+            <BitOffs>645991168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -79296,7 +79296,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990976</BitOffs>
+            <BitOffs>645991232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -79309,7 +79309,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990992</BitOffs>
+            <BitOffs>645991248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -79321,7 +79321,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646008832</BitOffs>
+            <BitOffs>646009088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -79334,7 +79334,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016768</BitOffs>
+            <BitOffs>646017024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -79347,7 +79347,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016776</BitOffs>
+            <BitOffs>646017032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -79360,7 +79360,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016784</BitOffs>
+            <BitOffs>646017040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -79383,7 +79383,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016800</BitOffs>
+            <BitOffs>646017056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -79396,7 +79396,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016832</BitOffs>
+            <BitOffs>646017088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -79409,7 +79409,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016896</BitOffs>
+            <BitOffs>646017152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -79422,7 +79422,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016912</BitOffs>
+            <BitOffs>646017168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -79434,7 +79434,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646312384</BitOffs>
+            <BitOffs>646312640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -79453,7 +79453,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504840</BitOffs>
+            <BitOffs>646505096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -79465,7 +79465,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504848</BitOffs>
+            <BitOffs>646505104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -79477,7 +79477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504856</BitOffs>
+            <BitOffs>646505112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -79489,7 +79489,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504864</BitOffs>
+            <BitOffs>646505120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -79502,7 +79502,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646505152</BitOffs>
+            <BitOffs>646505408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -79515,7 +79515,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646891968</BitOffs>
+            <BitOffs>646892224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
@@ -79528,7 +79528,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893120</BitOffs>
+            <BitOffs>646893376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -79547,7 +79547,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893768</BitOffs>
+            <BitOffs>646894024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -79559,7 +79559,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893776</BitOffs>
+            <BitOffs>646894032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -79571,7 +79571,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893784</BitOffs>
+            <BitOffs>646894040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -79583,7 +79583,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893792</BitOffs>
+            <BitOffs>646894048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowSwitch.bFlowOk</Name>
@@ -79603,7 +79603,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893888</BitOffs>
+            <BitOffs>646894144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79615,7 +79615,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647011648</BitOffs>
+            <BitOffs>647011904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -79627,7 +79627,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648641792</BitOffs>
+            <BitOffs>648642048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -79640,7 +79640,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649728</BitOffs>
+            <BitOffs>648649984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -79653,7 +79653,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649736</BitOffs>
+            <BitOffs>648649992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -79666,7 +79666,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649744</BitOffs>
+            <BitOffs>648650000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -79689,7 +79689,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649760</BitOffs>
+            <BitOffs>648650016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -79702,7 +79702,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649792</BitOffs>
+            <BitOffs>648650048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -79715,7 +79715,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649856</BitOffs>
+            <BitOffs>648650112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -79728,7 +79728,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649872</BitOffs>
+            <BitOffs>648650128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -79740,7 +79740,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648667712</BitOffs>
+            <BitOffs>648667968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -79753,7 +79753,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675648</BitOffs>
+            <BitOffs>648675904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -79766,7 +79766,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675656</BitOffs>
+            <BitOffs>648675912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -79779,7 +79779,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675664</BitOffs>
+            <BitOffs>648675920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -79802,7 +79802,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675680</BitOffs>
+            <BitOffs>648675936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -79815,7 +79815,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675712</BitOffs>
+            <BitOffs>648675968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -79828,7 +79828,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675776</BitOffs>
+            <BitOffs>648676032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -79841,7 +79841,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675792</BitOffs>
+            <BitOffs>648676048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -79853,7 +79853,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648693632</BitOffs>
+            <BitOffs>648693888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -79866,7 +79866,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701568</BitOffs>
+            <BitOffs>648701824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -79879,7 +79879,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701576</BitOffs>
+            <BitOffs>648701832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -79892,7 +79892,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701584</BitOffs>
+            <BitOffs>648701840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -79915,7 +79915,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701600</BitOffs>
+            <BitOffs>648701856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -79928,7 +79928,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701632</BitOffs>
+            <BitOffs>648701888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -79941,7 +79941,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701696</BitOffs>
+            <BitOffs>648701952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -79954,7 +79954,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701712</BitOffs>
+            <BitOffs>648701968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -79966,7 +79966,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648997184</BitOffs>
+            <BitOffs>648997440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -79985,7 +79985,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189640</BitOffs>
+            <BitOffs>649189896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -79997,7 +79997,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189648</BitOffs>
+            <BitOffs>649189904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -80009,7 +80009,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189656</BitOffs>
+            <BitOffs>649189912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -80021,7 +80021,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189664</BitOffs>
+            <BitOffs>649189920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -80034,7 +80034,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189952</BitOffs>
+            <BitOffs>649190208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -80047,7 +80047,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649576768</BitOffs>
+            <BitOffs>649577024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
@@ -80060,7 +80060,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577920</BitOffs>
+            <BitOffs>649578176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -80079,7 +80079,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578568</BitOffs>
+            <BitOffs>649578824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -80091,7 +80091,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578576</BitOffs>
+            <BitOffs>649578832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -80103,7 +80103,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578584</BitOffs>
+            <BitOffs>649578840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -80115,7 +80115,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578592</BitOffs>
+            <BitOffs>649578848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowSwitch.bFlowOk</Name>
@@ -80135,7 +80135,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578688</BitOffs>
+            <BitOffs>649578944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80147,7 +80147,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649696448</BitOffs>
+            <BitOffs>649696704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -80159,7 +80159,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651326592</BitOffs>
+            <BitOffs>651326848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -80172,7 +80172,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334528</BitOffs>
+            <BitOffs>651334784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -80185,7 +80185,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334536</BitOffs>
+            <BitOffs>651334792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -80198,7 +80198,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334544</BitOffs>
+            <BitOffs>651334800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -80221,7 +80221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334560</BitOffs>
+            <BitOffs>651334816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -80234,7 +80234,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334592</BitOffs>
+            <BitOffs>651334848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -80247,7 +80247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334656</BitOffs>
+            <BitOffs>651334912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -80260,7 +80260,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334672</BitOffs>
+            <BitOffs>651334928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -80272,7 +80272,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651352512</BitOffs>
+            <BitOffs>651352768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -80285,7 +80285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360448</BitOffs>
+            <BitOffs>651360704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -80298,7 +80298,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360456</BitOffs>
+            <BitOffs>651360712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -80311,7 +80311,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360464</BitOffs>
+            <BitOffs>651360720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -80334,7 +80334,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360480</BitOffs>
+            <BitOffs>651360736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -80347,7 +80347,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360512</BitOffs>
+            <BitOffs>651360768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -80360,7 +80360,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360576</BitOffs>
+            <BitOffs>651360832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -80373,7 +80373,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360592</BitOffs>
+            <BitOffs>651360848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -80385,7 +80385,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651378432</BitOffs>
+            <BitOffs>651378688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -80398,7 +80398,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386368</BitOffs>
+            <BitOffs>651386624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -80411,7 +80411,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386376</BitOffs>
+            <BitOffs>651386632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -80424,7 +80424,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386384</BitOffs>
+            <BitOffs>651386640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -80447,7 +80447,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386400</BitOffs>
+            <BitOffs>651386656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -80460,7 +80460,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386432</BitOffs>
+            <BitOffs>651386688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -80473,7 +80473,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386496</BitOffs>
+            <BitOffs>651386752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -80486,7 +80486,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386512</BitOffs>
+            <BitOffs>651386768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -80498,7 +80498,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651681984</BitOffs>
+            <BitOffs>651682240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -80517,7 +80517,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874440</BitOffs>
+            <BitOffs>651874696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -80529,7 +80529,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874448</BitOffs>
+            <BitOffs>651874704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -80541,7 +80541,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874456</BitOffs>
+            <BitOffs>651874712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -80553,7 +80553,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874464</BitOffs>
+            <BitOffs>651874720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -80566,7 +80566,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874752</BitOffs>
+            <BitOffs>651875008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -80579,7 +80579,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652261568</BitOffs>
+            <BitOffs>652261824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
@@ -80592,7 +80592,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262720</BitOffs>
+            <BitOffs>652262976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -80611,7 +80611,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263368</BitOffs>
+            <BitOffs>652263624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -80623,7 +80623,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263376</BitOffs>
+            <BitOffs>652263632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -80635,7 +80635,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263384</BitOffs>
+            <BitOffs>652263640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -80647,7 +80647,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263392</BitOffs>
+            <BitOffs>652263648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowSwitch.bFlowOk</Name>
@@ -80667,7 +80667,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263488</BitOffs>
+            <BitOffs>652263744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80679,7 +80679,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652381248</BitOffs>
+            <BitOffs>652381504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -80691,7 +80691,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654011392</BitOffs>
+            <BitOffs>654011648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -80704,7 +80704,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019328</BitOffs>
+            <BitOffs>654019584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -80717,7 +80717,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019336</BitOffs>
+            <BitOffs>654019592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -80730,7 +80730,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019344</BitOffs>
+            <BitOffs>654019600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -80753,7 +80753,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019360</BitOffs>
+            <BitOffs>654019616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -80766,7 +80766,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019392</BitOffs>
+            <BitOffs>654019648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -80779,7 +80779,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019456</BitOffs>
+            <BitOffs>654019712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -80792,7 +80792,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019472</BitOffs>
+            <BitOffs>654019728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -80804,7 +80804,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654037312</BitOffs>
+            <BitOffs>654037568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -80817,7 +80817,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045248</BitOffs>
+            <BitOffs>654045504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -80830,7 +80830,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045256</BitOffs>
+            <BitOffs>654045512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -80843,7 +80843,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045264</BitOffs>
+            <BitOffs>654045520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -80866,7 +80866,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045280</BitOffs>
+            <BitOffs>654045536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -80879,7 +80879,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045312</BitOffs>
+            <BitOffs>654045568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -80892,7 +80892,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045376</BitOffs>
+            <BitOffs>654045632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -80905,7 +80905,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045392</BitOffs>
+            <BitOffs>654045648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -80917,7 +80917,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654063232</BitOffs>
+            <BitOffs>654063488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -80930,7 +80930,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071168</BitOffs>
+            <BitOffs>654071424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -80943,7 +80943,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071176</BitOffs>
+            <BitOffs>654071432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -80956,7 +80956,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071184</BitOffs>
+            <BitOffs>654071440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -80979,7 +80979,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071200</BitOffs>
+            <BitOffs>654071456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -80992,7 +80992,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071232</BitOffs>
+            <BitOffs>654071488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81005,7 +81005,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071296</BitOffs>
+            <BitOffs>654071552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81018,7 +81018,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071312</BitOffs>
+            <BitOffs>654071568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -81030,7 +81030,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654366784</BitOffs>
+            <BitOffs>654367040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -81049,7 +81049,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559240</BitOffs>
+            <BitOffs>654559496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -81061,7 +81061,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559248</BitOffs>
+            <BitOffs>654559504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -81073,7 +81073,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559256</BitOffs>
+            <BitOffs>654559512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -81085,7 +81085,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559264</BitOffs>
+            <BitOffs>654559520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -81098,7 +81098,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559552</BitOffs>
+            <BitOffs>654559808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -81111,7 +81111,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654946368</BitOffs>
+            <BitOffs>654946624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
@@ -81124,7 +81124,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947520</BitOffs>
+            <BitOffs>654947776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -81143,7 +81143,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948168</BitOffs>
+            <BitOffs>654948424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -81155,7 +81155,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948176</BitOffs>
+            <BitOffs>654948432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -81167,7 +81167,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948184</BitOffs>
+            <BitOffs>654948440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -81179,7 +81179,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948192</BitOffs>
+            <BitOffs>654948448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowSwitch.bFlowOk</Name>
@@ -81199,7 +81199,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948288</BitOffs>
+            <BitOffs>654948544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81211,7 +81211,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655066368</BitOffs>
+            <BitOffs>655066624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -81223,7 +81223,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656696512</BitOffs>
+            <BitOffs>656696768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -81236,7 +81236,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704448</BitOffs>
+            <BitOffs>656704704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -81249,7 +81249,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704456</BitOffs>
+            <BitOffs>656704712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -81262,7 +81262,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704464</BitOffs>
+            <BitOffs>656704720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -81285,7 +81285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704480</BitOffs>
+            <BitOffs>656704736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -81298,7 +81298,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704512</BitOffs>
+            <BitOffs>656704768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -81311,7 +81311,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704576</BitOffs>
+            <BitOffs>656704832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -81324,7 +81324,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704592</BitOffs>
+            <BitOffs>656704848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -81336,7 +81336,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656722432</BitOffs>
+            <BitOffs>656722688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -81349,7 +81349,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730368</BitOffs>
+            <BitOffs>656730624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -81362,7 +81362,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730376</BitOffs>
+            <BitOffs>656730632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -81375,7 +81375,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730384</BitOffs>
+            <BitOffs>656730640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -81398,7 +81398,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730400</BitOffs>
+            <BitOffs>656730656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -81411,7 +81411,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730432</BitOffs>
+            <BitOffs>656730688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -81424,7 +81424,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730496</BitOffs>
+            <BitOffs>656730752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -81437,7 +81437,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730512</BitOffs>
+            <BitOffs>656730768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -81449,7 +81449,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656748352</BitOffs>
+            <BitOffs>656748608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -81462,7 +81462,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756288</BitOffs>
+            <BitOffs>656756544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -81475,7 +81475,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756296</BitOffs>
+            <BitOffs>656756552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -81488,7 +81488,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756304</BitOffs>
+            <BitOffs>656756560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -81511,7 +81511,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756320</BitOffs>
+            <BitOffs>656756576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -81524,7 +81524,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756352</BitOffs>
+            <BitOffs>656756608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81537,7 +81537,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756416</BitOffs>
+            <BitOffs>656756672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81550,7 +81550,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756432</BitOffs>
+            <BitOffs>656756688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81562,7 +81562,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657177664</BitOffs>
+            <BitOffs>657177920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81574,7 +81574,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657504704</BitOffs>
+            <BitOffs>657504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -81586,7 +81586,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659134848</BitOffs>
+            <BitOffs>659135104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -81599,7 +81599,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142784</BitOffs>
+            <BitOffs>659143040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -81612,7 +81612,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142792</BitOffs>
+            <BitOffs>659143048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -81625,7 +81625,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142800</BitOffs>
+            <BitOffs>659143056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -81648,7 +81648,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142816</BitOffs>
+            <BitOffs>659143072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -81661,7 +81661,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142848</BitOffs>
+            <BitOffs>659143104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -81674,7 +81674,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142912</BitOffs>
+            <BitOffs>659143168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -81687,7 +81687,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142928</BitOffs>
+            <BitOffs>659143184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -81699,7 +81699,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659160768</BitOffs>
+            <BitOffs>659161024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -81712,7 +81712,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168704</BitOffs>
+            <BitOffs>659168960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -81725,7 +81725,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168712</BitOffs>
+            <BitOffs>659168968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -81738,7 +81738,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168720</BitOffs>
+            <BitOffs>659168976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -81761,7 +81761,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168736</BitOffs>
+            <BitOffs>659168992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -81774,7 +81774,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168768</BitOffs>
+            <BitOffs>659169024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -81787,7 +81787,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168832</BitOffs>
+            <BitOffs>659169088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -81800,7 +81800,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168848</BitOffs>
+            <BitOffs>659169104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -81812,7 +81812,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659186688</BitOffs>
+            <BitOffs>659186944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -81825,7 +81825,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194624</BitOffs>
+            <BitOffs>659194880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -81838,7 +81838,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194632</BitOffs>
+            <BitOffs>659194888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -81851,7 +81851,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194640</BitOffs>
+            <BitOffs>659194896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -81874,7 +81874,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194656</BitOffs>
+            <BitOffs>659194912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -81887,7 +81887,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194688</BitOffs>
+            <BitOffs>659194944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81900,7 +81900,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194752</BitOffs>
+            <BitOffs>659195008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81913,7 +81913,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194768</BitOffs>
+            <BitOffs>659195024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -81937,7 +81937,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490376</BitOffs>
+            <BitOffs>659490632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -81949,7 +81949,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490384</BitOffs>
+            <BitOffs>659490640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -81961,7 +81961,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490392</BitOffs>
+            <BitOffs>659490648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -81973,7 +81973,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490400</BitOffs>
+            <BitOffs>659490656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -81997,7 +81997,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490632</BitOffs>
+            <BitOffs>659490888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -82009,7 +82009,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490640</BitOffs>
+            <BitOffs>659490896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -82021,7 +82021,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490648</BitOffs>
+            <BitOffs>659490904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -82033,7 +82033,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490656</BitOffs>
+            <BitOffs>659490912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowSwitch.bFlowOk</Name>
@@ -82053,7 +82053,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490752</BitOffs>
+            <BitOffs>659491008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowMeter.iRaw</Name>
@@ -82066,7 +82066,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490880</BitOffs>
+            <BitOffs>659491136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82078,7 +82078,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659616448</BitOffs>
+            <BitOffs>659616704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82090,7 +82090,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659943488</BitOffs>
+            <BitOffs>659943744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -82102,7 +82102,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661573632</BitOffs>
+            <BitOffs>661573888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -82115,7 +82115,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581568</BitOffs>
+            <BitOffs>661581824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -82128,7 +82128,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581576</BitOffs>
+            <BitOffs>661581832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -82141,7 +82141,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581584</BitOffs>
+            <BitOffs>661581840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -82164,7 +82164,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581600</BitOffs>
+            <BitOffs>661581856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -82177,7 +82177,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581632</BitOffs>
+            <BitOffs>661581888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -82190,7 +82190,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581696</BitOffs>
+            <BitOffs>661581952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -82203,7 +82203,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581712</BitOffs>
+            <BitOffs>661581968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -82215,7 +82215,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661599552</BitOffs>
+            <BitOffs>661599808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -82228,7 +82228,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607488</BitOffs>
+            <BitOffs>661607744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -82241,7 +82241,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607496</BitOffs>
+            <BitOffs>661607752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -82254,7 +82254,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607504</BitOffs>
+            <BitOffs>661607760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -82277,7 +82277,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607520</BitOffs>
+            <BitOffs>661607776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -82290,7 +82290,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607552</BitOffs>
+            <BitOffs>661607808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -82303,7 +82303,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607616</BitOffs>
+            <BitOffs>661607872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -82316,7 +82316,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607632</BitOffs>
+            <BitOffs>661607888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -82328,7 +82328,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661625472</BitOffs>
+            <BitOffs>661625728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -82341,7 +82341,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633408</BitOffs>
+            <BitOffs>661633664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -82354,7 +82354,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633416</BitOffs>
+            <BitOffs>661633672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -82367,7 +82367,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633424</BitOffs>
+            <BitOffs>661633680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -82390,7 +82390,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633440</BitOffs>
+            <BitOffs>661633696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -82403,7 +82403,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633472</BitOffs>
+            <BitOffs>661633728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -82416,7 +82416,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633536</BitOffs>
+            <BitOffs>661633792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -82429,7 +82429,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633552</BitOffs>
+            <BitOffs>661633808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -82453,7 +82453,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929160</BitOffs>
+            <BitOffs>661929416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -82465,7 +82465,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929168</BitOffs>
+            <BitOffs>661929424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -82477,7 +82477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929176</BitOffs>
+            <BitOffs>661929432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -82489,7 +82489,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929184</BitOffs>
+            <BitOffs>661929440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -82513,7 +82513,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929416</BitOffs>
+            <BitOffs>661929672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -82525,7 +82525,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929424</BitOffs>
+            <BitOffs>661929680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -82537,7 +82537,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929432</BitOffs>
+            <BitOffs>661929688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -82549,7 +82549,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929440</BitOffs>
+            <BitOffs>661929696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowSwitch.bFlowOk</Name>
@@ -82569,7 +82569,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929536</BitOffs>
+            <BitOffs>661929792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowMeter.iRaw</Name>
@@ -82582,7 +82582,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929664</BitOffs>
+            <BitOffs>661929920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82594,7 +82594,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662031360</BitOffs>
+            <BitOffs>662031616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82606,7 +82606,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662358400</BitOffs>
+            <BitOffs>662358656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82618,7 +82618,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662685440</BitOffs>
+            <BitOffs>662685696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82630,7 +82630,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663012480</BitOffs>
+            <BitOffs>663012736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -82642,67 +82642,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663494784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663503488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663830528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664157568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664484608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664966912</BitOffs>
+            <BitOffs>663495040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -82718,39 +82658,67 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664967064</BitOffs>
+            <BitOffs>663499192</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bHallInput2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[LensX_EL1004]^Channel 2^Input</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664971040</BitOffs>
+            <BitOffs>663503808</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL1High</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664971048</BitOffs>
+            <BitOffs>663830848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664157888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664484928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664967232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -82763,7 +82731,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665085952</BitOffs>
+            <BitOffs>665086208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -82775,7 +82743,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665085960</BitOffs>
+            <BitOffs>665086216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82787,7 +82755,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665123968</BitOffs>
+            <BitOffs>665124224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82799,7 +82767,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665451008</BitOffs>
+            <BitOffs>665451264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -82823,7 +82791,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492040</BitOffs>
+            <BitOffs>666492296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -82835,7 +82803,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492048</BitOffs>
+            <BitOffs>666492304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -82847,7 +82815,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492056</BitOffs>
+            <BitOffs>666492312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -82859,7 +82827,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492064</BitOffs>
+            <BitOffs>666492320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbFlowMeter.iRaw</Name>
@@ -82872,7 +82840,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492160</BitOffs>
+            <BitOffs>666492416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82884,7 +82852,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666520256</BitOffs>
+            <BitOffs>666520512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82896,7 +82864,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666847296</BitOffs>
+            <BitOffs>666847552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -82920,7 +82888,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880904</BitOffs>
+            <BitOffs>667881160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -82932,7 +82900,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880912</BitOffs>
+            <BitOffs>667881168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -82944,7 +82912,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880920</BitOffs>
+            <BitOffs>667881176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -82956,7 +82924,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880928</BitOffs>
+            <BitOffs>667881184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbFlowMeter.iRaw</Name>
@@ -82969,7 +82937,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667881024</BitOffs>
+            <BitOffs>667881280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82981,7 +82949,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667884864</BitOffs>
+            <BitOffs>667885120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82993,7 +82961,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668211904</BitOffs>
+            <BitOffs>668212160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83005,7 +82973,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668538944</BitOffs>
+            <BitOffs>668539200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83017,7 +82985,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668865984</BitOffs>
+            <BitOffs>668866240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83029,7 +82997,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669193024</BitOffs>
+            <BitOffs>669193280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83041,7 +83009,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669520064</BitOffs>
+            <BitOffs>669520320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83053,7 +83021,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669847104</BitOffs>
+            <BitOffs>669847360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83065,7 +83033,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670174144</BitOffs>
+            <BitOffs>670174400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83077,7 +83045,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670501184</BitOffs>
+            <BitOffs>670501440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83089,7 +83057,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670828224</BitOffs>
+            <BitOffs>670828480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83101,7 +83069,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671155264</BitOffs>
+            <BitOffs>671155520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83113,7 +83081,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671482304</BitOffs>
+            <BitOffs>671482560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83125,7 +83093,39 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671809344</BitOffs>
+            <BitOffs>671809600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bHallInput2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[LensX_EL1004]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>672134016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL1High</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>672134024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1Low</Name>
@@ -83141,7 +83141,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672133760</BitOffs>
+            <BitOffs>672134048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2High</Name>
@@ -83157,7 +83157,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672133768</BitOffs>
+            <BitOffs>672134056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2Low</Name>
@@ -83173,7 +83173,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672133808</BitOffs>
+            <BitOffs>672134096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -83185,7 +83185,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673438784</BitOffs>
+            <BitOffs>673439104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83198,7 +83198,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446720</BitOffs>
+            <BitOffs>673447040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83211,7 +83211,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446728</BitOffs>
+            <BitOffs>673447048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -83224,7 +83224,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446736</BitOffs>
+            <BitOffs>673447056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83247,7 +83247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446752</BitOffs>
+            <BitOffs>673447072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83260,7 +83260,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446784</BitOffs>
+            <BitOffs>673447104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83273,7 +83273,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446848</BitOffs>
+            <BitOffs>673447168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83286,7 +83286,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446864</BitOffs>
+            <BitOffs>673447184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83298,7 +83298,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673464704</BitOffs>
+            <BitOffs>673465024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83311,7 +83311,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472640</BitOffs>
+            <BitOffs>673472960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83324,7 +83324,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472648</BitOffs>
+            <BitOffs>673472968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -83337,7 +83337,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472656</BitOffs>
+            <BitOffs>673472976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83360,7 +83360,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472672</BitOffs>
+            <BitOffs>673472992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83373,7 +83373,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472704</BitOffs>
+            <BitOffs>673473024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83386,7 +83386,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472768</BitOffs>
+            <BitOffs>673473088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83399,7 +83399,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472784</BitOffs>
+            <BitOffs>673473104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83411,7 +83411,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673490624</BitOffs>
+            <BitOffs>673490944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83424,7 +83424,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498560</BitOffs>
+            <BitOffs>673498880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83437,7 +83437,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498568</BitOffs>
+            <BitOffs>673498888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -83450,7 +83450,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498576</BitOffs>
+            <BitOffs>673498896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83473,7 +83473,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498592</BitOffs>
+            <BitOffs>673498912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83486,7 +83486,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498624</BitOffs>
+            <BitOffs>673498944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83499,7 +83499,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498688</BitOffs>
+            <BitOffs>673499008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83512,7 +83512,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498704</BitOffs>
+            <BitOffs>673499024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -83524,7 +83524,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675250112</BitOffs>
+            <BitOffs>675250368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83537,7 +83537,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258048</BitOffs>
+            <BitOffs>675258304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83550,7 +83550,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258056</BitOffs>
+            <BitOffs>675258312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -83563,7 +83563,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258064</BitOffs>
+            <BitOffs>675258320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83586,7 +83586,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258080</BitOffs>
+            <BitOffs>675258336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83599,7 +83599,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258112</BitOffs>
+            <BitOffs>675258368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83612,7 +83612,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258176</BitOffs>
+            <BitOffs>675258432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83625,7 +83625,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258192</BitOffs>
+            <BitOffs>675258448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83637,7 +83637,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675276032</BitOffs>
+            <BitOffs>675276288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83650,7 +83650,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675283968</BitOffs>
+            <BitOffs>675284224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83663,7 +83663,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675283976</BitOffs>
+            <BitOffs>675284232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -83676,7 +83676,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675283984</BitOffs>
+            <BitOffs>675284240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83699,7 +83699,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284000</BitOffs>
+            <BitOffs>675284256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83712,7 +83712,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284032</BitOffs>
+            <BitOffs>675284288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83725,7 +83725,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284096</BitOffs>
+            <BitOffs>675284352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83738,7 +83738,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284112</BitOffs>
+            <BitOffs>675284368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83750,7 +83750,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675301952</BitOffs>
+            <BitOffs>675302208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83763,7 +83763,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309888</BitOffs>
+            <BitOffs>675310144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83776,7 +83776,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309896</BitOffs>
+            <BitOffs>675310152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -83789,7 +83789,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309904</BitOffs>
+            <BitOffs>675310160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83812,7 +83812,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309920</BitOffs>
+            <BitOffs>675310176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83825,7 +83825,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309952</BitOffs>
+            <BitOffs>675310208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83838,7 +83838,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675310016</BitOffs>
+            <BitOffs>675310272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83851,7 +83851,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675310032</BitOffs>
+            <BitOffs>675310288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bError</Name>
@@ -83875,7 +83875,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701128</BitOffs>
+            <BitOffs>675701448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange</Name>
@@ -83887,7 +83887,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701136</BitOffs>
+            <BitOffs>675701456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange</Name>
@@ -83899,7 +83899,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701144</BitOffs>
+            <BitOffs>675701464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw</Name>
@@ -83911,7 +83911,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701152</BitOffs>
+            <BitOffs>675701472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bError</Name>
@@ -83935,7 +83935,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701384</BitOffs>
+            <BitOffs>675701704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange</Name>
@@ -83947,7 +83947,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701392</BitOffs>
+            <BitOffs>675701712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange</Name>
@@ -83959,7 +83959,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701400</BitOffs>
+            <BitOffs>675701720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw</Name>
@@ -83971,7 +83971,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701408</BitOffs>
+            <BitOffs>675701728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83983,7 +83983,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675704576</BitOffs>
+            <BitOffs>675704896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83995,7 +83995,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676031616</BitOffs>
+            <BitOffs>676031936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -84007,7 +84007,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677660800</BitOffs>
+            <BitOffs>677661120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -84020,7 +84020,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668736</BitOffs>
+            <BitOffs>677669056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -84033,7 +84033,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668744</BitOffs>
+            <BitOffs>677669064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHome</Name>
@@ -84046,7 +84046,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668752</BitOffs>
+            <BitOffs>677669072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -84069,7 +84069,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668768</BitOffs>
+            <BitOffs>677669088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -84082,7 +84082,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668800</BitOffs>
+            <BitOffs>677669120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -84095,7 +84095,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668864</BitOffs>
+            <BitOffs>677669184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -84108,7 +84108,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668880</BitOffs>
+            <BitOffs>677669200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -84120,7 +84120,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677686720</BitOffs>
+            <BitOffs>677687040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -84133,7 +84133,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694656</BitOffs>
+            <BitOffs>677694976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -84146,7 +84146,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694664</BitOffs>
+            <BitOffs>677694984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHome</Name>
@@ -84159,7 +84159,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694672</BitOffs>
+            <BitOffs>677694992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -84182,7 +84182,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694688</BitOffs>
+            <BitOffs>677695008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -84195,7 +84195,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694720</BitOffs>
+            <BitOffs>677695040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -84208,7 +84208,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694784</BitOffs>
+            <BitOffs>677695104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -84221,7 +84221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694800</BitOffs>
+            <BitOffs>677695120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -84233,7 +84233,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677712640</BitOffs>
+            <BitOffs>677712960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -84246,7 +84246,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720576</BitOffs>
+            <BitOffs>677720896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -84259,7 +84259,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720584</BitOffs>
+            <BitOffs>677720904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHome</Name>
@@ -84272,7 +84272,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720592</BitOffs>
+            <BitOffs>677720912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -84295,7 +84295,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720608</BitOffs>
+            <BitOffs>677720928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -84308,7 +84308,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720640</BitOffs>
+            <BitOffs>677720960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -84321,7 +84321,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720704</BitOffs>
+            <BitOffs>677721024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -84334,7 +84334,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720720</BitOffs>
+            <BitOffs>677721040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84346,7 +84346,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678114816</BitOffs>
+            <BitOffs>678115072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -84358,7 +84358,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679743872</BitOffs>
+            <BitOffs>679744128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -84371,7 +84371,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751808</BitOffs>
+            <BitOffs>679752064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -84384,7 +84384,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751816</BitOffs>
+            <BitOffs>679752072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHome</Name>
@@ -84397,7 +84397,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751824</BitOffs>
+            <BitOffs>679752080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -84420,7 +84420,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751840</BitOffs>
+            <BitOffs>679752096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -84433,7 +84433,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751872</BitOffs>
+            <BitOffs>679752128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -84446,7 +84446,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751936</BitOffs>
+            <BitOffs>679752192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -84459,7 +84459,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751952</BitOffs>
+            <BitOffs>679752208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -84471,7 +84471,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679769792</BitOffs>
+            <BitOffs>679770048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -84484,7 +84484,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777728</BitOffs>
+            <BitOffs>679777984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -84497,7 +84497,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777736</BitOffs>
+            <BitOffs>679777992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHome</Name>
@@ -84510,7 +84510,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777744</BitOffs>
+            <BitOffs>679778000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -84533,7 +84533,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777760</BitOffs>
+            <BitOffs>679778016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -84546,7 +84546,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777792</BitOffs>
+            <BitOffs>679778048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -84559,7 +84559,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777856</BitOffs>
+            <BitOffs>679778112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -84572,7 +84572,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777872</BitOffs>
+            <BitOffs>679778128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -84584,7 +84584,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679795712</BitOffs>
+            <BitOffs>679795968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -84597,7 +84597,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803648</BitOffs>
+            <BitOffs>679803904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -84610,7 +84610,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803656</BitOffs>
+            <BitOffs>679803912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHome</Name>
@@ -84623,7 +84623,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803664</BitOffs>
+            <BitOffs>679803920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -84646,7 +84646,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803680</BitOffs>
+            <BitOffs>679803936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -84659,7 +84659,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803712</BitOffs>
+            <BitOffs>679803968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -84672,7 +84672,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803776</BitOffs>
+            <BitOffs>679804032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -84685,7 +84685,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803792</BitOffs>
+            <BitOffs>679804048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -84701,7 +84701,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680141184</BitOffs>
+            <BitOffs>680141504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -84722,7 +84722,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680144704</BitOffs>
+            <BitOffs>680145024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -84743,7 +84743,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680144705</BitOffs>
+            <BitOffs>680145025</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -84755,7 +84755,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690810048</BitOffs>
+            <BitOffs>690810304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -84768,7 +84768,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690817984</BitOffs>
+            <BitOffs>690818240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -84781,7 +84781,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690817992</BitOffs>
+            <BitOffs>690818248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -84794,7 +84794,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818000</BitOffs>
+            <BitOffs>690818256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -84817,7 +84817,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818016</BitOffs>
+            <BitOffs>690818272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -84830,7 +84830,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818048</BitOffs>
+            <BitOffs>690818304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -84843,7 +84843,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818112</BitOffs>
+            <BitOffs>690818368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -84856,7 +84856,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818128</BitOffs>
+            <BitOffs>690818384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -84868,7 +84868,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690835968</BitOffs>
+            <BitOffs>690836224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -84881,7 +84881,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843904</BitOffs>
+            <BitOffs>690844160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -84894,7 +84894,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843912</BitOffs>
+            <BitOffs>690844168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -84907,7 +84907,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843920</BitOffs>
+            <BitOffs>690844176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -84930,7 +84930,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843936</BitOffs>
+            <BitOffs>690844192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -84943,7 +84943,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843968</BitOffs>
+            <BitOffs>690844224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -84956,7 +84956,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690844032</BitOffs>
+            <BitOffs>690844288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -84969,7 +84969,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690844048</BitOffs>
+            <BitOffs>690844304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -84981,7 +84981,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690861888</BitOffs>
+            <BitOffs>690862144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -84994,7 +84994,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869824</BitOffs>
+            <BitOffs>690870080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -85007,7 +85007,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869832</BitOffs>
+            <BitOffs>690870088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -85020,7 +85020,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869840</BitOffs>
+            <BitOffs>690870096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -85043,7 +85043,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869856</BitOffs>
+            <BitOffs>690870112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -85056,7 +85056,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869888</BitOffs>
+            <BitOffs>690870144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -85069,7 +85069,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869952</BitOffs>
+            <BitOffs>690870208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -85082,7 +85082,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869968</BitOffs>
+            <BitOffs>690870224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -85094,7 +85094,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690887808</BitOffs>
+            <BitOffs>690888064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -85107,7 +85107,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895744</BitOffs>
+            <BitOffs>690896000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -85120,7 +85120,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895752</BitOffs>
+            <BitOffs>690896008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -85133,7 +85133,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895760</BitOffs>
+            <BitOffs>690896016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -85156,7 +85156,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895776</BitOffs>
+            <BitOffs>690896032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -85169,7 +85169,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895808</BitOffs>
+            <BitOffs>690896064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -85182,7 +85182,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895872</BitOffs>
+            <BitOffs>690896128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -85195,7 +85195,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895888</BitOffs>
+            <BitOffs>690896144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -85207,7 +85207,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690913728</BitOffs>
+            <BitOffs>690913984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -85220,7 +85220,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921664</BitOffs>
+            <BitOffs>690921920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -85233,7 +85233,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921672</BitOffs>
+            <BitOffs>690921928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -85246,7 +85246,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921680</BitOffs>
+            <BitOffs>690921936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -85269,7 +85269,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921696</BitOffs>
+            <BitOffs>690921952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -85282,7 +85282,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921728</BitOffs>
+            <BitOffs>690921984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -85295,7 +85295,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921792</BitOffs>
+            <BitOffs>690922048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -85308,7 +85308,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921808</BitOffs>
+            <BitOffs>690922064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -85320,7 +85320,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690939648</BitOffs>
+            <BitOffs>690939904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -85333,7 +85333,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947584</BitOffs>
+            <BitOffs>690947840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -85346,7 +85346,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947592</BitOffs>
+            <BitOffs>690947848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -85359,7 +85359,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947600</BitOffs>
+            <BitOffs>690947856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -85382,7 +85382,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947616</BitOffs>
+            <BitOffs>690947872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -85395,7 +85395,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947648</BitOffs>
+            <BitOffs>690947904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -85408,7 +85408,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947712</BitOffs>
+            <BitOffs>690947968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -85421,7 +85421,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947728</BitOffs>
+            <BitOffs>690947984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -85433,7 +85433,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690965568</BitOffs>
+            <BitOffs>690965824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -85446,7 +85446,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973504</BitOffs>
+            <BitOffs>690973760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -85459,7 +85459,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973512</BitOffs>
+            <BitOffs>690973768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -85472,7 +85472,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973520</BitOffs>
+            <BitOffs>690973776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -85495,7 +85495,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973536</BitOffs>
+            <BitOffs>690973792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -85508,7 +85508,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973568</BitOffs>
+            <BitOffs>690973824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -85521,7 +85521,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973632</BitOffs>
+            <BitOffs>690973888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -85534,7 +85534,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973648</BitOffs>
+            <BitOffs>690973904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -85546,7 +85546,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690991488</BitOffs>
+            <BitOffs>690991744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -85559,7 +85559,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999424</BitOffs>
+            <BitOffs>690999680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -85572,7 +85572,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999432</BitOffs>
+            <BitOffs>690999688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -85585,7 +85585,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999440</BitOffs>
+            <BitOffs>690999696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -85608,7 +85608,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999456</BitOffs>
+            <BitOffs>690999712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -85621,7 +85621,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999488</BitOffs>
+            <BitOffs>690999744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -85634,7 +85634,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999552</BitOffs>
+            <BitOffs>690999808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -85647,7 +85647,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999568</BitOffs>
+            <BitOffs>690999824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -85659,7 +85659,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691017408</BitOffs>
+            <BitOffs>691017664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -85672,7 +85672,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025344</BitOffs>
+            <BitOffs>691025600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -85685,7 +85685,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025352</BitOffs>
+            <BitOffs>691025608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -85698,7 +85698,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025360</BitOffs>
+            <BitOffs>691025616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -85721,7 +85721,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025376</BitOffs>
+            <BitOffs>691025632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -85734,7 +85734,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025408</BitOffs>
+            <BitOffs>691025664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -85747,7 +85747,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025472</BitOffs>
+            <BitOffs>691025728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -85760,7 +85760,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025488</BitOffs>
+            <BitOffs>691025744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -85772,7 +85772,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691043328</BitOffs>
+            <BitOffs>691043584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -85785,7 +85785,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051264</BitOffs>
+            <BitOffs>691051520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -85798,7 +85798,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051272</BitOffs>
+            <BitOffs>691051528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -85811,7 +85811,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051280</BitOffs>
+            <BitOffs>691051536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -85834,7 +85834,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051296</BitOffs>
+            <BitOffs>691051552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -85847,7 +85847,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051328</BitOffs>
+            <BitOffs>691051584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -85860,7 +85860,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051392</BitOffs>
+            <BitOffs>691051648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -85873,7 +85873,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051408</BitOffs>
+            <BitOffs>691051664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -85885,7 +85885,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691069248</BitOffs>
+            <BitOffs>691069504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -85898,7 +85898,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077184</BitOffs>
+            <BitOffs>691077440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -85911,7 +85911,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077192</BitOffs>
+            <BitOffs>691077448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -85924,7 +85924,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077200</BitOffs>
+            <BitOffs>691077456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -85947,7 +85947,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077216</BitOffs>
+            <BitOffs>691077472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -85960,7 +85960,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077248</BitOffs>
+            <BitOffs>691077504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -85973,7 +85973,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077312</BitOffs>
+            <BitOffs>691077568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -85986,7 +85986,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077328</BitOffs>
+            <BitOffs>691077584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -85998,7 +85998,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691095168</BitOffs>
+            <BitOffs>691095424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -86011,7 +86011,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103104</BitOffs>
+            <BitOffs>691103360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -86024,7 +86024,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103112</BitOffs>
+            <BitOffs>691103368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -86037,7 +86037,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103120</BitOffs>
+            <BitOffs>691103376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -86060,7 +86060,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103136</BitOffs>
+            <BitOffs>691103392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -86073,7 +86073,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103168</BitOffs>
+            <BitOffs>691103424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -86086,7 +86086,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103232</BitOffs>
+            <BitOffs>691103488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -86099,7 +86099,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103248</BitOffs>
+            <BitOffs>691103504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -86111,7 +86111,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691121088</BitOffs>
+            <BitOffs>691121344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -86124,7 +86124,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129024</BitOffs>
+            <BitOffs>691129280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -86137,7 +86137,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129032</BitOffs>
+            <BitOffs>691129288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -86150,7 +86150,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129040</BitOffs>
+            <BitOffs>691129296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -86173,7 +86173,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129056</BitOffs>
+            <BitOffs>691129312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -86186,7 +86186,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129088</BitOffs>
+            <BitOffs>691129344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -86199,7 +86199,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129152</BitOffs>
+            <BitOffs>691129408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -86212,7 +86212,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129168</BitOffs>
+            <BitOffs>691129424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -86224,7 +86224,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691147008</BitOffs>
+            <BitOffs>691147264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -86237,7 +86237,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154944</BitOffs>
+            <BitOffs>691155200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -86250,7 +86250,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154952</BitOffs>
+            <BitOffs>691155208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -86263,7 +86263,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154960</BitOffs>
+            <BitOffs>691155216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -86286,7 +86286,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154976</BitOffs>
+            <BitOffs>691155232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -86299,7 +86299,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691155008</BitOffs>
+            <BitOffs>691155264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -86312,7 +86312,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691155072</BitOffs>
+            <BitOffs>691155328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -86325,7 +86325,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691155088</BitOffs>
+            <BitOffs>691155344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -86337,7 +86337,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691172928</BitOffs>
+            <BitOffs>691173184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -86350,7 +86350,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180864</BitOffs>
+            <BitOffs>691181120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -86363,7 +86363,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180872</BitOffs>
+            <BitOffs>691181128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -86376,7 +86376,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180880</BitOffs>
+            <BitOffs>691181136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -86399,7 +86399,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180896</BitOffs>
+            <BitOffs>691181152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -86412,7 +86412,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180928</BitOffs>
+            <BitOffs>691181184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -86425,7 +86425,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180992</BitOffs>
+            <BitOffs>691181248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -86438,7 +86438,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691181008</BitOffs>
+            <BitOffs>691181264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -86450,7 +86450,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691198848</BitOffs>
+            <BitOffs>691199104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -86463,7 +86463,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206784</BitOffs>
+            <BitOffs>691207040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -86476,7 +86476,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206792</BitOffs>
+            <BitOffs>691207048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -86489,7 +86489,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206800</BitOffs>
+            <BitOffs>691207056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -86512,7 +86512,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206816</BitOffs>
+            <BitOffs>691207072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -86525,7 +86525,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206848</BitOffs>
+            <BitOffs>691207104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -86538,7 +86538,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206912</BitOffs>
+            <BitOffs>691207168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -86551,7 +86551,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206928</BitOffs>
+            <BitOffs>691207184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -86563,7 +86563,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691224768</BitOffs>
+            <BitOffs>691225024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -86576,7 +86576,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232704</BitOffs>
+            <BitOffs>691232960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -86589,7 +86589,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232712</BitOffs>
+            <BitOffs>691232968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -86602,7 +86602,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232720</BitOffs>
+            <BitOffs>691232976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -86625,7 +86625,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232736</BitOffs>
+            <BitOffs>691232992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -86638,7 +86638,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232768</BitOffs>
+            <BitOffs>691233024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -86651,7 +86651,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232832</BitOffs>
+            <BitOffs>691233088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -86664,7 +86664,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232848</BitOffs>
+            <BitOffs>691233104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -86676,7 +86676,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691250688</BitOffs>
+            <BitOffs>691250944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -86689,7 +86689,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258624</BitOffs>
+            <BitOffs>691258880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -86702,7 +86702,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258632</BitOffs>
+            <BitOffs>691258888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -86715,7 +86715,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258640</BitOffs>
+            <BitOffs>691258896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -86738,7 +86738,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258656</BitOffs>
+            <BitOffs>691258912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -86751,7 +86751,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258688</BitOffs>
+            <BitOffs>691258944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -86764,7 +86764,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258752</BitOffs>
+            <BitOffs>691259008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -86777,7 +86777,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258768</BitOffs>
+            <BitOffs>691259024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -86789,7 +86789,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691276608</BitOffs>
+            <BitOffs>691276864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -86802,7 +86802,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284544</BitOffs>
+            <BitOffs>691284800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -86815,7 +86815,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284552</BitOffs>
+            <BitOffs>691284808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -86828,7 +86828,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284560</BitOffs>
+            <BitOffs>691284816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -86851,7 +86851,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284576</BitOffs>
+            <BitOffs>691284832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -86864,7 +86864,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284608</BitOffs>
+            <BitOffs>691284864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -86877,7 +86877,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284672</BitOffs>
+            <BitOffs>691284928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -86890,7 +86890,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284688</BitOffs>
+            <BitOffs>691284944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -86902,7 +86902,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691302528</BitOffs>
+            <BitOffs>691302784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -86915,7 +86915,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310464</BitOffs>
+            <BitOffs>691310720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -86928,7 +86928,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310472</BitOffs>
+            <BitOffs>691310728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -86941,7 +86941,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310480</BitOffs>
+            <BitOffs>691310736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -86964,7 +86964,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310496</BitOffs>
+            <BitOffs>691310752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -86977,7 +86977,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310528</BitOffs>
+            <BitOffs>691310784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -86990,7 +86990,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310592</BitOffs>
+            <BitOffs>691310848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -87003,7 +87003,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310608</BitOffs>
+            <BitOffs>691310864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -87015,7 +87015,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691328448</BitOffs>
+            <BitOffs>691328704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -87028,7 +87028,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336384</BitOffs>
+            <BitOffs>691336640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -87041,7 +87041,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336392</BitOffs>
+            <BitOffs>691336648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -87054,7 +87054,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336400</BitOffs>
+            <BitOffs>691336656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -87077,7 +87077,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336416</BitOffs>
+            <BitOffs>691336672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -87090,7 +87090,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336448</BitOffs>
+            <BitOffs>691336704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -87103,7 +87103,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336512</BitOffs>
+            <BitOffs>691336768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -87116,7 +87116,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336528</BitOffs>
+            <BitOffs>691336784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -87128,7 +87128,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691354368</BitOffs>
+            <BitOffs>691354624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -87141,7 +87141,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362304</BitOffs>
+            <BitOffs>691362560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -87154,7 +87154,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362312</BitOffs>
+            <BitOffs>691362568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -87167,7 +87167,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362320</BitOffs>
+            <BitOffs>691362576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -87190,7 +87190,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362336</BitOffs>
+            <BitOffs>691362592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -87203,7 +87203,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362368</BitOffs>
+            <BitOffs>691362624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -87216,7 +87216,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362432</BitOffs>
+            <BitOffs>691362688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -87229,7 +87229,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362448</BitOffs>
+            <BitOffs>691362704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -87241,7 +87241,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691380288</BitOffs>
+            <BitOffs>691380544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -87254,7 +87254,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388224</BitOffs>
+            <BitOffs>691388480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -87267,7 +87267,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388232</BitOffs>
+            <BitOffs>691388488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -87280,7 +87280,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388240</BitOffs>
+            <BitOffs>691388496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -87303,7 +87303,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388256</BitOffs>
+            <BitOffs>691388512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -87316,7 +87316,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388288</BitOffs>
+            <BitOffs>691388544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -87329,7 +87329,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388352</BitOffs>
+            <BitOffs>691388608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -87342,7 +87342,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388368</BitOffs>
+            <BitOffs>691388624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -87354,7 +87354,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691406208</BitOffs>
+            <BitOffs>691406464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -87367,7 +87367,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414144</BitOffs>
+            <BitOffs>691414400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -87380,7 +87380,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414152</BitOffs>
+            <BitOffs>691414408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -87393,7 +87393,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414160</BitOffs>
+            <BitOffs>691414416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -87416,7 +87416,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414176</BitOffs>
+            <BitOffs>691414432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -87429,7 +87429,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414208</BitOffs>
+            <BitOffs>691414464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -87442,7 +87442,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414272</BitOffs>
+            <BitOffs>691414528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -87455,7 +87455,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414288</BitOffs>
+            <BitOffs>691414544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -87467,7 +87467,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691432128</BitOffs>
+            <BitOffs>691432384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -87480,7 +87480,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440064</BitOffs>
+            <BitOffs>691440320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -87493,7 +87493,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440072</BitOffs>
+            <BitOffs>691440328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -87506,7 +87506,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440080</BitOffs>
+            <BitOffs>691440336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -87529,7 +87529,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440096</BitOffs>
+            <BitOffs>691440352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -87542,7 +87542,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440128</BitOffs>
+            <BitOffs>691440384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -87555,7 +87555,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440192</BitOffs>
+            <BitOffs>691440448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -87568,7 +87568,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440208</BitOffs>
+            <BitOffs>691440464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -87580,7 +87580,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691458048</BitOffs>
+            <BitOffs>691458304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -87593,7 +87593,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691465984</BitOffs>
+            <BitOffs>691466240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -87606,7 +87606,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691465992</BitOffs>
+            <BitOffs>691466248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -87619,7 +87619,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466000</BitOffs>
+            <BitOffs>691466256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -87642,7 +87642,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466016</BitOffs>
+            <BitOffs>691466272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -87655,7 +87655,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466048</BitOffs>
+            <BitOffs>691466304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -87668,7 +87668,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466112</BitOffs>
+            <BitOffs>691466368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -87681,7 +87681,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466128</BitOffs>
+            <BitOffs>691466384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -87693,7 +87693,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691483968</BitOffs>
+            <BitOffs>691484224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -87706,7 +87706,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491904</BitOffs>
+            <BitOffs>691492160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -87719,7 +87719,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491912</BitOffs>
+            <BitOffs>691492168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -87732,7 +87732,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491920</BitOffs>
+            <BitOffs>691492176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -87755,7 +87755,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491936</BitOffs>
+            <BitOffs>691492192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -87768,7 +87768,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491968</BitOffs>
+            <BitOffs>691492224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -87781,7 +87781,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691492032</BitOffs>
+            <BitOffs>691492288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -87794,7 +87794,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691492048</BitOffs>
+            <BitOffs>691492304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -87806,7 +87806,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691509888</BitOffs>
+            <BitOffs>691510144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -87819,7 +87819,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517824</BitOffs>
+            <BitOffs>691518080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -87832,7 +87832,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517832</BitOffs>
+            <BitOffs>691518088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -87845,7 +87845,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517840</BitOffs>
+            <BitOffs>691518096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -87868,7 +87868,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517856</BitOffs>
+            <BitOffs>691518112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -87881,7 +87881,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517888</BitOffs>
+            <BitOffs>691518144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -87894,7 +87894,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517952</BitOffs>
+            <BitOffs>691518208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -87907,7 +87907,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517968</BitOffs>
+            <BitOffs>691518224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -87919,7 +87919,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691535808</BitOffs>
+            <BitOffs>691536064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -87932,7 +87932,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543744</BitOffs>
+            <BitOffs>691544000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -87945,7 +87945,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543752</BitOffs>
+            <BitOffs>691544008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -87958,7 +87958,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543760</BitOffs>
+            <BitOffs>691544016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -87981,7 +87981,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543776</BitOffs>
+            <BitOffs>691544032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -87994,7 +87994,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543808</BitOffs>
+            <BitOffs>691544064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -88007,7 +88007,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543872</BitOffs>
+            <BitOffs>691544128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -88020,7 +88020,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543888</BitOffs>
+            <BitOffs>691544144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -88032,7 +88032,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691561728</BitOffs>
+            <BitOffs>691561984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -88045,7 +88045,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569664</BitOffs>
+            <BitOffs>691569920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -88058,7 +88058,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569672</BitOffs>
+            <BitOffs>691569928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -88071,7 +88071,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569680</BitOffs>
+            <BitOffs>691569936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -88094,7 +88094,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569696</BitOffs>
+            <BitOffs>691569952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -88107,7 +88107,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569728</BitOffs>
+            <BitOffs>691569984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -88120,7 +88120,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569792</BitOffs>
+            <BitOffs>691570048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -88133,7 +88133,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569808</BitOffs>
+            <BitOffs>691570064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -88145,7 +88145,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691587648</BitOffs>
+            <BitOffs>691587904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -88158,7 +88158,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595584</BitOffs>
+            <BitOffs>691595840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -88171,7 +88171,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595592</BitOffs>
+            <BitOffs>691595848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -88184,7 +88184,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595600</BitOffs>
+            <BitOffs>691595856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -88207,7 +88207,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595616</BitOffs>
+            <BitOffs>691595872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -88220,7 +88220,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595648</BitOffs>
+            <BitOffs>691595904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -88233,7 +88233,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595712</BitOffs>
+            <BitOffs>691595968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -88246,7 +88246,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595728</BitOffs>
+            <BitOffs>691595984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -88258,7 +88258,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691613568</BitOffs>
+            <BitOffs>691613824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -88271,7 +88271,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621504</BitOffs>
+            <BitOffs>691621760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -88284,7 +88284,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621512</BitOffs>
+            <BitOffs>691621768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -88297,7 +88297,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621520</BitOffs>
+            <BitOffs>691621776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -88320,7 +88320,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621536</BitOffs>
+            <BitOffs>691621792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -88333,7 +88333,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621568</BitOffs>
+            <BitOffs>691621824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -88346,7 +88346,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621632</BitOffs>
+            <BitOffs>691621888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -88359,7 +88359,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621648</BitOffs>
+            <BitOffs>691621904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -88371,7 +88371,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691639488</BitOffs>
+            <BitOffs>691639744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -88384,7 +88384,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647424</BitOffs>
+            <BitOffs>691647680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -88397,7 +88397,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647432</BitOffs>
+            <BitOffs>691647688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -88410,7 +88410,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647440</BitOffs>
+            <BitOffs>691647696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -88433,7 +88433,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647456</BitOffs>
+            <BitOffs>691647712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -88446,7 +88446,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647488</BitOffs>
+            <BitOffs>691647744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -88459,7 +88459,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647552</BitOffs>
+            <BitOffs>691647808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -88472,7 +88472,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647568</BitOffs>
+            <BitOffs>691647824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -88484,7 +88484,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691665408</BitOffs>
+            <BitOffs>691665664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -88497,7 +88497,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673344</BitOffs>
+            <BitOffs>691673600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -88510,7 +88510,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673352</BitOffs>
+            <BitOffs>691673608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -88523,7 +88523,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673360</BitOffs>
+            <BitOffs>691673616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -88546,7 +88546,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673376</BitOffs>
+            <BitOffs>691673632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -88559,7 +88559,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673408</BitOffs>
+            <BitOffs>691673664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -88572,7 +88572,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673472</BitOffs>
+            <BitOffs>691673728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -88585,7 +88585,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673488</BitOffs>
+            <BitOffs>691673744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -88597,7 +88597,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691691328</BitOffs>
+            <BitOffs>691691584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -88610,7 +88610,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699264</BitOffs>
+            <BitOffs>691699520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -88623,7 +88623,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699272</BitOffs>
+            <BitOffs>691699528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -88636,7 +88636,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699280</BitOffs>
+            <BitOffs>691699536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -88659,7 +88659,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699296</BitOffs>
+            <BitOffs>691699552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -88672,7 +88672,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699328</BitOffs>
+            <BitOffs>691699584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -88685,7 +88685,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699392</BitOffs>
+            <BitOffs>691699648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -88698,7 +88698,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699408</BitOffs>
+            <BitOffs>691699664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -88710,7 +88710,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691717248</BitOffs>
+            <BitOffs>691717504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -88723,7 +88723,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725184</BitOffs>
+            <BitOffs>691725440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -88736,7 +88736,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725192</BitOffs>
+            <BitOffs>691725448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -88749,7 +88749,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725200</BitOffs>
+            <BitOffs>691725456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -88772,7 +88772,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725216</BitOffs>
+            <BitOffs>691725472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -88785,7 +88785,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725248</BitOffs>
+            <BitOffs>691725504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -88798,7 +88798,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725312</BitOffs>
+            <BitOffs>691725568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -88811,7 +88811,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725328</BitOffs>
+            <BitOffs>691725584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -88823,7 +88823,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691743168</BitOffs>
+            <BitOffs>691743424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -88836,7 +88836,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751104</BitOffs>
+            <BitOffs>691751360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -88849,7 +88849,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751112</BitOffs>
+            <BitOffs>691751368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -88862,7 +88862,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751120</BitOffs>
+            <BitOffs>691751376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -88885,7 +88885,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751136</BitOffs>
+            <BitOffs>691751392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -88898,7 +88898,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751168</BitOffs>
+            <BitOffs>691751424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -88911,7 +88911,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751232</BitOffs>
+            <BitOffs>691751488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -88924,7 +88924,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751248</BitOffs>
+            <BitOffs>691751504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -88936,7 +88936,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691769088</BitOffs>
+            <BitOffs>691769344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -88949,7 +88949,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777024</BitOffs>
+            <BitOffs>691777280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -88962,7 +88962,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777032</BitOffs>
+            <BitOffs>691777288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -88975,7 +88975,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777040</BitOffs>
+            <BitOffs>691777296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -88998,7 +88998,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777056</BitOffs>
+            <BitOffs>691777312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -89011,7 +89011,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777088</BitOffs>
+            <BitOffs>691777344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -89024,7 +89024,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777152</BitOffs>
+            <BitOffs>691777408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -89037,7 +89037,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777168</BitOffs>
+            <BitOffs>691777424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -89049,7 +89049,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691795008</BitOffs>
+            <BitOffs>691795264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -89062,7 +89062,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802944</BitOffs>
+            <BitOffs>691803200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -89075,7 +89075,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802952</BitOffs>
+            <BitOffs>691803208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -89088,7 +89088,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802960</BitOffs>
+            <BitOffs>691803216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -89111,7 +89111,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802976</BitOffs>
+            <BitOffs>691803232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -89124,7 +89124,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691803008</BitOffs>
+            <BitOffs>691803264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -89137,7 +89137,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691803072</BitOffs>
+            <BitOffs>691803328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -89150,7 +89150,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691803088</BitOffs>
+            <BitOffs>691803344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -89162,7 +89162,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691820928</BitOffs>
+            <BitOffs>691821184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -89175,7 +89175,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828864</BitOffs>
+            <BitOffs>691829120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -89188,7 +89188,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828872</BitOffs>
+            <BitOffs>691829128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -89201,7 +89201,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828880</BitOffs>
+            <BitOffs>691829136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -89224,7 +89224,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828896</BitOffs>
+            <BitOffs>691829152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -89237,7 +89237,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828928</BitOffs>
+            <BitOffs>691829184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -89250,7 +89250,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828992</BitOffs>
+            <BitOffs>691829248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -89263,7 +89263,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691829008</BitOffs>
+            <BitOffs>691829264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -89275,7 +89275,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691846848</BitOffs>
+            <BitOffs>691847104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -89288,7 +89288,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854784</BitOffs>
+            <BitOffs>691855040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -89301,7 +89301,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854792</BitOffs>
+            <BitOffs>691855048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -89314,7 +89314,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854800</BitOffs>
+            <BitOffs>691855056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -89337,7 +89337,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854816</BitOffs>
+            <BitOffs>691855072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -89350,7 +89350,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854848</BitOffs>
+            <BitOffs>691855104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -89363,7 +89363,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854912</BitOffs>
+            <BitOffs>691855168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -89376,7 +89376,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854928</BitOffs>
+            <BitOffs>691855184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -89388,7 +89388,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691872768</BitOffs>
+            <BitOffs>691873024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -89401,7 +89401,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880704</BitOffs>
+            <BitOffs>691880960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -89414,7 +89414,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880712</BitOffs>
+            <BitOffs>691880968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -89427,7 +89427,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880720</BitOffs>
+            <BitOffs>691880976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -89450,7 +89450,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880736</BitOffs>
+            <BitOffs>691880992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -89463,7 +89463,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880768</BitOffs>
+            <BitOffs>691881024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -89476,7 +89476,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880832</BitOffs>
+            <BitOffs>691881088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -89489,7 +89489,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880848</BitOffs>
+            <BitOffs>691881104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -89501,7 +89501,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691898688</BitOffs>
+            <BitOffs>691898944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -89514,7 +89514,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906624</BitOffs>
+            <BitOffs>691906880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -89527,7 +89527,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906632</BitOffs>
+            <BitOffs>691906888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -89540,7 +89540,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906640</BitOffs>
+            <BitOffs>691906896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -89563,7 +89563,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906656</BitOffs>
+            <BitOffs>691906912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -89576,7 +89576,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906688</BitOffs>
+            <BitOffs>691906944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -89589,7 +89589,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906752</BitOffs>
+            <BitOffs>691907008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -89602,7 +89602,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906768</BitOffs>
+            <BitOffs>691907024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -89614,7 +89614,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691924608</BitOffs>
+            <BitOffs>691924864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -89627,7 +89627,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932544</BitOffs>
+            <BitOffs>691932800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -89640,7 +89640,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932552</BitOffs>
+            <BitOffs>691932808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -89653,7 +89653,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932560</BitOffs>
+            <BitOffs>691932816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -89676,7 +89676,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932576</BitOffs>
+            <BitOffs>691932832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -89689,7 +89689,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932608</BitOffs>
+            <BitOffs>691932864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -89702,7 +89702,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932672</BitOffs>
+            <BitOffs>691932928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -89715,7 +89715,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932688</BitOffs>
+            <BitOffs>691932944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.NcToPlc</Name>
@@ -89727,7 +89727,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691950528</BitOffs>
+            <BitOffs>691950784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitForwardEnable</Name>
@@ -89740,7 +89740,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958464</BitOffs>
+            <BitOffs>691958720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitBackwardEnable</Name>
@@ -89753,7 +89753,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958472</BitOffs>
+            <BitOffs>691958728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHome</Name>
@@ -89766,7 +89766,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958480</BitOffs>
+            <BitOffs>691958736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHardwareEnable</Name>
@@ -89789,7 +89789,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958496</BitOffs>
+            <BitOffs>691958752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderULINT</Name>
@@ -89802,7 +89802,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958528</BitOffs>
+            <BitOffs>691958784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderUINT</Name>
@@ -89815,7 +89815,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958592</BitOffs>
+            <BitOffs>691958848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderINT</Name>
@@ -89828,7 +89828,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958608</BitOffs>
+            <BitOffs>691958864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.NcToPlc</Name>
@@ -89840,7 +89840,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691976448</BitOffs>
+            <BitOffs>691976704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitForwardEnable</Name>
@@ -89853,7 +89853,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984384</BitOffs>
+            <BitOffs>691984640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitBackwardEnable</Name>
@@ -89866,7 +89866,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984392</BitOffs>
+            <BitOffs>691984648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHome</Name>
@@ -89879,7 +89879,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984400</BitOffs>
+            <BitOffs>691984656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHardwareEnable</Name>
@@ -89902,7 +89902,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984416</BitOffs>
+            <BitOffs>691984672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderULINT</Name>
@@ -89915,7 +89915,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984448</BitOffs>
+            <BitOffs>691984704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderUINT</Name>
@@ -89928,7 +89928,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984512</BitOffs>
+            <BitOffs>691984768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderINT</Name>
@@ -89941,7 +89941,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984528</BitOffs>
+            <BitOffs>691984784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.NcToPlc</Name>
@@ -89953,7 +89953,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692002368</BitOffs>
+            <BitOffs>692002624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitForwardEnable</Name>
@@ -89966,7 +89966,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010304</BitOffs>
+            <BitOffs>692010560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitBackwardEnable</Name>
@@ -89979,7 +89979,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010312</BitOffs>
+            <BitOffs>692010568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHome</Name>
@@ -89992,7 +89992,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010320</BitOffs>
+            <BitOffs>692010576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHardwareEnable</Name>
@@ -90015,7 +90015,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010336</BitOffs>
+            <BitOffs>692010592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderULINT</Name>
@@ -90028,7 +90028,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010368</BitOffs>
+            <BitOffs>692010624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderUINT</Name>
@@ -90041,7 +90041,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010432</BitOffs>
+            <BitOffs>692010688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderINT</Name>
@@ -90054,14 +90054,14 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010448</BitOffs>
+            <BitOffs>692010704</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>87883776</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -90072,7 +90072,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639534272</BitOffs>
+            <BitOffs>639534528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90084,7 +90084,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641164416</BitOffs>
+            <BitOffs>641164672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90097,7 +90097,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641173400</BitOffs>
+            <BitOffs>641173656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90109,7 +90109,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641190336</BitOffs>
+            <BitOffs>641190592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90122,7 +90122,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641199320</BitOffs>
+            <BitOffs>641199576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90134,7 +90134,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641216256</BitOffs>
+            <BitOffs>641216512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90147,7 +90147,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641225240</BitOffs>
+            <BitOffs>641225496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -90159,7 +90159,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641520960</BitOffs>
+            <BitOffs>641521216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -90171,7 +90171,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641520976</BitOffs>
+            <BitOffs>641521232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -90184,7 +90184,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641521984</BitOffs>
+            <BitOffs>641522240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90196,7 +90196,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641641024</BitOffs>
+            <BitOffs>641641280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90208,7 +90208,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643271168</BitOffs>
+            <BitOffs>643271424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90221,7 +90221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643280152</BitOffs>
+            <BitOffs>643280408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90233,7 +90233,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643297088</BitOffs>
+            <BitOffs>643297344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90246,7 +90246,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643306072</BitOffs>
+            <BitOffs>643306328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90258,7 +90258,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643323008</BitOffs>
+            <BitOffs>643323264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90271,7 +90271,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643331992</BitOffs>
+            <BitOffs>643332248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -90283,7 +90283,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644206976</BitOffs>
+            <BitOffs>644207232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -90303,7 +90303,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644206992</BitOffs>
+            <BitOffs>644207248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90316,7 +90316,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644208064</BitOffs>
+            <BitOffs>644208320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90328,7 +90328,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644325824</BitOffs>
+            <BitOffs>644326080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90340,7 +90340,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645955968</BitOffs>
+            <BitOffs>645956224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90353,7 +90353,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645964952</BitOffs>
+            <BitOffs>645965208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90365,7 +90365,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645981888</BitOffs>
+            <BitOffs>645982144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90378,7 +90378,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645990872</BitOffs>
+            <BitOffs>645991128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90390,7 +90390,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646007808</BitOffs>
+            <BitOffs>646008064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90403,7 +90403,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646016792</BitOffs>
+            <BitOffs>646017048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -90415,7 +90415,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646891776</BitOffs>
+            <BitOffs>646892032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -90435,7 +90435,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646891792</BitOffs>
+            <BitOffs>646892048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90448,7 +90448,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646892864</BitOffs>
+            <BitOffs>646893120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90460,7 +90460,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647010624</BitOffs>
+            <BitOffs>647010880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90472,7 +90472,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648640768</BitOffs>
+            <BitOffs>648641024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90485,7 +90485,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648649752</BitOffs>
+            <BitOffs>648650008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90497,7 +90497,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648666688</BitOffs>
+            <BitOffs>648666944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90510,7 +90510,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648675672</BitOffs>
+            <BitOffs>648675928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90522,7 +90522,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648692608</BitOffs>
+            <BitOffs>648692864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90535,7 +90535,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648701592</BitOffs>
+            <BitOffs>648701848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -90547,7 +90547,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649576576</BitOffs>
+            <BitOffs>649576832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -90567,7 +90567,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649576592</BitOffs>
+            <BitOffs>649576848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90580,7 +90580,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649577664</BitOffs>
+            <BitOffs>649577920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90592,7 +90592,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649695424</BitOffs>
+            <BitOffs>649695680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90604,7 +90604,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651325568</BitOffs>
+            <BitOffs>651325824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90617,7 +90617,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651334552</BitOffs>
+            <BitOffs>651334808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90629,7 +90629,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651351488</BitOffs>
+            <BitOffs>651351744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90642,7 +90642,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651360472</BitOffs>
+            <BitOffs>651360728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90654,7 +90654,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651377408</BitOffs>
+            <BitOffs>651377664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90667,7 +90667,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651386392</BitOffs>
+            <BitOffs>651386648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -90679,7 +90679,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652261376</BitOffs>
+            <BitOffs>652261632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -90699,7 +90699,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652261392</BitOffs>
+            <BitOffs>652261648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90712,7 +90712,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652262464</BitOffs>
+            <BitOffs>652262720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90724,7 +90724,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652380224</BitOffs>
+            <BitOffs>652380480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90736,7 +90736,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654010368</BitOffs>
+            <BitOffs>654010624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90749,7 +90749,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654019352</BitOffs>
+            <BitOffs>654019608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90761,7 +90761,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654036288</BitOffs>
+            <BitOffs>654036544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90774,7 +90774,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654045272</BitOffs>
+            <BitOffs>654045528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90786,7 +90786,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654062208</BitOffs>
+            <BitOffs>654062464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90799,7 +90799,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654071192</BitOffs>
+            <BitOffs>654071448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -90811,7 +90811,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654946176</BitOffs>
+            <BitOffs>654946432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -90831,7 +90831,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654946192</BitOffs>
+            <BitOffs>654946448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90844,7 +90844,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654947264</BitOffs>
+            <BitOffs>654947520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90856,7 +90856,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655065344</BitOffs>
+            <BitOffs>655065600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90868,7 +90868,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656695488</BitOffs>
+            <BitOffs>656695744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90881,7 +90881,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656704472</BitOffs>
+            <BitOffs>656704728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90893,7 +90893,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656721408</BitOffs>
+            <BitOffs>656721664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90906,7 +90906,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656730392</BitOffs>
+            <BitOffs>656730648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90918,7 +90918,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656747328</BitOffs>
+            <BitOffs>656747584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90931,7 +90931,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656756312</BitOffs>
+            <BitOffs>656756568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90943,7 +90943,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657176640</BitOffs>
+            <BitOffs>657176896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90955,7 +90955,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657503680</BitOffs>
+            <BitOffs>657503936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90967,7 +90967,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659133824</BitOffs>
+            <BitOffs>659134080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90980,7 +90980,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659142808</BitOffs>
+            <BitOffs>659143064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90992,7 +90992,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659159744</BitOffs>
+            <BitOffs>659160000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91005,7 +91005,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659168728</BitOffs>
+            <BitOffs>659168984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91017,7 +91017,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659185664</BitOffs>
+            <BitOffs>659185920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91030,7 +91030,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659194648</BitOffs>
+            <BitOffs>659194904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91042,7 +91042,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659615424</BitOffs>
+            <BitOffs>659615680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91054,7 +91054,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659942464</BitOffs>
+            <BitOffs>659942720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91066,7 +91066,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661572608</BitOffs>
+            <BitOffs>661572864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91079,7 +91079,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661581592</BitOffs>
+            <BitOffs>661581848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91091,7 +91091,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661598528</BitOffs>
+            <BitOffs>661598784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91104,7 +91104,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661607512</BitOffs>
+            <BitOffs>661607768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91116,7 +91116,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661624448</BitOffs>
+            <BitOffs>661624704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91129,7 +91129,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661633432</BitOffs>
+            <BitOffs>661633688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91141,7 +91141,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662030336</BitOffs>
+            <BitOffs>662030592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91153,7 +91153,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662357376</BitOffs>
+            <BitOffs>662357632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91165,7 +91165,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662684416</BitOffs>
+            <BitOffs>662684672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91177,7 +91177,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663011456</BitOffs>
+            <BitOffs>663011712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -91189,7 +91189,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663494688</BitOffs>
+            <BitOffs>663494944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91201,7 +91201,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663502464</BitOffs>
+            <BitOffs>663502784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91213,7 +91213,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663829504</BitOffs>
+            <BitOffs>663829824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91225,7 +91225,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664156544</BitOffs>
+            <BitOffs>664156864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91237,7 +91237,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664483584</BitOffs>
+            <BitOffs>664483904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -91249,7 +91249,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664966816</BitOffs>
+            <BitOffs>664967136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -91261,7 +91261,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665085968</BitOffs>
+            <BitOffs>665086224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -91273,7 +91273,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665085976</BitOffs>
+            <BitOffs>665086232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91285,7 +91285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665122944</BitOffs>
+            <BitOffs>665123200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91297,7 +91297,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665449984</BitOffs>
+            <BitOffs>665450240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91309,7 +91309,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666519232</BitOffs>
+            <BitOffs>666519488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91321,7 +91321,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666846272</BitOffs>
+            <BitOffs>666846528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91333,7 +91333,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667883840</BitOffs>
+            <BitOffs>667884096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91345,7 +91345,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668210880</BitOffs>
+            <BitOffs>668211136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91357,7 +91357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668537920</BitOffs>
+            <BitOffs>668538176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91369,7 +91369,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668864960</BitOffs>
+            <BitOffs>668865216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91381,7 +91381,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669192000</BitOffs>
+            <BitOffs>669192256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91393,7 +91393,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669519040</BitOffs>
+            <BitOffs>669519296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91405,7 +91405,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669846080</BitOffs>
+            <BitOffs>669846336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91417,7 +91417,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670173120</BitOffs>
+            <BitOffs>670173376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91429,7 +91429,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670500160</BitOffs>
+            <BitOffs>670500416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91441,7 +91441,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670827200</BitOffs>
+            <BitOffs>670827456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91453,7 +91453,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671154240</BitOffs>
+            <BitOffs>671154496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91465,7 +91465,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671481280</BitOffs>
+            <BitOffs>671481536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91477,7 +91477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671808320</BitOffs>
+            <BitOffs>671808576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91489,7 +91489,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673437760</BitOffs>
+            <BitOffs>673438080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91502,7 +91502,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673446744</BitOffs>
+            <BitOffs>673447064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91514,7 +91514,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673463680</BitOffs>
+            <BitOffs>673464000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91527,7 +91527,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673472664</BitOffs>
+            <BitOffs>673472984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91539,7 +91539,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673489600</BitOffs>
+            <BitOffs>673489920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91552,7 +91552,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673498584</BitOffs>
+            <BitOffs>673498904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91564,7 +91564,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675249088</BitOffs>
+            <BitOffs>675249344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91577,7 +91577,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675258072</BitOffs>
+            <BitOffs>675258328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91589,7 +91589,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675275008</BitOffs>
+            <BitOffs>675275264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91602,7 +91602,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675283992</BitOffs>
+            <BitOffs>675284248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91614,7 +91614,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675300928</BitOffs>
+            <BitOffs>675301184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91627,7 +91627,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675309912</BitOffs>
+            <BitOffs>675310168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91639,7 +91639,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675703552</BitOffs>
+            <BitOffs>675703872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91651,7 +91651,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676030592</BitOffs>
+            <BitOffs>676030912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91663,7 +91663,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677659776</BitOffs>
+            <BitOffs>677660096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91676,7 +91676,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677668760</BitOffs>
+            <BitOffs>677669080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91688,7 +91688,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677685696</BitOffs>
+            <BitOffs>677686016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91701,7 +91701,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677694680</BitOffs>
+            <BitOffs>677695000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91713,7 +91713,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677711616</BitOffs>
+            <BitOffs>677711936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91726,7 +91726,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677720600</BitOffs>
+            <BitOffs>677720920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91738,7 +91738,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678113792</BitOffs>
+            <BitOffs>678114048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91750,7 +91750,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679742848</BitOffs>
+            <BitOffs>679743104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91763,7 +91763,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679751832</BitOffs>
+            <BitOffs>679752088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91775,7 +91775,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679768768</BitOffs>
+            <BitOffs>679769024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91788,7 +91788,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679777752</BitOffs>
+            <BitOffs>679778008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91800,7 +91800,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679794688</BitOffs>
+            <BitOffs>679794944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91813,23 +91813,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679803672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
-            <BitSize>1760</BitSize>
-            <BaseType GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[PMPS_PRE]^IO Outputs^RequestedBP</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>680142944</BitOffs>
+            <BitOffs>679803928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -91848,7 +91832,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680313224</BitOffs>
+            <BitOffs>679987888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -91867,7 +91851,23 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680313232</BitOffs>
+            <BitOffs>679987896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
+            <BitSize>1760</BitSize>
+            <BaseType GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[PMPS_PRE]^IO Outputs^RequestedBP</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>680143264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -91887,7 +91887,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>687322856</BitOffs>
+            <BitOffs>687323112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -91907,7 +91907,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689066024</BitOffs>
+            <BitOffs>689066280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -91919,7 +91919,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690809024</BitOffs>
+            <BitOffs>690809280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -91932,7 +91932,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690818008</BitOffs>
+            <BitOffs>690818264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -91944,7 +91944,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690834944</BitOffs>
+            <BitOffs>690835200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -91957,7 +91957,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690843928</BitOffs>
+            <BitOffs>690844184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -91969,7 +91969,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690860864</BitOffs>
+            <BitOffs>690861120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -91982,7 +91982,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690869848</BitOffs>
+            <BitOffs>690870104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -91994,7 +91994,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690886784</BitOffs>
+            <BitOffs>690887040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -92007,7 +92007,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690895768</BitOffs>
+            <BitOffs>690896024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -92019,7 +92019,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690912704</BitOffs>
+            <BitOffs>690912960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -92032,7 +92032,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690921688</BitOffs>
+            <BitOffs>690921944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -92044,7 +92044,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690938624</BitOffs>
+            <BitOffs>690938880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -92057,7 +92057,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690947608</BitOffs>
+            <BitOffs>690947864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -92069,7 +92069,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690964544</BitOffs>
+            <BitOffs>690964800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -92082,7 +92082,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690973528</BitOffs>
+            <BitOffs>690973784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -92094,7 +92094,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690990464</BitOffs>
+            <BitOffs>690990720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -92107,7 +92107,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690999448</BitOffs>
+            <BitOffs>690999704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -92119,7 +92119,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691016384</BitOffs>
+            <BitOffs>691016640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -92132,7 +92132,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691025368</BitOffs>
+            <BitOffs>691025624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -92144,7 +92144,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691042304</BitOffs>
+            <BitOffs>691042560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -92157,7 +92157,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691051288</BitOffs>
+            <BitOffs>691051544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -92169,7 +92169,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691068224</BitOffs>
+            <BitOffs>691068480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -92182,7 +92182,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691077208</BitOffs>
+            <BitOffs>691077464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -92194,7 +92194,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691094144</BitOffs>
+            <BitOffs>691094400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -92207,7 +92207,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691103128</BitOffs>
+            <BitOffs>691103384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -92219,7 +92219,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691120064</BitOffs>
+            <BitOffs>691120320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -92232,7 +92232,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691129048</BitOffs>
+            <BitOffs>691129304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -92244,7 +92244,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691145984</BitOffs>
+            <BitOffs>691146240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -92257,7 +92257,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691154968</BitOffs>
+            <BitOffs>691155224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -92269,7 +92269,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691171904</BitOffs>
+            <BitOffs>691172160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -92282,7 +92282,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691180888</BitOffs>
+            <BitOffs>691181144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -92294,7 +92294,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691197824</BitOffs>
+            <BitOffs>691198080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -92307,7 +92307,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691206808</BitOffs>
+            <BitOffs>691207064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -92319,7 +92319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691223744</BitOffs>
+            <BitOffs>691224000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -92332,7 +92332,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691232728</BitOffs>
+            <BitOffs>691232984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -92344,7 +92344,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691249664</BitOffs>
+            <BitOffs>691249920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -92357,7 +92357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691258648</BitOffs>
+            <BitOffs>691258904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -92369,7 +92369,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691275584</BitOffs>
+            <BitOffs>691275840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -92382,7 +92382,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691284568</BitOffs>
+            <BitOffs>691284824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -92394,7 +92394,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691301504</BitOffs>
+            <BitOffs>691301760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -92407,7 +92407,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691310488</BitOffs>
+            <BitOffs>691310744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -92419,7 +92419,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691327424</BitOffs>
+            <BitOffs>691327680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -92432,7 +92432,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691336408</BitOffs>
+            <BitOffs>691336664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -92444,7 +92444,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691353344</BitOffs>
+            <BitOffs>691353600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -92457,7 +92457,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691362328</BitOffs>
+            <BitOffs>691362584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -92469,7 +92469,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691379264</BitOffs>
+            <BitOffs>691379520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -92482,7 +92482,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691388248</BitOffs>
+            <BitOffs>691388504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -92494,7 +92494,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691405184</BitOffs>
+            <BitOffs>691405440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -92507,7 +92507,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691414168</BitOffs>
+            <BitOffs>691414424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -92519,7 +92519,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691431104</BitOffs>
+            <BitOffs>691431360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -92532,7 +92532,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691440088</BitOffs>
+            <BitOffs>691440344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -92544,7 +92544,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691457024</BitOffs>
+            <BitOffs>691457280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -92557,7 +92557,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691466008</BitOffs>
+            <BitOffs>691466264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -92569,7 +92569,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691482944</BitOffs>
+            <BitOffs>691483200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -92582,7 +92582,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691491928</BitOffs>
+            <BitOffs>691492184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -92594,7 +92594,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691508864</BitOffs>
+            <BitOffs>691509120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -92607,7 +92607,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691517848</BitOffs>
+            <BitOffs>691518104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -92619,7 +92619,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691534784</BitOffs>
+            <BitOffs>691535040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -92632,7 +92632,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691543768</BitOffs>
+            <BitOffs>691544024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -92644,7 +92644,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691560704</BitOffs>
+            <BitOffs>691560960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -92657,7 +92657,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691569688</BitOffs>
+            <BitOffs>691569944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -92669,7 +92669,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691586624</BitOffs>
+            <BitOffs>691586880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -92682,7 +92682,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691595608</BitOffs>
+            <BitOffs>691595864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -92694,7 +92694,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691612544</BitOffs>
+            <BitOffs>691612800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -92707,7 +92707,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691621528</BitOffs>
+            <BitOffs>691621784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -92719,7 +92719,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691638464</BitOffs>
+            <BitOffs>691638720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -92732,7 +92732,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691647448</BitOffs>
+            <BitOffs>691647704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -92744,7 +92744,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691664384</BitOffs>
+            <BitOffs>691664640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -92757,7 +92757,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691673368</BitOffs>
+            <BitOffs>691673624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -92769,7 +92769,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691690304</BitOffs>
+            <BitOffs>691690560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -92782,7 +92782,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691699288</BitOffs>
+            <BitOffs>691699544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -92794,7 +92794,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691716224</BitOffs>
+            <BitOffs>691716480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -92807,7 +92807,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691725208</BitOffs>
+            <BitOffs>691725464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -92819,7 +92819,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691742144</BitOffs>
+            <BitOffs>691742400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -92832,7 +92832,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691751128</BitOffs>
+            <BitOffs>691751384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -92844,7 +92844,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691768064</BitOffs>
+            <BitOffs>691768320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -92857,7 +92857,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691777048</BitOffs>
+            <BitOffs>691777304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -92869,7 +92869,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691793984</BitOffs>
+            <BitOffs>691794240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -92882,7 +92882,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691802968</BitOffs>
+            <BitOffs>691803224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -92894,7 +92894,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691819904</BitOffs>
+            <BitOffs>691820160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -92907,7 +92907,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691828888</BitOffs>
+            <BitOffs>691829144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -92919,7 +92919,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691845824</BitOffs>
+            <BitOffs>691846080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -92932,7 +92932,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691854808</BitOffs>
+            <BitOffs>691855064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -92944,7 +92944,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691871744</BitOffs>
+            <BitOffs>691872000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -92957,7 +92957,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691880728</BitOffs>
+            <BitOffs>691880984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -92969,7 +92969,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691897664</BitOffs>
+            <BitOffs>691897920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -92982,7 +92982,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691906648</BitOffs>
+            <BitOffs>691906904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -92994,7 +92994,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691923584</BitOffs>
+            <BitOffs>691923840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -93007,7 +93007,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691932568</BitOffs>
+            <BitOffs>691932824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.PlcToNc</Name>
@@ -93019,7 +93019,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691949504</BitOffs>
+            <BitOffs>691949760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bBrakeRelease</Name>
@@ -93032,7 +93032,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691958488</BitOffs>
+            <BitOffs>691958744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.PlcToNc</Name>
@@ -93044,7 +93044,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691975424</BitOffs>
+            <BitOffs>691975680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bBrakeRelease</Name>
@@ -93057,7 +93057,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691984408</BitOffs>
+            <BitOffs>691984664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.PlcToNc</Name>
@@ -93069,7 +93069,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692001344</BitOffs>
+            <BitOffs>692001600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bBrakeRelease</Name>
@@ -93082,14 +93082,14 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692010328</BitOffs>
+            <BitOffs>692010584</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>87883776</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -99230,6 +99230,46 @@ second version of targets paddle 2</Comment>
             <BitOffs>8583808</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Global_Version.stLibVersion_PMPS</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8584192</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
@@ -99263,35 +99303,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8584192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>1000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
             <BitOffs>8584480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8584496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -99302,7 +99314,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8584512</BitOffs>
+            <BitOffs>8584768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -99316,7 +99328,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8591616</BitOffs>
+            <BitOffs>8591872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -99330,7 +99342,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8591680</BitOffs>
+            <BitOffs>8591936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -99366,7 +99378,35 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8591744</BitOffs>
+            <BitOffs>8592000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8592288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8592304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -99380,7 +99420,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592032</BitOffs>
+            <BitOffs>8592320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -99407,7 +99447,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592048</BitOffs>
+            <BitOffs>8592336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -99422,7 +99462,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592056</BitOffs>
+            <BitOffs>8592344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -99437,7 +99477,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592064</BitOffs>
+            <BitOffs>8592352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -99452,7 +99492,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592096</BitOffs>
+            <BitOffs>8592384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -99470,7 +99510,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594144</BitOffs>
+            <BitOffs>8594432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -99482,7 +99522,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594160</BitOffs>
+            <BitOffs>8594448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -99494,7 +99534,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594168</BitOffs>
+            <BitOffs>8594456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -99510,7 +99550,42 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594176</BitOffs>
+            <BitOffs>8594464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TcUnitRunner</Name>
+            <BitSize>621828480</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8594496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
+            <Comment> Pointer to current test suite being called </Comment>
+            <BitSize>64</BitSize>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>630422976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
+            <Comment> Current name of test being called </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>630423040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -99524,7 +99599,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594208</BitOffs>
+            <BitOffs>630425088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.bSP1K4AttOut</Name>
@@ -99532,7 +99607,7 @@ second version of targets paddle 2</Comment>
     bInit: BOOL;</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>8594216</BitOffs>
+            <BitOffs>630425096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -99548,42 +99623,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.TcUnitRunner</Name>
-            <BitSize>621828480</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8594240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
-            <Comment> Pointer to current test suite being called </Comment>
-            <BitSize>64</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>630422720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
-            <Comment> Current name of test being called </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>630422784</BitOffs>
+            <BitOffs>630425104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -99598,7 +99638,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>630424832</BitOffs>
+            <BitOffs>630425152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -99616,7 +99656,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>630488832</BitOffs>
+            <BitOffs>630489152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -99628,7 +99668,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>630504832</BitOffs>
+            <BitOffs>630505152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -99664,7 +99704,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638825984</BitOffs>
+            <BitOffs>638826304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_IPCDiag</Name>
@@ -99704,7 +99744,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638826272</BitOffs>
+            <BitOffs>638826592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_DynamicMemory</Name>
@@ -99744,17 +99784,6 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638827840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Physics.fbScatteringFactors</Name>
-            <BitSize>576000</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
             <BitOffs>638828160</BitOffs>
           </Symbol>
           <Symbol>
@@ -99766,70 +99795,30 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarStatic</Name>
               </Property>
             </Properties>
-            <BitOffs>639492800</BitOffs>
+            <BitOffs>638828448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.bSP1K4FzpOut</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>639492816</BitOffs>
+            <BitOffs>638828464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.bSP1K4Out</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>639492824</BitOffs>
+            <BitOffs>638828472</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <BitOffs>639492832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
+            <Name>GVL_Physics.fbScatteringFactors</Name>
+            <BitSize>576000</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639492840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <BitOffs>639492848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <BitOffs>639492856</BitOffs>
+            <BitOffs>638828480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
@@ -99849,13 +99838,13 @@ second version of targets paddle 2</Comment>
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
               </Property>
             </Properties>
-            <BitOffs>639521024</BitOffs>
+            <BitOffs>639521280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>641522240</BitOffs>
+            <BitOffs>641522496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.stDefault</Name>
@@ -99875,7 +99864,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>641614272</BitOffs>
+            <BitOffs>641614528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
@@ -99905,14 +99894,14 @@ second version of targets paddle 2</Comment>
                               .fbFlowSwitch.bFlowOk := TIIB[IM2K4-EL1004-E8]^Channel 1^Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641620288</BitOffs>
+            <BitOffs>641620544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbStateSetup</Name>
             <Comment>    fStartupVelo: LREAL := 13;</Comment>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>644209344</BitOffs>
+            <BitOffs>644209600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.stDefault</Name>
@@ -99932,7 +99921,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>644301376</BitOffs>
+            <BitOffs>644301632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
@@ -99963,13 +99952,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>644305088</BitOffs>
+            <BitOffs>644305344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>646894144</BitOffs>
+            <BitOffs>646894400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.stDefault</Name>
@@ -99989,7 +99978,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>646986176</BitOffs>
+            <BitOffs>646986432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
@@ -100019,13 +100008,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>646989888</BitOffs>
+            <BitOffs>646990144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>649578944</BitOffs>
+            <BitOffs>649579200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.stDefault</Name>
@@ -100045,7 +100034,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>649670976</BitOffs>
+            <BitOffs>649671232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
@@ -100075,13 +100064,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649674688</BitOffs>
+            <BitOffs>649674944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>652263744</BitOffs>
+            <BitOffs>652264000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.stDefault</Name>
@@ -100101,7 +100090,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>652355776</BitOffs>
+            <BitOffs>652356032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
@@ -100131,13 +100120,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>652359488</BitOffs>
+            <BitOffs>652359744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>654948544</BitOffs>
+            <BitOffs>654948800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.stDefault</Name>
@@ -100157,7 +100146,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>655040576</BitOffs>
+            <BitOffs>655040832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
@@ -100172,13 +100161,13 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>655044672</BitOffs>
+            <BitOffs>655044928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>657052032</BitOffs>
+            <BitOffs>657052288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stDefault</Name>
@@ -100198,7 +100187,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>657144064</BitOffs>
+            <BitOffs>657144320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
@@ -100226,13 +100215,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw             := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>657148480</BitOffs>
+            <BitOffs>657148736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>659491520</BitOffs>
+            <BitOffs>659491776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stDefault</Name>
@@ -100248,7 +100237,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>659583552</BitOffs>
+            <BitOffs>659583808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -100276,13 +100265,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw             := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>659587264</BitOffs>
+            <BitOffs>659587520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>661930304</BitOffs>
+            <BitOffs>661930560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stDefault</Name>
@@ -100302,7 +100291,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>662022336</BitOffs>
+            <BitOffs>662022592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -100317,7 +100306,68 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662027392</BitOffs>
+            <BitOffs>662027648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <BitOffs>663495168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663495176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <BitOffs>663495184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <BitOffs>663495192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>663495200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -100328,17 +100378,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663494912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>663498752</BitOffs>
+            <BitOffs>663495232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -100348,7 +100388,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663498784</BitOffs>
+            <BitOffs>663499072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -100358,7 +100398,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663498816</BitOffs>
+            <BitOffs>663499104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -100368,22 +100408,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663498848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
-            <BitSize>1467520</BitSize>
-            <BaseType>FB_SLITS</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL2K4:SCATTER
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>663499520</BitOffs>
+            <BitOffs>663499136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
@@ -100403,7 +100428,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664967040</BitOffs>
+            <BitOffs>663499168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bTest</Name>
@@ -100412,23 +100437,28 @@ second version of targets paddle 2</Comment>
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>664967048</BitOffs>
+            <BitOffs>663499176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>664967056</BitOffs>
+            <BitOffs>663499184</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>664967072</BitOffs>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
+            <BitSize>1467520</BitSize>
+            <BaseType>FB_SLITS</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL2K4:SCATTER
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663499840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -100439,7 +100469,17 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>664967104</BitOffs>
+            <BitOffs>664967360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>664971200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -100449,7 +100489,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664970944</BitOffs>
+            <BitOffs>664971232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -100459,7 +100499,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664970976</BitOffs>
+            <BitOffs>664971264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -100469,13 +100509,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664971008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL1HighCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>664971056</BitOffs>
+            <BitOffs>664971296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -100494,7 +100528,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664971584</BitOffs>
+            <BitOffs>664971840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -100518,7 +100552,7 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>665089984</BitOffs>
+            <BitOffs>665090240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -100542,97 +100576,103 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>666493696</BitOffs>
+            <BitOffs>666493952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667882240</BitOffs>
+            <BitOffs>667882496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668209280</BitOffs>
+            <BitOffs>668209536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668536320</BitOffs>
+            <BitOffs>668536576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668863360</BitOffs>
+            <BitOffs>668863616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669190400</BitOffs>
+            <BitOffs>669190656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669517440</BitOffs>
+            <BitOffs>669517696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669844480</BitOffs>
+            <BitOffs>669844736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670171520</BitOffs>
+            <BitOffs>670171776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670498560</BitOffs>
+            <BitOffs>670498816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670825600</BitOffs>
+            <BitOffs>670825856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671152640</BitOffs>
+            <BitOffs>671152896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671479680</BitOffs>
+            <BitOffs>671479936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671806720</BitOffs>
+            <BitOffs>671806976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL1HighCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>672134032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672133776</BitOffs>
+            <BitOffs>672134064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672133792</BitOffs>
+            <BitOffs>672134080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -100641,13 +100681,13 @@ second version of targets paddle 2</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>672133816</BitOffs>
+            <BitOffs>672134104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672133824</BitOffs>
+            <BitOffs>672134112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -100656,20 +100696,20 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>672133840</BitOffs>
+            <BitOffs>672134128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>672133856</BitOffs>
+            <BitOffs>672134144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bPF1K4Out</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>672133864</BitOffs>
+            <BitOffs>672134152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -100684,22 +100724,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672133872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.fbZPStates</Name>
-            <Comment>/ZP states start</Comment>
-            <BitSize>1548608</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>672133888</BitOffs>
+            <BitOffs>672134160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -100714,7 +100739,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673682496</BitOffs>
+            <BitOffs>672134176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumSet</Name>
@@ -100729,43 +100754,28 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673682512</BitOffs>
+            <BitOffs>672134192</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Name>PRG_SP1K4.fbZPStates</Name>
+            <Comment>/ZP states start</Comment>
+            <BitSize>1548608</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
+        pv: SP1K4:FZP
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673682528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_LaserCoupling_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: LI2K4:IP1:STATE:SET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>673682544</BitOffs>
+            <BitOffs>672134208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>673682560</BitOffs>
+            <BitOffs>673682816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -100785,7 +100795,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>673774592</BitOffs>
+            <BitOffs>673774848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -100795,7 +100805,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673778304</BitOffs>
+            <BitOffs>673778560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -100805,7 +100815,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673833984</BitOffs>
+            <BitOffs>673834240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -100815,7 +100825,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673889664</BitOffs>
+            <BitOffs>673889920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -100830,13 +100840,73 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673945344</BitOffs>
+            <BitOffs>673945600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_LaserCoupling_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: LI2K4:IP1:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.li2k4_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_LaserCoupling_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: LI2K4:IP1:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AT2K4_IP1.at2k4_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_Sample_Calibration_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: AT2K4:IP1:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>675493824</BitOffs>
+            <BitOffs>675494144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -100856,7 +100926,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>675585856</BitOffs>
+            <BitOffs>675586176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -100866,7 +100936,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>675589568</BitOffs>
+            <BitOffs>675589888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -100876,7 +100946,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>675645248</BitOffs>
+            <BitOffs>675645568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01</Name>
@@ -100900,7 +100970,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675700928</BitOffs>
+            <BitOffs>675701248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02</Name>
@@ -100923,19 +100993,19 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675701184</BitOffs>
+            <BitOffs>675701504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>675701952</BitOffs>
+            <BitOffs>675702272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>676028992</BitOffs>
+            <BitOffs>676029312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States</Name>
@@ -100950,71 +101020,13 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>676356032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_LI2K4_IP1.li2k4_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_LaserCoupling_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: LI2K4:IP1:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>677904512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_AT2K4_IP1.at2k4_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_Sample_Calibration_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: AT2K4:IP1:STATE:SET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>677904528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_AT2K4_IP1.at2k4_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_Sample_Calibration_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: AT2K4:IP1:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>677904544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>677904560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <Comment>	bST1K4_Veto: BOOL;</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>677904568</BitOffs>
+            <BitOffs>676356352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>677904576</BitOffs>
+            <BitOffs>677904832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.stDefault</Name>
@@ -101034,7 +101046,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>677996608</BitOffs>
+            <BitOffs>677996864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4XStates</Name>
@@ -101044,7 +101056,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>678000320</BitOffs>
+            <BitOffs>678000576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4YStates</Name>
@@ -101054,37 +101066,37 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>678056000</BitOffs>
+            <BitOffs>678056256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678111680</BitOffs>
+            <BitOffs>678111936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678111808</BitOffs>
+            <BitOffs>678112064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678111936</BitOffs>
+            <BitOffs>678112192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678112064</BitOffs>
+            <BitOffs>678112320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>678112192</BitOffs>
+            <BitOffs>678112448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States</Name>
@@ -101099,13 +101111,53 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>678439232</BitOffs>
+            <BitOffs>678439488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_AT2K4_IP1.at2k4_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_Sample_Calibration_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: AT2K4:IP1:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>679987840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>679987856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <Comment>	bST1K4_Veto: BOOL;</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>679987864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K3Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>679987872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>679987880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>679987584</BitOffs>
+            <BitOffs>679987904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.stDefault</Name>
@@ -101129,7 +101181,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>680079616</BitOffs>
+            <BitOffs>680079936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.aAT2K4States</Name>
@@ -101139,53 +101191,25 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>680083328</BitOffs>
+            <BitOffs>680083648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>144640</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>680140224</BitOffs>
+            <BitOffs>680140544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>680284864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>680313216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcGVL.ePF1K4State</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>680313248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcGVL.ePF2K4State</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>680313264</BitOffs>
+            <BitOffs>680285184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5802176</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>680320640</BitOffs>
+            <BitOffs>680320896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -101204,7 +101228,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686128576</BitOffs>
+            <BitOffs>686128832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -101223,7 +101247,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686725568</BitOffs>
+            <BitOffs>686725824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -101253,7 +101277,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>687322560</BitOffs>
+            <BitOffs>687322816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -101283,7 +101307,29 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689065728</BitOffs>
+            <BitOffs>689065984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcGVL.ePF1K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>690809152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcGVL.ePF2K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>690809168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4ATT</Name>
@@ -101294,7 +101340,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808896</BitOffs>
+            <BitOffs>690809184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4FZP</Name>
@@ -101305,52 +101351,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>690808928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>690808936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>690808944</BitOffs>
+            <BitOffs>690809200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -101379,7 +101380,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808960</BitOffs>
+            <BitOffs>690809216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -101391,7 +101392,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690834880</BitOffs>
+            <BitOffs>690835136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -101402,7 +101403,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690860800</BitOffs>
+            <BitOffs>690861056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -101413,7 +101414,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690886720</BitOffs>
+            <BitOffs>690886976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -101424,7 +101425,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690912640</BitOffs>
+            <BitOffs>690912896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -101435,7 +101436,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690938560</BitOffs>
+            <BitOffs>690938816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -101446,7 +101447,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690964480</BitOffs>
+            <BitOffs>690964736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -101457,7 +101458,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690990400</BitOffs>
+            <BitOffs>690990656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -101486,7 +101487,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691016320</BitOffs>
+            <BitOffs>691016576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -101514,7 +101515,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691042240</BitOffs>
+            <BitOffs>691042496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -101541,7 +101542,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691068160</BitOffs>
+            <BitOffs>691068416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -101568,7 +101569,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691094080</BitOffs>
+            <BitOffs>691094336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -101595,7 +101596,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691120000</BitOffs>
+            <BitOffs>691120256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -101607,7 +101608,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691145920</BitOffs>
+            <BitOffs>691146176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -101636,7 +101637,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691171840</BitOffs>
+            <BitOffs>691172096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -101665,7 +101666,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691197760</BitOffs>
+            <BitOffs>691198016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -101694,7 +101695,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691223680</BitOffs>
+            <BitOffs>691223936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -101723,7 +101724,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691249600</BitOffs>
+            <BitOffs>691249856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -101748,7 +101749,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691275520</BitOffs>
+            <BitOffs>691275776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -101777,7 +101778,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691301440</BitOffs>
+            <BitOffs>691301696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -101806,7 +101807,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691327360</BitOffs>
+            <BitOffs>691327616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -101831,7 +101832,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691353280</BitOffs>
+            <BitOffs>691353536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -101859,7 +101860,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691379200</BitOffs>
+            <BitOffs>691379456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -101886,7 +101887,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691405120</BitOffs>
+            <BitOffs>691405376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -101913,7 +101914,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691431040</BitOffs>
+            <BitOffs>691431296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -101940,7 +101941,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691456960</BitOffs>
+            <BitOffs>691457216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -101969,7 +101970,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691482880</BitOffs>
+            <BitOffs>691483136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -101998,7 +101999,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691508800</BitOffs>
+            <BitOffs>691509056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -102023,7 +102024,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691534720</BitOffs>
+            <BitOffs>691534976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -102052,7 +102053,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691560640</BitOffs>
+            <BitOffs>691560896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -102077,7 +102078,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691586560</BitOffs>
+            <BitOffs>691586816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -102114,7 +102115,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691612480</BitOffs>
+            <BitOffs>691612736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -102159,7 +102160,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691638400</BitOffs>
+            <BitOffs>691638656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -102200,7 +102201,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691664320</BitOffs>
+            <BitOffs>691664576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -102241,7 +102242,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691690240</BitOffs>
+            <BitOffs>691690496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -102282,7 +102283,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691716160</BitOffs>
+            <BitOffs>691716416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -102323,7 +102324,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691742080</BitOffs>
+            <BitOffs>691742336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -102364,7 +102365,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691768000</BitOffs>
+            <BitOffs>691768256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -102405,7 +102406,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691793920</BitOffs>
+            <BitOffs>691794176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -102446,7 +102447,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691819840</BitOffs>
+            <BitOffs>691820096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -102482,7 +102483,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691845760</BitOffs>
+            <BitOffs>691846016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -102518,7 +102519,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691871680</BitOffs>
+            <BitOffs>691871936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -102554,7 +102555,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691897600</BitOffs>
+            <BitOffs>691897856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -102599,7 +102600,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691923520</BitOffs>
+            <BitOffs>691923776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45</Name>
@@ -102645,7 +102646,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691949440</BitOffs>
+            <BitOffs>691949696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46</Name>
@@ -102691,7 +102692,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691975360</BitOffs>
+            <BitOffs>691975616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47</Name>
@@ -102722,20 +102723,37 @@ second version of targets paddle 2</Comment>
             </Default>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>pv: AT2K4:MMS:FILT</Value>
-              </Property>
-              <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable  := TIIB[AT2K4-EL7047-E4]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable := TIIB[AT2K4-EL7047-E4]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT     := TIIB[AT2K4-EL5042-E5]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: AT2K4:IP1:MMS
+    </Value>
+              </Property>
+              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692001280</BitOffs>
+            <BitOffs>692001536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>692027464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -102765,7 +102783,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027200</BitOffs>
+            <BitOffs>692027472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -102795,22 +102813,22 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027264</BitOffs>
+            <BitOffs>692027536</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.nPackMode</Name>
+            <Name>Constants.bSimulationMode</Name>
             <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>8</Value>
+              <Bool>false</Bool>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027328</BitOffs>
+            <BitOffs>692027600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -102825,21 +102843,37 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027344</BitOffs>
+            <BitOffs>692027608</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Constants.bMulticoreSupport</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
             <Default>
-              <Bool>false</Bool>
+              <Value>64</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027352</BitOffs>
+            <BitOffs>692027616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nPackMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>8</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>692027632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -102854,7 +102888,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027360</BitOffs>
+            <BitOffs>692027648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -102869,7 +102903,21 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027392</BitOffs>
+            <BitOffs>692027680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bMulticoreSupport</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>692027712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -102883,7 +102931,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027424</BitOffs>
+            <BitOffs>692027744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -102897,7 +102945,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027456</BitOffs>
+            <BitOffs>692027776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -102915,7 +102963,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692029504</BitOffs>
+            <BitOffs>692029824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -102929,7 +102977,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692030528</BitOffs>
+            <BitOffs>692030848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -102950,7 +102998,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692030592</BitOffs>
+            <BitOffs>692030912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -103022,7 +103070,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692046976</BitOffs>
+            <BitOffs>692047296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -103094,7 +103142,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047104</BitOffs>
+            <BitOffs>692047424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -103166,7 +103214,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047232</BitOffs>
+            <BitOffs>692047552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -103238,7 +103286,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047360</BitOffs>
+            <BitOffs>692047680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -103310,7 +103358,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047488</BitOffs>
+            <BitOffs>692047808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -103382,7 +103430,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047616</BitOffs>
+            <BitOffs>692047936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -103454,7 +103502,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047744</BitOffs>
+            <BitOffs>692048064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -103526,7 +103574,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047872</BitOffs>
+            <BitOffs>692048192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -103552,60 +103600,14 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692080896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K3Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>692119056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_PMPS</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>3.3.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>701552896</BitOffs>
+            <BitOffs>692081216</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>87883776</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -103691,7 +103693,7 @@ second version of targets paddle 2</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-06-20T09:57:47</Value>
+          <Value>2024-07-23T13:48:54</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## AT2K4 in main program has define two different PVs, and I delete the wrong one 
<!--- Describe your changes in detail -->
Keep only one PV for AT2K4:IP1:MMS, delete another one
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When I make the GUI for this axe, could not find AT2K4:IP1:MMS PV, then I find out because I define two different PVs for this axe. So, I delete another one to keep it correct.
<!--- If it fixes an open issue, please link to the issue here. -->
(https://jira.slac.stanford.edu/browse/ECS-4824)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I can grep_pv AT2K4:IP1:MMS after rebuilding IOC. I also make a test GUI and it works well. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
https://jira.slac.stanford.edu/browse/ECS-4824
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
