### PR TITLE
Li2k4 sequence mover

### DIFF
--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1260,7 +1260,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{9DD0BA81-4A92-4D5E-8BD9-E101C02702D4}" Name="tmo_motion" PrjFilePath="..\..\tmo_motion\tmo_motion.plcproj" TmcFilePath="..\..\tmo_motion\tmo_motion.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{71D9AF80-0111-60BD-E642-58E77DBD9A91}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{873F1F43-C4FE-B593-1F13-39E588FDC7A4}">
 			<Name>tmo_motion Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -2745,6 +2745,10 @@ External Setpoint Generation:
 					<Type GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Type>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K4.bHallInput1</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
@@ -2763,18 +2767,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
 					<Type GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput1</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bHallInput2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K4.bTL1High</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -2894,6 +2886,14 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bHallInput2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K4.bTL1High</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K4.bTL1Low</Name>
@@ -3182,119 +3182,236 @@ External Setpoint Generation:
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bLimitForwardEnable</Name>
 					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
 					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHome</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bHome</Name>
 					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHardwareEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bHardwareEnable</Name>
 					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].nRawEncoderULINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].nRawEncoderUINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].nRawEncoderINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bLimitForwardEnable</Name>
 					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
 					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHome</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bHome</Name>
 					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHardwareEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bHardwareEnable</Name>
 					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].nRawEncoderULINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].nRawEncoderUINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].nRawEncoderINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bLimitForwardEnable</Name>
 					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
 					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHome</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bHome</Name>
 					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHardwareEnable</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bHardwareEnable</Name>
 					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].nRawEncoderULINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].nRawEncoderUINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].nRawEncoderINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
@@ -5811,29 +5928,56 @@ External Setpoint Generation:
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].Axis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bBrakeRelease</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bBrakeRelease</Name>
 					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].Axis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bBrakeRelease</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bBrakeRelease</Name>
 					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].Axis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bBrakeRelease</Name>
+					<Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bBrakeRelease</Name>
 					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1260,7 +1260,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{9DD0BA81-4A92-4D5E-8BD9-E101C02702D4}" Name="tmo_motion" PrjFilePath="..\..\tmo_motion\tmo_motion.plcproj" TmcFilePath="..\..\tmo_motion\tmo_motion.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{873F1F43-C4FE-B593-1F13-39E588FDC7A4}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{71335523-D1BE-63BE-B51D-6AC18BBF0850}">
 			<Name>tmo_motion Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -6013,16 +6013,16 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
+					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
+				</Var>
+				<Var>
 					<Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
-					<Type GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Type>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>

--- a/plc-tmo-motion/plc-tmo-motion.tsproj
+++ b/plc-tmo-motion/plc-tmo-motion.tsproj
@@ -9,8 +9,8 @@
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
-					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<TargetSelect TargetId="2">{E008E3C8-6BD9-491C-B673-DC45CC7AA4F1}</TargetSelect>
+					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020003" DongleLevel="50" DongleSystemId="{48EB253C-818D-610A-0B70-DC68309EB817}"/>
 				</Target>
 			</Licenses>

--- a/plc-tmo-motion/plc-tmo-motion.tsproj
+++ b/plc-tmo-motion/plc-tmo-motion.tsproj
@@ -9,8 +9,8 @@
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
-					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<TargetSelect TargetId="2">{E008E3C8-6BD9-491C-B673-DC45CC7AA4F1}</TargetSelect>
+					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020003" DongleLevel="50" DongleSystemId="{48EB253C-818D-610A-0B70-DC68309EB817}"/>
 				</Target>
 			</Licenses>
@@ -31,6 +31,9 @@
 		</Io>
 	</Project>
 	<Mappings>
+		<MappingInfo Identifier="{00000000-2001-0850-0020-500841000403}" Id="#x02030030"/>
 		<MappingInfo Identifier="{00000000-0010-0304-3000-040310000403}" Id="#x02030010"/>
+		<MappingInfo Identifier="{08502001-0010-0304-0020-500810000403}" Id="#x02030020" Watchdog="00000000000000000000000000000000"/>
+		<MappingInfo Identifier="{05000010-2001-0850-3000-040300205008}" Id="#x02030040" Watchdog="14000000040000000400000004000000"/>
 	</Mappings>
 </TcSmProject>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_2_PMPS_PRE.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_2_PMPS_PRE.TcPOU
@@ -12,7 +12,7 @@ END_VAR
     io_fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,
     bEnable:=TRUE,
     sPLCName:='plc-tmo-motion',
-	sDirectory:='/home/ecs-user/pmpsdb/'
+    sDirectory:='/home/ecs-user/pmpsdb/'
     );
 
 ]]></ST>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
@@ -7,17 +7,19 @@ VAR
     fbMotionLI2K4X: FB_MotionStage;
     fbMotionLI2K4Y: FB_MotionStage;
 
-   //{attribute 'pytmc' := '
-   //     pv: LI2K4:IP1
-   //    io: io
-   // '}
-   // fbLI2K4States: FB_PositionStatePMPS2D;
     bLI2K4StatesReset : BOOL;
     anStateSequenceOrderLI2K4Y : ARRAY[1...GeneralConstants.MAX_STATES] OF UINT;
     anStateSequenceOrderLI2K4X : ARRAY[1...GeneralConstants.MAX_STATES] OF UINT;
     fbLI2K4YStates: FB_PositionStatePMPS1D;
     fbLI2K4XStates: FB_PositionStatePMPS1D;
+    fbFastFault: FB_FastFault;
+
+    {attribute 'pytmc' := '
+        pv: LI2K4:IP1
+        io: io
+    '}
     fbLI2K4States : FB_SequenceMover2D;
+    //fbLI2K4States : FB_PositionStatePMPS2D;
 
     {attribute 'pytmc' := '
         pv: LI2K4:IP1:STATE:SET
@@ -64,6 +66,8 @@ fbStateSetup(stPositionState:=aLI2K4YStates[ENUM_LaserCoupling_States.OUT], fDel
 fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 1.5, sName := 'MIRROR1', fPosition:=-3.375);
 fbStateSetup(stPositionState:=aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 0.5, sName := 'MIRROR1', fPosition:=84.5);
 
+aLI2K4YStates[ENUM_LaserCoupling_States.OUT].stPMPS.sPmpsState := 'LI2K4:IP1-OUT';
+aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1].stPMPS.sPmpsState := 'LI2K4:IP1-MIRROR1';
 aLI2K4XStates[ENUM_LaserCoupling_States.OUT].stPMPS.sPmpsState := 'LI2K4:IP1-OUT';
 aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1].stPMPS.sPmpsState := 'LI2K4:IP1-MIRROR1';
 
@@ -102,6 +106,16 @@ anStateSequenceOrderLI2K4Y[ENUM_LaserCoupling_States.Out] := 2;
 anStateSequenceOrderLI2K4Y[ENUM_LaserCoupling_States.Mirror1] := 1;
 anStateSequenceOrderLI2K4X[ENUM_LaserCoupling_States.Out] := 1;
 anStateSequenceOrderLI2K4X[ENUM_LaserCoupling_States.Mirror1] := 2;
+
+fbFastFault(
+    i_xOK:=li2k4_enumGet<>0,
+    i_xAutoReset:=TRUE,
+    i_DevName:='LI2K4:IP1',
+    i_Desc:='LI2K4 is in a transition state.',
+    i_TypeCode:=16#1005,
+    io_fbFFHWO:=fbFastFaultOutput1
+);
+
 fbLI2K4States(
     bReset:=bLI2K4StatesReset,
     anStateSequenceOrder1:=anStateSequenceOrderLI2K4Y,

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
@@ -7,11 +7,18 @@ VAR
     fbMotionLI2K4X: FB_MotionStage;
     fbMotionLI2K4Y: FB_MotionStage;
 
-   {attribute 'pytmc' := '
-        pv: LI2K4:IP1
-        io: io
-    '}
-    fbLI2K4States: FB_PositionStatePMPS2D;
+   //{attribute 'pytmc' := '
+   //     pv: LI2K4:IP1
+   //    io: io
+   // '}
+   // fbLI2K4States: FB_PositionStatePMPS2D;
+    bLI2K4StatesReset : BOOL;
+    anStateSequenceOrderLI2K4Y : ARRAY[1...GeneralConstants.MAX_STATES] OF UINT;
+    anStateSequenceOrderLI2K4X : ARRAY[1...GeneralConstants.MAX_STATES] OF UINT;
+    fbLI2K4YStates: FB_PositionStatePMPS1D;
+    fbLI2K4XStates: FB_PositionStatePMPS1D;
+    fbLI2K4States : FB_SequenceMover2D;
+
     {attribute 'pytmc' := '
         pv: LI2K4:IP1:STATE:SET
         io: io
@@ -32,8 +39,6 @@ VAR
     aLI2K4XStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     aLI2K4YStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
 
-
-
     EPS_LI2K4Y_Positive : FB_EPS;
     EPS_LI2K4Y_Negative : FB_EPS;
     EPS_LI2K4X_Positive : FB_EPS;
@@ -41,12 +46,12 @@ VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[IF Main.M46.stAxisStatus.fActPosition < -0.85 THEN
-   Main.M45.fVelocity := 0.01;
-END_IF
-IF Main.M45.stAxisStatus.fActPosition > 85 THEN
-   Main.M46.bExecute := FALSE;
-END_IF
+      <ST><![CDATA[//IF Main.M46.stAxisStatus.fActPosition < -0.85 THEN
+//   Main.M45.fVelocity := 0.01;
+//END_IF
+//IF Main.M45.stAxisStatus.fActPosition > 85 THEN
+//   Main.M46.bExecute := FALSE;
+//END_IF
 
 fbMotionLI2K4Y(stMotionStage:=Main.M45);
 fbMotionLI2K4X(stMotionStage:=Main.M46);
@@ -54,11 +59,6 @@ fbMotionLI2K4X(stMotionStage:=Main.M46);
 //LI2K4 2DPMPS
 fbStateSetup(stPositionState:=stDefault, bSetDefault:=TRUE);
 fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.OUT], fDelta := 0.5, sName := 'OUT', fPosition:=-0.75);
-{*
-aLI2K4XStates[ENUM_LaserCoupling_States.OUT].nMoveOrder := 1;
-aLI2K4YStates[ENUM_LaserCoupling_States.OUT].nMoveOrder := 2;
-aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1].nMoveOrder := 2;
-aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1].nMoveOrder := 1; *}
 
 fbStateSetup(stPositionState:=aLI2K4YStates[ENUM_LaserCoupling_States.OUT], fDelta := 0.5,  sName := 'OUT', fPosition:=133.0);
 fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 1.5, sName := 'MIRROR1', fPosition:=-3.375);
@@ -83,7 +83,31 @@ EPS_LI2K4X_Negative.setBit(nBits := 0, bValue:= Main.M45.stAxisStatus.fActPositi
 
 //LI2K4 sequenct move : OUT->IN Y move first and then X moves IN->OUT X moves first then Y
 
+(*fbLI2K4States(
+    stMotionStage1:=Main.M45,
+    stMotionStage2:=Main.M46,
+    astPositionState1:=aLI2K4YStates,
+    astPositionState2:=aLI2K4XStates,
+    eEnumSet:=li2k4_enumSet,
+    eEnumGet:=li2k4_enumGet,
+    sDeviceName := 'LI2K4:IP1',
+    sTransitionKey := 'LI2K4:IP1-TRANSITION',
+    fbFFHWO:=fbFastFaultOutput1,
+    fbArbiter:=fbArbiter,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    bEnablePositionLimits:=TRUE,
+);*)
+anStateSequenceOrderLI2K4Y[ENUM_LaserCoupling_States.Out] := 2;
+anStateSequenceOrderLI2K4Y[ENUM_LaserCoupling_States.Mirror1] := 1;
+anStateSequenceOrderLI2K4X[ENUM_LaserCoupling_States.Out] := 1;
+anStateSequenceOrderLI2K4X[ENUM_LaserCoupling_States.Mirror1] := 2;
 fbLI2K4States(
+    bReset:=bLI2K4StatesReset,
+    anStateSequenceOrder1:=anStateSequenceOrderLI2K4Y,
+    anStateSequenceOrder2:=anStateSequenceOrderLI2K4X,
+    fbPositionState1D1:=fbLI2K4YStates,
+    fbPositionState1D2:=fbLI2K4XStates,
     stMotionStage1:=Main.M45,
     stMotionStage2:=Main.M46,
     astPositionState1:=aLI2K4YStates,

--- a/plc-tmo-motion/tmo_motion/POUs/Sequence_Mover/FB_SequenceMover2D.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/Sequence_Mover/FB_SequenceMover2D.TcPOU
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_SequenceMover2D" Id="{a63f23fb-65f2-4a77-987b-d3b574c6f9d5}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_SequenceMover2D
+VAR_IN_OUT
+    // Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.
+    eEnumSet: UINT;
+    // The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.
+    eEnumGet: UINT;
+    // The fast fault output to fault to.
+    fbFFHWO: FB_HardwareFFOutput;
+    // The arbiter to request beam conditions from.
+    fbArbiter: FB_Arbiter;
+
+    // The motor to move.
+    stMotionStage1: ST_MotionStage;
+    // All possible position states, including unused/invalid states.
+    astPositionState1: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    // The motor to move.
+    stMotionStage2: ST_MotionStage;
+    // All possible position states, including unused/invalid states.
+    astPositionState2: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
+    fbPositionState1D1 : FB_PositionStatePMPS1D;
+    fbPositionState1D2 : FB_PositionStatePMPS1D;
+END_VAR
+VAR_INPUT
+    bReset : BOOL;
+
+    // Index is state enum value. Value at index is sequence order for that state as a goal for the specified axis number.
+    // e.g. if state number 2 needs axis 1 to move second, then in index 2 put a 2 for axis 1 and for index 2 on axis 2 put a 1.
+    anStateSequenceOrder1 : ARRAY[1...GeneralConstants.MAX_STATES] OF UINT;
+    anStateSequenceOrder2 : ARRAY[1...GeneralConstants.MAX_STATES] OF UINT;
+
+    // Set this to TRUE to enable input state moves, or FALSE to disable them.
+    bEnableMotion: BOOL;
+    // Set this to TRUE to enable beam parameter checks, or FALSE to disable them.
+    bEnableBeamParams: BOOL;
+    // Set this to TRUE to enable position limit checks, or FALSE to disable them.
+    bEnablePositionLimits: BOOL;
+    // The name of the device for use in the PMPS DB lookup and diagnostic screens.
+    sDeviceName: STRING;
+    // The name of the transition state in the PMPS database.
+    sTransitionKey: STRING;
+    // Normal EPICS inputs, gathered into a single struct
+    stEpicsToPlc: ST_StateEpicsToPlc;
+    // PMPS EPICS inputs, gathered into a single struct
+    stPMPSEpicsToPlc: ST_StatePMPSEpicsToPlc;
+    // Set this to TRUE to re-read the loaded database immediately (useful for debug)
+    bReadDBNow: BOOL;
+END_VAR
+VAR
+    tonStateSequenceTimeout : TON;
+    tStateSequenceTimeoutTime : TIME := T#5s;
+    nGoal: UINT;
+    nState: UINT;
+    // The current state index of the 1st axis state mover
+    eEnumGet1: UINT;
+    // The current state index of the 2nd axis state mover
+    eEnumGet2: UINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[
+IF bReset THEN
+    bReset := FALSE;
+    nState := 0;
+END_IF
+
+CASE nState OF
+    0:
+        IF eEnumSet <> 0 THEN
+            nGoal := eEnumSet;
+            nState := nState + 1;
+        ELSE
+            fbPositionState1D1(
+                stMotionStage:=stMotionStage1,
+                astPositionState:=astPositionState1,
+                eEnumSet:=eEnumSet,
+                eEnumGet:=eEnumGet1,
+                sDeviceName:=sDeviceName,
+                sTransitionKey:=sTransitionKey,
+                fbFFHWO:=fbFFHWO,
+                fbArbiter:=fbArbiter,
+                bEnableMotion:=bEnableMotion,
+                bEnableBeamParams:=bEnableBeamParams,
+                bEnablePositionLimits:=bEnablePositionLimits,
+            );
+            fbPositionState1D2(
+                stMotionStage:=stMotionStage2,
+                astPositionState:=astPositionState2,
+                eEnumSet:=eEnumSet,
+                eEnumGet:=eEnumGet2,
+                sDeviceName:=sDeviceName,
+                sTransitionKey:=sTransitionKey,
+                fbFFHWO:=fbFFHWO,
+                fbArbiter:=fbArbiter,
+                bEnableMotion:=bEnableMotion,
+                bEnableBeamParams:=bEnableBeamParams,
+                bEnablePositionLimits:=bEnablePositionLimits,
+            );
+        END_IF
+        tonStateSequenceTimeout(IN:=FALSE);
+    1:
+        IF anStateSequenceOrder1[nGoal] <= anStateSequenceOrder2[nGoal] THEN
+            // Move 1 then 2
+            fbPositionState1D1(
+                stMotionStage:=stMotionStage1,
+                astPositionState:=astPositionState1,
+                eEnumSet:=eEnumSet,
+                eEnumGet:=eEnumGet1,
+                sDeviceName:=sDeviceName,
+                sTransitionKey:=sTransitionKey,
+                fbFFHWO:=fbFFHWO,
+                fbArbiter:=fbArbiter,
+                bEnableMotion:=bEnableMotion,
+                bEnableBeamParams:=bEnableBeamParams,
+                bEnablePositionLimits:=bEnablePositionLimits,
+            );
+            tonStateSequenceTimeout(IN:=NOT stMotionStage1.bBusy,PT:=tStateSequenceTimeoutTime);
+            IF eEnumGet1 = nGoal THEN
+                eEnumSet := nGoal;
+                tonStateSequenceTimeout(IN:=FALSE);
+                nState := 10;
+            ELSIF tonStateSequenceTimeout.Q THEN
+                nState := 0;
+            END_IF
+        ELSIF anStateSequenceOrder1[nGoal] > anStateSequenceOrder2[nGoal] THEN
+            // Move 2 then 1
+            fbPositionState1D2(
+                stMotionStage:=stMotionStage2,
+                astPositionState:=astPositionState2,
+                eEnumSet:=eEnumSet,
+                eEnumGet:=eEnumGet2,
+                sDeviceName:=sDeviceName,
+                sTransitionKey:=sTransitionKey,
+                fbFFHWO:=fbFFHWO,
+                fbArbiter:=fbArbiter,
+                bEnableMotion:=bEnableMotion,
+                bEnableBeamParams:=bEnableBeamParams,
+                bEnablePositionLimits:=bEnablePositionLimits,
+            );
+            tonStateSequenceTimeout(IN:=NOT stMotionStage2.bBusy,PT:=tStateSequenceTimeoutTime);
+            IF eEnumGet2 = nGoal THEN
+                eEnumSet := nGoal;
+                tonStateSequenceTimeout(IN:=FALSE);
+                nState := 20;
+            ELSIF tonStateSequenceTimeout.Q THEN
+                nState := 0;
+            END_IF
+        END_IF
+    10: // Move 2 after 1
+        fbPositionState1D2(
+            stMotionStage:=stMotionStage2,
+            astPositionState:=astPositionState2,
+            eEnumSet:=eEnumSet,
+            eEnumGet:=eEnumGet2,
+            sDeviceName:=sDeviceName,
+            sTransitionKey:=sTransitionKey,
+            fbFFHWO:=fbFFHWO,
+            fbArbiter:=fbArbiter,
+            bEnableMotion:=bEnableMotion,
+            bEnableBeamParams:=bEnableBeamParams,
+            bEnablePositionLimits:=bEnablePositionLimits,
+        );
+        tonStateSequenceTimeout(IN:=NOT stMotionStage2.bBusy,PT:=tStateSequenceTimeoutTime);
+        IF eEnumGet2 = nGoal THEN
+            nState := 0;
+            tonStateSequenceTimeout(IN:=FALSE);
+        ELSIF tonStateSequenceTimeout.Q THEN
+            nState := 0;
+        END_IF
+    20: // Move 1 after 2
+        fbPositionState1D1(
+            stMotionStage:=stMotionStage1,
+            astPositionState:=astPositionState1,
+            eEnumSet:=eEnumSet,
+            eEnumGet:=eEnumGet1,
+            sDeviceName:=sDeviceName,
+            sTransitionKey:=sTransitionKey,
+            fbFFHWO:=fbFFHWO,
+            fbArbiter:=fbArbiter,
+            bEnableMotion:=bEnableMotion,
+            bEnableBeamParams:=bEnableBeamParams,
+            bEnablePositionLimits:=bEnablePositionLimits,
+        );
+        tonStateSequenceTimeout(IN:=NOT stMotionStage1.bBusy,PT:=tStateSequenceTimeoutTime);
+        IF eEnumGet1 = nGoal THEN
+            nState := 0;
+            tonStateSequenceTimeout(IN:=FALSE);
+        ELSIF tonStateSequenceTimeout.Q THEN
+            nState := 0;
+        END_IF
+END_CASE
+
+IF eEnumGet1 = eEnumGet2 THEN
+    eEnumGet := eEnumGet1;
+ELSE
+    eEnumGet := 0;
+END_IF
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/plc-tmo-motion/tmo_motion/POUs/Sequence_Mover/FB_SequenceMover2D.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/Sequence_Mover/FB_SequenceMover2D.TcPOU
@@ -15,10 +15,20 @@ VAR_IN_OUT
     // The motor to move.
     stMotionStage1: ST_MotionStage;
     // All possible position states, including unused/invalid states.
+    {attribute 'pytmc' := '
+        pv: STATE:M1
+        io: io
+        expand: :%.2d
+    '}
     astPositionState1: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     // The motor to move.
     stMotionStage2: ST_MotionStage;
     // All possible position states, including unused/invalid states.
+    {attribute 'pytmc' := '
+        pv: STATE:M2
+        io: io
+        expand: :%.2d
+    '}
     astPositionState2: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
 
     fbPositionState1D1 : FB_PositionStatePMPS1D;
@@ -43,11 +53,23 @@ VAR_INPUT
     // The name of the transition state in the PMPS database.
     sTransitionKey: STRING;
     // Normal EPICS inputs, gathered into a single struct
+    {attribute 'pytmc' := 'pv: STATE'}
     stEpicsToPlc: ST_StateEpicsToPlc;
     // PMPS EPICS inputs, gathered into a single struct
+    {attribute 'pytmc' := 'pv: STATE'}
     stPMPSEpicsToPlc: ST_StatePMPSEpicsToPlc;
     // Set this to TRUE to re-read the loaded database immediately (useful for debug)
     bReadDBNow: BOOL;
+END_VAR
+VAR_OUTPUT
+    // Normal EPICS outputs, gathered into a single struct
+    {attribute 'pytmc' := 'pv: STATE'}
+    stPlcToEpics: ST_StatePlcToEpics;
+    // PMPS EPICS outputs, gathered into a single struct
+    {attribute 'pytmc' := 'pv: STATE'}
+    stPMPSPlcToEpics: ST_StatePMPSPlcToEpics;
+    // The PMPS database lookup associated with the current position state.
+    stDbStateParams: ST_DbStateParams;
 END_VAR
 VAR
     tonStateSequenceTimeout : TON;
@@ -85,6 +107,11 @@ CASE nState OF
                 bEnableMotion:=bEnableMotion,
                 bEnableBeamParams:=bEnableBeamParams,
                 bEnablePositionLimits:=bEnablePositionLimits,
+                stEpicsToPlc:=stEpicsToPlc,
+                stPMPSEpicsToPlc:=stPMPSEpicsToPlc,
+                stDbStateParams=>stDbStateParams,
+                stPlcToEpics=>stPlcToEpics,
+                stPMPSPlcToEpics=>stPMPSPlcToEpics,
             );
             fbPositionState1D2(
                 stMotionStage:=stMotionStage2,
@@ -98,6 +125,11 @@ CASE nState OF
                 bEnableMotion:=bEnableMotion,
                 bEnableBeamParams:=bEnableBeamParams,
                 bEnablePositionLimits:=bEnablePositionLimits,
+                stEpicsToPlc:=stEpicsToPlc,
+                stPMPSEpicsToPlc:=stPMPSEpicsToPlc,
+                stDbStateParams=>stDbStateParams,
+                stPlcToEpics=>stPlcToEpics,
+                stPMPSPlcToEpics=>stPMPSPlcToEpics,
             );
         END_IF
         tonStateSequenceTimeout(IN:=FALSE);
@@ -116,6 +148,11 @@ CASE nState OF
                 bEnableMotion:=bEnableMotion,
                 bEnableBeamParams:=bEnableBeamParams,
                 bEnablePositionLimits:=bEnablePositionLimits,
+                stEpicsToPlc:=stEpicsToPlc,
+                stPMPSEpicsToPlc:=stPMPSEpicsToPlc,
+                stDbStateParams=>stDbStateParams,
+                stPlcToEpics=>stPlcToEpics,
+                stPMPSPlcToEpics=>stPMPSPlcToEpics,
             );
             tonStateSequenceTimeout(IN:=NOT stMotionStage1.bBusy,PT:=tStateSequenceTimeoutTime);
             IF eEnumGet1 = nGoal THEN
@@ -139,6 +176,11 @@ CASE nState OF
                 bEnableMotion:=bEnableMotion,
                 bEnableBeamParams:=bEnableBeamParams,
                 bEnablePositionLimits:=bEnablePositionLimits,
+                stEpicsToPlc:=stEpicsToPlc,
+                stPMPSEpicsToPlc:=stPMPSEpicsToPlc,
+                stDbStateParams=>stDbStateParams,
+                stPlcToEpics=>stPlcToEpics,
+                stPMPSPlcToEpics=>stPMPSPlcToEpics,
             );
             tonStateSequenceTimeout(IN:=NOT stMotionStage2.bBusy,PT:=tStateSequenceTimeoutTime);
             IF eEnumGet2 = nGoal THEN
@@ -162,6 +204,11 @@ CASE nState OF
             bEnableMotion:=bEnableMotion,
             bEnableBeamParams:=bEnableBeamParams,
             bEnablePositionLimits:=bEnablePositionLimits,
+            stEpicsToPlc:=stEpicsToPlc,
+            stPMPSEpicsToPlc:=stPMPSEpicsToPlc,
+            stDbStateParams=>stDbStateParams,
+            stPlcToEpics=>stPlcToEpics,
+            stPMPSPlcToEpics=>stPMPSPlcToEpics,
         );
         tonStateSequenceTimeout(IN:=NOT stMotionStage2.bBusy,PT:=tStateSequenceTimeoutTime);
         IF eEnumGet2 = nGoal THEN
@@ -183,6 +230,11 @@ CASE nState OF
             bEnableMotion:=bEnableMotion,
             bEnableBeamParams:=bEnableBeamParams,
             bEnablePositionLimits:=bEnablePositionLimits,
+            stEpicsToPlc:=stEpicsToPlc,
+            stPMPSEpicsToPlc:=stPMPSEpicsToPlc,
+            stDbStateParams=>stDbStateParams,
+            stPlcToEpics=>stPlcToEpics,
+            stPMPSPlcToEpics=>stPMPSPlcToEpics,
         );
         tonStateSequenceTimeout(IN:=NOT stMotionStage1.bBusy,PT:=tStateSequenceTimeoutTime);
         IF eEnumGet1 = nGoal THEN

--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -120,6 +120,9 @@
     <Compile Include="POUs\PRG_TM2K4.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Sequence_Mover\FB_SequenceMover2D.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\temp\FB_SLITS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -154,6 +157,7 @@
   <ItemGroup>
     <Folder Include="DUTs" />
     <Folder Include="GVLs" />
+    <Folder Include="POUs\Sequence_Mover" />
     <Folder Include="POUs\TM2K4" />
     <Folder Include="POUs\TM1K4" />
     <Folder Include="POUs\temp" />

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{71D9AF80-0111-60BD-E642-58E77DBD9A91}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{873F1F43-C4FE-B593-1F13-39E588FDC7A4}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -181,31 +181,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86539112</GetCodeOffs>
+        <GetCodeOffs>86733208</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86539176</GetCodeOffs>
+        <GetCodeOffs>86733272</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539192</GetCodeOffs>
+        <GetCodeOffs>86733288</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539160</GetCodeOffs>
+        <GetCodeOffs>86733256</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539184</GetCodeOffs>
+        <GetCodeOffs>86733280</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1427,15 +1427,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86538992</GetCodeOffs>
-        <SetCodeOffs>86539040</SetCodeOffs>
+        <GetCodeOffs>86733088</GetCodeOffs>
+        <SetCodeOffs>86733136</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539064</GetCodeOffs>
-        <SetCodeOffs>86539088</SetCodeOffs>
+        <GetCodeOffs>86733160</GetCodeOffs>
+        <SetCodeOffs>86733184</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1455,9 +1455,6 @@
             <Name>property</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
       </Method>
       <Method>
         <Name>ExtendName</Name>
@@ -1515,19 +1512,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Name>Clear</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1571,6 +1556,21 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1698,25 +1698,25 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>86539288</GetCodeOffs>
+        <GetCodeOffs>86733384</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86539248</GetCodeOffs>
+        <GetCodeOffs>86733344</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86539424</GetCodeOffs>
+        <GetCodeOffs>86733520</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539344</GetCodeOffs>
+        <GetCodeOffs>86733440</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1728,7 +1728,7 @@
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86539432</GetCodeOffs>
+        <GetCodeOffs>86733528</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1795,7 +1795,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1994,9 +1994,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2159,6 +2156,9 @@
         </Local>
       </Method>
       <Method>
+        <Name>UpdateLangId</Name>
+      </Method>
+      <Method>
         <Name>EqualsToEventEntryEx</Name>
         <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
@@ -2299,7 +2299,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86539488</GetCodeOffs>
+        <GetCodeOffs>86733584</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -2680,7 +2680,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T#1ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2696,7 +2696,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T#100ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2712,7 +2712,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T#10m</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -3633,7 +3633,7 @@
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#300MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -4132,6 +4132,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <Comment> String format argument types </Comment>
       <BitSize>16</BitSize>
@@ -4614,69 +4677,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4707,15 +4707,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -5000,12 +5000,91 @@
         <BitOffs>8224416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -5054,53 +5133,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5315,44 +5347,12 @@
         </Properties>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -5669,6 +5669,14 @@
         <BitOffs>4240416</BitOffs>
       </SubItem>
       <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5708,46 +5716,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5944,7 +5912,39 @@
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6288,6 +6288,103 @@
         <BitOffs>12701056</BitOffs>
       </SubItem>
       <Method>
+        <Name>AssertArrayEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6529,21 +6626,21 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6699,113 +6796,6 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6942,21 +6932,6 @@
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7345,14 +7320,29 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
         <Comment>
-    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -7366,8 +7356,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -7431,6 +7421,16 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7440,45 +7440,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7518,6 +7479,210 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7724,14 +7889,20 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7740,6 +7911,16 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -7998,40 +8179,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertEquals_REAL</Name>
         <Comment>
     Asserts that two REALs are equal to within a positive delta. If they are not, an assertion error is created.
@@ -8106,37 +8253,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LTIME</Name>
-        <Comment>
-    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8305,341 +8433,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -8737,6 +8530,208 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -8770,14 +8765,14 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -8791,8 +8786,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9293,19 +9288,22 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9353,6 +9351,40 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Comment>
+    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9463,103 +9495,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -9657,11 +9592,48 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9675,8 +9647,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9687,12 +9659,6 @@
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9754,6 +9720,40 @@
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -10067,7 +10067,7 @@
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#50MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -10095,7 +10095,7 @@
         <BitSize>32</BitSize>
         <BitOffs>4129120</BitOffs>
         <Default>
-          <DateTime>T#50MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
@@ -13140,6 +13140,14 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13192,6 +13200,20 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13205,25 +13227,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13248,10 +13260,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13271,23 +13279,36 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13314,20 +13335,6 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13371,22 +13378,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13438,36 +13429,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13480,20 +13443,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
+        <Name>AddRawObject</Name>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -13503,11 +13455,22 @@
             </Property>
           </Properties>
         </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13516,6 +13479,22 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13539,7 +13518,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
+        <Name>AddKeyDateTime</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13550,6 +13529,11 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13562,10 +13546,26 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>AddReal</Name>
+        <Name>CopyDocument</Name>
+        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13884,22 +13884,11 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13958,41 +13947,14 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -14030,14 +13992,52 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14305,23 +14305,13 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14407,19 +14397,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14463,32 +14449,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14512,16 +14472,6 @@
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14556,34 +14506,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14623,6 +14562,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14638,7 +14587,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -14648,8 +14597,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14714,16 +14663,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14760,7 +14699,60 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -14770,8 +14762,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14790,9 +14782,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14805,6 +14797,16 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14815,12 +14817,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -14893,36 +14900,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14933,25 +14910,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -15004,9 +14975,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15014,7 +14985,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -15113,7 +15084,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -15122,15 +15093,9 @@
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15150,21 +15115,6 @@
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -15212,6 +15162,38 @@
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15248,39 +15230,46 @@
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15314,34 +15303,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15404,9 +15368,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15414,7 +15378,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -15423,26 +15397,9 @@
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -15476,9 +15433,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15578,14 +15535,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15668,59 +15617,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15774,6 +15681,42 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15800,13 +15743,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15895,9 +15848,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15915,7 +15868,22 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -15947,17 +15915,28 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -15972,11 +15951,136 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -16014,7 +16118,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -16024,112 +16128,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -19527,12 +19527,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetMDPTableID</Name>
-        <Comment> returns the MDP table id (part of MDP address) </Comment>
-        <ReturnType>BYTE</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>GetMDPSubIndex</Name>
         <ReturnType>BYTE</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19558,6 +19552,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetMDPModuleType</Name>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>IsListParam</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19573,9 +19572,10 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetMDPModuleType</Name>
-        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>GetMDPTableID</Name>
+        <Comment> returns the MDP table id (part of MDP address) </Comment>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetKey</Name>
@@ -19640,14 +19640,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86545304</GetCodeOffs>
+        <GetCodeOffs>86739400</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86545208</GetCodeOffs>
+        <GetCodeOffs>86739304</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -20743,7 +20743,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86545456</GetCodeOffs>
+        <GetCodeOffs>86739552</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -21402,114 +21402,8 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86545568</GetCodeOffs>
+        <GetCodeOffs>86739664</GetCodeOffs>
       </PropertyItem>
-      <Method>
-        <Name>Clear</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetFreeSpaceOfVol</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
-        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Local>
-          <Name>ipMemMan</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetMDPVersion</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nLen</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetTCVersion</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nLen</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetParameterStrings</Name>
-        <Comment>| access a read string parameter with multiple values.
-| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nStrings</Name>
-          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
       <Method>
         <Name>ReadFreeSpaceOfVol</Name>
         <Local>
@@ -21578,6 +21472,112 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetFreeSpaceOfVol</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMDPVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTCVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetParameterStrings</Name>
+        <Comment>| access a read string parameter with multiple values.
+| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nStrings</Name>
+          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipMemMan</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>ReadMDPVersion</Name>
@@ -24978,21 +24978,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -25011,22 +25012,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -25225,100 +25225,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -25377,6 +25283,100 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -25580,6 +25580,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -25610,36 +25617,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -25655,9 +25632,29 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -25678,17 +25675,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -26062,6 +26062,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -26073,14 +26079,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -26097,9 +26095,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -26139,15 +26137,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -26432,35 +26432,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -26508,9 +26525,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -26734,47 +26769,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -26920,37 +26920,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -26958,9 +26928,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -27177,7 +27145,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -27745,21 +27745,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -28496,6 +28496,688 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -28805,533 +29487,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -29876,6 +30031,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -30367,56 +30537,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -30487,45 +30625,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -30534,22 +30648,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -30557,124 +30656,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -30948,18 +30929,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31306,7 +31306,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -31325,13 +31325,40 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T#10MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -31368,33 +31395,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -35573,37 +35573,6 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -35648,6 +35617,37 @@ External Setpoint Generation:
     </Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -36263,28 +36263,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -36511,7 +36511,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>339528</BitOffs>
         <Default>
-          <Bool> : u</Bool>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -36545,42 +36545,30 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>511296</BitOffs>
       </SubItem>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>85696</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36711,6 +36699,42 @@ ELSE:
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -36752,44 +36776,20 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>85696</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -44606,7 +44606,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -48369,13 +48369,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -48396,7 +48396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -48554,7 +48554,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>1088</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -49388,7 +49388,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>2720</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -55534,19 +55534,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Motion</Name>
-      </Action>
-      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_CalculatePositions</Name>
+        <Name>ACT_BLOCK</Name>
       </Action>
       <Action>
-        <Name>ACT_BLOCK</Name>
+        <Name>ACT_Motion</Name>
+      </Action>
+      <Action>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -56186,7 +56186,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>27200</BitOffs>
         <Default>
-          <DateTime>T#10S</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -56208,7 +56208,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>27776</BitOffs>
         <Default>
-          <DateTime>T#1S</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -56305,10 +56305,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Properties>
         <Property>
@@ -56587,10 +56587,10 @@ Digital outputs</Comment>
         <BitOffs>258496</BitOffs>
       </SubItem>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Properties>
         <Property>
@@ -56725,7 +56725,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -56978,13 +56978,13 @@ Digital outputs</Comment>
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -57257,10 +57257,10 @@ Digital outputs</Comment>
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -57356,7 +57356,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>260000</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -58513,6 +58513,44 @@ second version of targets paddle 2</Comment>
       </Properties>
     </DataType>
     <DataType>
+      <Name>ENUM_SolidAttenuator_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+        <Comment>    Target4 := 5,
+   Target5 := 6</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</Name>
       <BitSize>1548608</BitSize>
       <SubItem>
@@ -58884,72 +58922,6 @@ second version of targets paddle 2</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name>ENUM_SolidAttenuator_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-        <Comment>    Target4 := 5,
-   Target5 := 6</Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>ENUM_LaserCoupling_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Mirror1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</Name>
       <BitSize>1548480</BitSize>
       <SubItem>
@@ -59283,117 +59255,6 @@ second version of targets paddle 2</Comment>
       </Properties>
     </DataType>
     <DataType>
-      <Name>ENUM_Sample_Calibration_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target1</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target2</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target3</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target4</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Target5</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_EPS</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>eps</Name>
-        <Type Namespace="LCLS_General" ReferenceTo="true">DUT_EPS</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Method>
-        <Name>setBit</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nBits</Name>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bValue</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nMask</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>nBitValue</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>setMessage</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>message</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>setDescription</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>desciption</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name GUID="{292CD354-C7C0-4A61-AAD0-1C85DD69646B}">ST_BeamParams_IO</Name>
       <BitSize>1760</BitSize>
       <SubItem>
@@ -59594,6 +59455,145 @@ second version of targets paddle 2</Comment>
         <Hide GUID="{C9AB5DB1-1B57-42EF-8E17-FBE97768475C}"/>
         <Hide GUID="{43851ABC-CF8A-4AF9-A768-E27D209879D8}"/>
       </Hides>
+    </DataType>
+    <DataType>
+      <Name>ENUM_LaserCoupling_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Mirror1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>ENUM_Sample_Calibration_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target1</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target2</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target3</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target4</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Target5</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_EPS</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>eps</Name>
+        <Type Namespace="LCLS_General" ReferenceTo="true">DUT_EPS</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>setDescription</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>desciption</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>setMessage</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>message</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>setBit</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nBits</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bValue</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nMask</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>nBitValue</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">FB_VetoArbiter</Name>
@@ -59954,8 +59954,7 @@ second version of targets paddle 2</Comment>
         <BitSize>8</BitSize>
         <BitOffs>144576</BitOffs>
         <Default>
-          <Bool>,
-  </Bool>
+          <Bool>,</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -60156,8 +60155,8 @@ second version of targets paddle 2</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86554512</GetCodeOffs>
-        <SetCodeOffs>86554528</SetCodeOffs>
+        <GetCodeOffs>86748656</GetCodeOffs>
+        <SetCodeOffs>86748672</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -60476,47 +60475,6 @@ second version of targets paddle 2</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -60564,6 +60522,21 @@ second version of targets paddle 2</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -60666,19 +60639,45 @@ second version of targets paddle 2</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -61334,31 +61333,31 @@ second version of targets paddle 2</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86553640</GetCodeOffs>
+        <GetCodeOffs>86747784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86553704</GetCodeOffs>
+        <GetCodeOffs>86747848</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86553712</GetCodeOffs>
+        <GetCodeOffs>86747856</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86553688</GetCodeOffs>
+        <GetCodeOffs>86747832</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86553728</GetCodeOffs>
+        <GetCodeOffs>86747872</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -61378,6 +61377,26 @@ second version of targets paddle 2</Comment>
         <Local>
           <Name>b32IsBusy</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -61429,26 +61448,6 @@ second version of targets paddle 2</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -61576,10 +61575,11 @@ second version of targets paddle 2</Comment>
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> generates a JSON string from a given symbol (via address/size)</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -61593,29 +61593,27 @@ second version of targets paddle 2</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -61698,47 +61696,6 @@ second version of targets paddle 2</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -61874,6 +61831,48 @@ second version of targets paddle 2</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> generates a JSON string from a given symbol (via address/size)</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -62577,46 +62576,12 @@ second version of targets paddle 2</Comment>
         </Parameter>
       </Method>
       <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -62746,6 +62711,40 @@ second version of targets paddle 2</Comment>
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -62956,7 +62955,7 @@ second version of targets paddle 2</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -63713,7 +63712,7 @@ second version of targets paddle 2</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -64135,7 +64134,7 @@ second version of targets paddle 2</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1h</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -64147,7 +64146,7 @@ second version of targets paddle 2</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -64159,7 +64158,7 @@ second version of targets paddle 2</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -78155,6 +78154,343 @@ second version of targets paddle 2</Comment>
         </Property>
       </Properties>
     </DataType>
+    <DataType>
+      <Name>FB_SequenceMover2D</Name>
+      <BitSize>3008</BitSize>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage1</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to move.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState1</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage2</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to move.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState2</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbPositionState1D1</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">FB_PositionStatePMPS1D</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbPositionState1D2</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">FB_PositionStatePMPS1D</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>anStateSequenceOrder1</Name>
+        <Type>UINT</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Index is state enum value. Value at index is sequence order for that state as a goal for the specified axis number.
+ e.g. if state number 2 needs axis 1 to move second, then in index 2 put a 2 for axis 1 and for index 2 on axis 2 put a 1.</Comment>
+        <BitSize>240</BitSize>
+        <BitOffs>720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>anStateSequenceOrder2</Name>
+        <Type>UINT</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>240</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1872</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tonStateSequenceTimeout</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>2624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tStateSequenceTimeoutTime</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2880</BitOffs>
+        <Default>
+          <DateTime>T</DateTime>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nGoal</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet1</Name>
+        <Type>UINT</Type>
+        <Comment> The current state index of the 1st axis state mover</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet2</Name>
+        <Type>UINT</Type>
+        <Comment> The current state index of the 2nd axis state mover</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2960</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{A4C97A60-C95C-4787-A832-16AA681FD195}" TcSmClass="TComPlcObjDef" TargetPlatform="TwinCAT RT (x64)">
@@ -78176,7 +78512,7 @@ second version of targets paddle 2</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -78187,7 +78523,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>639535296</BitOffs>
+            <BitOffs>639535552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -78199,7 +78535,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641165440</BitOffs>
+            <BitOffs>641165696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -78212,7 +78548,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173376</BitOffs>
+            <BitOffs>641173632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -78225,7 +78561,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173384</BitOffs>
+            <BitOffs>641173640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -78238,7 +78574,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173392</BitOffs>
+            <BitOffs>641173648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -78261,7 +78597,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173408</BitOffs>
+            <BitOffs>641173664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -78274,7 +78610,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173440</BitOffs>
+            <BitOffs>641173696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -78287,7 +78623,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173504</BitOffs>
+            <BitOffs>641173760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -78300,7 +78636,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641173520</BitOffs>
+            <BitOffs>641173776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -78312,7 +78648,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641191360</BitOffs>
+            <BitOffs>641191616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -78325,7 +78661,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199296</BitOffs>
+            <BitOffs>641199552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -78338,7 +78674,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199304</BitOffs>
+            <BitOffs>641199560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -78351,7 +78687,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199312</BitOffs>
+            <BitOffs>641199568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -78374,7 +78710,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199328</BitOffs>
+            <BitOffs>641199584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -78387,7 +78723,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199360</BitOffs>
+            <BitOffs>641199616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -78400,7 +78736,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199424</BitOffs>
+            <BitOffs>641199680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -78413,7 +78749,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641199440</BitOffs>
+            <BitOffs>641199696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -78425,7 +78761,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641217280</BitOffs>
+            <BitOffs>641217536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -78438,7 +78774,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225216</BitOffs>
+            <BitOffs>641225472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -78451,7 +78787,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225224</BitOffs>
+            <BitOffs>641225480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -78464,7 +78800,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225232</BitOffs>
+            <BitOffs>641225488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -78487,7 +78823,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225248</BitOffs>
+            <BitOffs>641225504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -78500,7 +78836,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225280</BitOffs>
+            <BitOffs>641225536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -78513,7 +78849,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225344</BitOffs>
+            <BitOffs>641225600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -78526,7 +78862,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641225360</BitOffs>
+            <BitOffs>641225616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbGetLasPercent.iRaw</Name>
@@ -78539,7 +78875,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641521088</BitOffs>
+            <BitOffs>641521344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78551,7 +78887,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641642048</BitOffs>
+            <BitOffs>641642304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -78563,7 +78899,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643272192</BitOffs>
+            <BitOffs>643272448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -78576,7 +78912,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280128</BitOffs>
+            <BitOffs>643280384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -78589,7 +78925,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280136</BitOffs>
+            <BitOffs>643280392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -78602,7 +78938,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280144</BitOffs>
+            <BitOffs>643280400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -78625,7 +78961,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280160</BitOffs>
+            <BitOffs>643280416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -78638,7 +78974,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280192</BitOffs>
+            <BitOffs>643280448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -78651,7 +78987,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280256</BitOffs>
+            <BitOffs>643280512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -78664,7 +79000,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643280272</BitOffs>
+            <BitOffs>643280528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -78676,7 +79012,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643298112</BitOffs>
+            <BitOffs>643298368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -78689,7 +79025,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306048</BitOffs>
+            <BitOffs>643306304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -78702,7 +79038,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306056</BitOffs>
+            <BitOffs>643306312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -78715,7 +79051,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306064</BitOffs>
+            <BitOffs>643306320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -78738,7 +79074,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306080</BitOffs>
+            <BitOffs>643306336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -78751,7 +79087,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306112</BitOffs>
+            <BitOffs>643306368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -78764,7 +79100,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306176</BitOffs>
+            <BitOffs>643306432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -78777,7 +79113,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643306192</BitOffs>
+            <BitOffs>643306448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -78789,7 +79125,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643324032</BitOffs>
+            <BitOffs>643324288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -78802,7 +79138,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331968</BitOffs>
+            <BitOffs>643332224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -78815,7 +79151,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331976</BitOffs>
+            <BitOffs>643332232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -78828,7 +79164,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643331984</BitOffs>
+            <BitOffs>643332240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -78851,7 +79187,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332000</BitOffs>
+            <BitOffs>643332256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -78864,7 +79200,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332032</BitOffs>
+            <BitOffs>643332288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -78877,7 +79213,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332096</BitOffs>
+            <BitOffs>643332352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -78890,7 +79226,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643332112</BitOffs>
+            <BitOffs>643332368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.iVoltageINT</Name>
@@ -78902,7 +79238,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643627584</BitOffs>
+            <BitOffs>643627840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -78921,7 +79257,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820040</BitOffs>
+            <BitOffs>643820296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -78933,7 +79269,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820048</BitOffs>
+            <BitOffs>643820304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -78945,7 +79281,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820056</BitOffs>
+            <BitOffs>643820312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -78957,7 +79293,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820064</BitOffs>
+            <BitOffs>643820320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -78970,7 +79306,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>643820352</BitOffs>
+            <BitOffs>643820608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -78983,7 +79319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644207168</BitOffs>
+            <BitOffs>644207424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowMeter.iRaw</Name>
@@ -78996,7 +79332,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208320</BitOffs>
+            <BitOffs>644208576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bError</Name>
@@ -79015,7 +79351,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208968</BitOffs>
+            <BitOffs>644209224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bUnderrange</Name>
@@ -79027,7 +79363,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208976</BitOffs>
+            <BitOffs>644209232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.bOverrange</Name>
@@ -79039,7 +79375,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208984</BitOffs>
+            <BitOffs>644209240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYagThermoCouple.iRaw</Name>
@@ -79051,7 +79387,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644208992</BitOffs>
+            <BitOffs>644209248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbFlowSwitch.bFlowOk</Name>
@@ -79071,7 +79407,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644209088</BitOffs>
+            <BitOffs>644209344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79083,7 +79419,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>644326848</BitOffs>
+            <BitOffs>644327104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -79095,7 +79431,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645956992</BitOffs>
+            <BitOffs>645957248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -79108,7 +79444,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964928</BitOffs>
+            <BitOffs>645965184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -79121,7 +79457,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964936</BitOffs>
+            <BitOffs>645965192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -79134,7 +79470,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964944</BitOffs>
+            <BitOffs>645965200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -79157,7 +79493,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964960</BitOffs>
+            <BitOffs>645965216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -79170,7 +79506,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645964992</BitOffs>
+            <BitOffs>645965248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -79183,7 +79519,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645965056</BitOffs>
+            <BitOffs>645965312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -79196,7 +79532,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645965072</BitOffs>
+            <BitOffs>645965328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -79208,7 +79544,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645982912</BitOffs>
+            <BitOffs>645983168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -79221,7 +79557,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990848</BitOffs>
+            <BitOffs>645991104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -79234,7 +79570,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990856</BitOffs>
+            <BitOffs>645991112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -79247,7 +79583,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990864</BitOffs>
+            <BitOffs>645991120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -79270,7 +79606,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990880</BitOffs>
+            <BitOffs>645991136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -79283,7 +79619,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990912</BitOffs>
+            <BitOffs>645991168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -79296,7 +79632,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990976</BitOffs>
+            <BitOffs>645991232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -79309,7 +79645,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>645990992</BitOffs>
+            <BitOffs>645991248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -79321,7 +79657,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646008832</BitOffs>
+            <BitOffs>646009088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -79334,7 +79670,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016768</BitOffs>
+            <BitOffs>646017024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -79347,7 +79683,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016776</BitOffs>
+            <BitOffs>646017032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -79360,7 +79696,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016784</BitOffs>
+            <BitOffs>646017040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -79383,7 +79719,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016800</BitOffs>
+            <BitOffs>646017056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -79396,7 +79732,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016832</BitOffs>
+            <BitOffs>646017088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -79409,7 +79745,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016896</BitOffs>
+            <BitOffs>646017152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -79422,7 +79758,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646016912</BitOffs>
+            <BitOffs>646017168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.iVoltageINT</Name>
@@ -79434,7 +79770,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646312384</BitOffs>
+            <BitOffs>646312640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -79453,7 +79789,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504840</BitOffs>
+            <BitOffs>646505096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -79465,7 +79801,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504848</BitOffs>
+            <BitOffs>646505104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -79477,7 +79813,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504856</BitOffs>
+            <BitOffs>646505112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -79489,7 +79825,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646504864</BitOffs>
+            <BitOffs>646505120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -79502,7 +79838,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646505152</BitOffs>
+            <BitOffs>646505408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -79515,7 +79851,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646891968</BitOffs>
+            <BitOffs>646892224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowMeter.iRaw</Name>
@@ -79528,7 +79864,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893120</BitOffs>
+            <BitOffs>646893376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bError</Name>
@@ -79547,7 +79883,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893768</BitOffs>
+            <BitOffs>646894024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bUnderrange</Name>
@@ -79559,7 +79895,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893776</BitOffs>
+            <BitOffs>646894032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.bOverrange</Name>
@@ -79571,7 +79907,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893784</BitOffs>
+            <BitOffs>646894040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYagThermoCouple.iRaw</Name>
@@ -79583,7 +79919,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893792</BitOffs>
+            <BitOffs>646894048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbFlowSwitch.bFlowOk</Name>
@@ -79603,7 +79939,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>646893888</BitOffs>
+            <BitOffs>646894144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79615,7 +79951,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>647011648</BitOffs>
+            <BitOffs>647011904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -79627,7 +79963,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648641792</BitOffs>
+            <BitOffs>648642048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -79640,7 +79976,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649728</BitOffs>
+            <BitOffs>648649984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -79653,7 +79989,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649736</BitOffs>
+            <BitOffs>648649992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -79666,7 +80002,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649744</BitOffs>
+            <BitOffs>648650000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -79689,7 +80025,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649760</BitOffs>
+            <BitOffs>648650016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -79702,7 +80038,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649792</BitOffs>
+            <BitOffs>648650048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -79715,7 +80051,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649856</BitOffs>
+            <BitOffs>648650112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -79728,7 +80064,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648649872</BitOffs>
+            <BitOffs>648650128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -79740,7 +80076,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648667712</BitOffs>
+            <BitOffs>648667968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -79753,7 +80089,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675648</BitOffs>
+            <BitOffs>648675904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -79766,7 +80102,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675656</BitOffs>
+            <BitOffs>648675912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -79779,7 +80115,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675664</BitOffs>
+            <BitOffs>648675920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -79802,7 +80138,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675680</BitOffs>
+            <BitOffs>648675936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -79815,7 +80151,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675712</BitOffs>
+            <BitOffs>648675968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -79828,7 +80164,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675776</BitOffs>
+            <BitOffs>648676032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -79841,7 +80177,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648675792</BitOffs>
+            <BitOffs>648676048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -79853,7 +80189,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648693632</BitOffs>
+            <BitOffs>648693888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -79866,7 +80202,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701568</BitOffs>
+            <BitOffs>648701824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -79879,7 +80215,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701576</BitOffs>
+            <BitOffs>648701832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -79892,7 +80228,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701584</BitOffs>
+            <BitOffs>648701840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -79915,7 +80251,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701600</BitOffs>
+            <BitOffs>648701856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -79928,7 +80264,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701632</BitOffs>
+            <BitOffs>648701888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -79941,7 +80277,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701696</BitOffs>
+            <BitOffs>648701952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -79954,7 +80290,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648701712</BitOffs>
+            <BitOffs>648701968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.iVoltageINT</Name>
@@ -79966,7 +80302,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>648997184</BitOffs>
+            <BitOffs>648997440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -79985,7 +80321,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189640</BitOffs>
+            <BitOffs>649189896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -79997,7 +80333,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189648</BitOffs>
+            <BitOffs>649189904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -80009,7 +80345,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189656</BitOffs>
+            <BitOffs>649189912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -80021,7 +80357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189664</BitOffs>
+            <BitOffs>649189920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -80034,7 +80370,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649189952</BitOffs>
+            <BitOffs>649190208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -80047,7 +80383,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649576768</BitOffs>
+            <BitOffs>649577024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowMeter.iRaw</Name>
@@ -80060,7 +80396,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649577920</BitOffs>
+            <BitOffs>649578176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bError</Name>
@@ -80079,7 +80415,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578568</BitOffs>
+            <BitOffs>649578824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bUnderrange</Name>
@@ -80091,7 +80427,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578576</BitOffs>
+            <BitOffs>649578832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.bOverrange</Name>
@@ -80103,7 +80439,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578584</BitOffs>
+            <BitOffs>649578840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYagThermoCouple.iRaw</Name>
@@ -80115,7 +80451,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578592</BitOffs>
+            <BitOffs>649578848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbFlowSwitch.bFlowOk</Name>
@@ -80135,7 +80471,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649578688</BitOffs>
+            <BitOffs>649578944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80147,7 +80483,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>649696448</BitOffs>
+            <BitOffs>649696704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -80159,7 +80495,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651326592</BitOffs>
+            <BitOffs>651326848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -80172,7 +80508,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334528</BitOffs>
+            <BitOffs>651334784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -80185,7 +80521,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334536</BitOffs>
+            <BitOffs>651334792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -80198,7 +80534,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334544</BitOffs>
+            <BitOffs>651334800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -80221,7 +80557,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334560</BitOffs>
+            <BitOffs>651334816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -80234,7 +80570,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334592</BitOffs>
+            <BitOffs>651334848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -80247,7 +80583,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334656</BitOffs>
+            <BitOffs>651334912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -80260,7 +80596,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651334672</BitOffs>
+            <BitOffs>651334928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -80272,7 +80608,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651352512</BitOffs>
+            <BitOffs>651352768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -80285,7 +80621,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360448</BitOffs>
+            <BitOffs>651360704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -80298,7 +80634,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360456</BitOffs>
+            <BitOffs>651360712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -80311,7 +80647,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360464</BitOffs>
+            <BitOffs>651360720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -80334,7 +80670,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360480</BitOffs>
+            <BitOffs>651360736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -80347,7 +80683,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360512</BitOffs>
+            <BitOffs>651360768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -80360,7 +80696,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360576</BitOffs>
+            <BitOffs>651360832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -80373,7 +80709,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651360592</BitOffs>
+            <BitOffs>651360848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -80385,7 +80721,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651378432</BitOffs>
+            <BitOffs>651378688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -80398,7 +80734,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386368</BitOffs>
+            <BitOffs>651386624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -80411,7 +80747,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386376</BitOffs>
+            <BitOffs>651386632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -80424,7 +80760,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386384</BitOffs>
+            <BitOffs>651386640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -80447,7 +80783,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386400</BitOffs>
+            <BitOffs>651386656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -80460,7 +80796,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386432</BitOffs>
+            <BitOffs>651386688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -80473,7 +80809,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386496</BitOffs>
+            <BitOffs>651386752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -80486,7 +80822,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651386512</BitOffs>
+            <BitOffs>651386768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.iVoltageINT</Name>
@@ -80498,7 +80834,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651681984</BitOffs>
+            <BitOffs>651682240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -80517,7 +80853,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874440</BitOffs>
+            <BitOffs>651874696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -80529,7 +80865,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874448</BitOffs>
+            <BitOffs>651874704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -80541,7 +80877,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874456</BitOffs>
+            <BitOffs>651874712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -80553,7 +80889,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874464</BitOffs>
+            <BitOffs>651874720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -80566,7 +80902,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>651874752</BitOffs>
+            <BitOffs>651875008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -80579,7 +80915,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652261568</BitOffs>
+            <BitOffs>652261824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowMeter.iRaw</Name>
@@ -80592,7 +80928,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652262720</BitOffs>
+            <BitOffs>652262976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bError</Name>
@@ -80611,7 +80947,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263368</BitOffs>
+            <BitOffs>652263624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bUnderrange</Name>
@@ -80623,7 +80959,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263376</BitOffs>
+            <BitOffs>652263632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.bOverrange</Name>
@@ -80635,7 +80971,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263384</BitOffs>
+            <BitOffs>652263640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYagThermoCouple.iRaw</Name>
@@ -80647,7 +80983,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263392</BitOffs>
+            <BitOffs>652263648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbFlowSwitch.bFlowOk</Name>
@@ -80667,7 +81003,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652263488</BitOffs>
+            <BitOffs>652263744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80679,7 +81015,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>652381248</BitOffs>
+            <BitOffs>652381504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -80691,7 +81027,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654011392</BitOffs>
+            <BitOffs>654011648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -80704,7 +81040,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019328</BitOffs>
+            <BitOffs>654019584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -80717,7 +81053,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019336</BitOffs>
+            <BitOffs>654019592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -80730,7 +81066,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019344</BitOffs>
+            <BitOffs>654019600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -80753,7 +81089,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019360</BitOffs>
+            <BitOffs>654019616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -80766,7 +81102,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019392</BitOffs>
+            <BitOffs>654019648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -80779,7 +81115,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019456</BitOffs>
+            <BitOffs>654019712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -80792,7 +81128,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654019472</BitOffs>
+            <BitOffs>654019728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -80804,7 +81140,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654037312</BitOffs>
+            <BitOffs>654037568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -80817,7 +81153,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045248</BitOffs>
+            <BitOffs>654045504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -80830,7 +81166,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045256</BitOffs>
+            <BitOffs>654045512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -80843,7 +81179,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045264</BitOffs>
+            <BitOffs>654045520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -80866,7 +81202,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045280</BitOffs>
+            <BitOffs>654045536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -80879,7 +81215,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045312</BitOffs>
+            <BitOffs>654045568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -80892,7 +81228,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045376</BitOffs>
+            <BitOffs>654045632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -80905,7 +81241,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654045392</BitOffs>
+            <BitOffs>654045648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -80917,7 +81253,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654063232</BitOffs>
+            <BitOffs>654063488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -80930,7 +81266,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071168</BitOffs>
+            <BitOffs>654071424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -80943,7 +81279,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071176</BitOffs>
+            <BitOffs>654071432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -80956,7 +81292,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071184</BitOffs>
+            <BitOffs>654071440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -80979,7 +81315,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071200</BitOffs>
+            <BitOffs>654071456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -80992,7 +81328,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071232</BitOffs>
+            <BitOffs>654071488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81005,7 +81341,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071296</BitOffs>
+            <BitOffs>654071552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81018,7 +81354,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654071312</BitOffs>
+            <BitOffs>654071568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.iVoltageINT</Name>
@@ -81030,7 +81366,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654366784</BitOffs>
+            <BitOffs>654367040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bError</Name>
@@ -81049,7 +81385,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559240</BitOffs>
+            <BitOffs>654559496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bUnderrange</Name>
@@ -81061,7 +81397,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559248</BitOffs>
+            <BitOffs>654559504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.bOverrange</Name>
@@ -81073,7 +81409,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559256</BitOffs>
+            <BitOffs>654559512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbThermoCouple.iRaw</Name>
@@ -81085,7 +81421,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559264</BitOffs>
+            <BitOffs>654559520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbPowerMeter.fbGetPMVoltage.iRaw</Name>
@@ -81098,7 +81434,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654559552</BitOffs>
+            <BitOffs>654559808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbGetIllPercent.iRaw</Name>
@@ -81111,7 +81447,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654946368</BitOffs>
+            <BitOffs>654946624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowMeter.iRaw</Name>
@@ -81124,7 +81460,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654947520</BitOffs>
+            <BitOffs>654947776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bError</Name>
@@ -81143,7 +81479,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948168</BitOffs>
+            <BitOffs>654948424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bUnderrange</Name>
@@ -81155,7 +81491,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948176</BitOffs>
+            <BitOffs>654948432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.bOverrange</Name>
@@ -81167,7 +81503,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948184</BitOffs>
+            <BitOffs>654948440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYagThermoCouple.iRaw</Name>
@@ -81179,7 +81515,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948192</BitOffs>
+            <BitOffs>654948448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbFlowSwitch.bFlowOk</Name>
@@ -81199,7 +81535,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>654948288</BitOffs>
+            <BitOffs>654948544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81211,7 +81547,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>655066368</BitOffs>
+            <BitOffs>655066624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -81223,7 +81559,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656696512</BitOffs>
+            <BitOffs>656696768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -81236,7 +81572,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704448</BitOffs>
+            <BitOffs>656704704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -81249,7 +81585,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704456</BitOffs>
+            <BitOffs>656704712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -81262,7 +81598,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704464</BitOffs>
+            <BitOffs>656704720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -81285,7 +81621,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704480</BitOffs>
+            <BitOffs>656704736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -81298,7 +81634,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704512</BitOffs>
+            <BitOffs>656704768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -81311,7 +81647,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704576</BitOffs>
+            <BitOffs>656704832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -81324,7 +81660,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656704592</BitOffs>
+            <BitOffs>656704848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -81336,7 +81672,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656722432</BitOffs>
+            <BitOffs>656722688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -81349,7 +81685,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730368</BitOffs>
+            <BitOffs>656730624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -81362,7 +81698,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730376</BitOffs>
+            <BitOffs>656730632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -81375,7 +81711,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730384</BitOffs>
+            <BitOffs>656730640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -81398,7 +81734,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730400</BitOffs>
+            <BitOffs>656730656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -81411,7 +81747,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730432</BitOffs>
+            <BitOffs>656730688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -81424,7 +81760,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730496</BitOffs>
+            <BitOffs>656730752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -81437,7 +81773,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656730512</BitOffs>
+            <BitOffs>656730768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -81449,7 +81785,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656748352</BitOffs>
+            <BitOffs>656748608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -81462,7 +81798,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756288</BitOffs>
+            <BitOffs>656756544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -81475,7 +81811,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756296</BitOffs>
+            <BitOffs>656756552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -81488,7 +81824,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756304</BitOffs>
+            <BitOffs>656756560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -81511,7 +81847,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756320</BitOffs>
+            <BitOffs>656756576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -81524,7 +81860,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756352</BitOffs>
+            <BitOffs>656756608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81537,7 +81873,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756416</BitOffs>
+            <BitOffs>656756672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81550,7 +81886,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>656756432</BitOffs>
+            <BitOffs>656756688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81562,7 +81898,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657177664</BitOffs>
+            <BitOffs>657177920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81574,7 +81910,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>657504704</BitOffs>
+            <BitOffs>657504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -81586,7 +81922,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659134848</BitOffs>
+            <BitOffs>659135104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -81599,7 +81935,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142784</BitOffs>
+            <BitOffs>659143040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -81612,7 +81948,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142792</BitOffs>
+            <BitOffs>659143048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -81625,7 +81961,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142800</BitOffs>
+            <BitOffs>659143056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -81648,7 +81984,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142816</BitOffs>
+            <BitOffs>659143072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -81661,7 +81997,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142848</BitOffs>
+            <BitOffs>659143104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -81674,7 +82010,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142912</BitOffs>
+            <BitOffs>659143168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -81687,7 +82023,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659142928</BitOffs>
+            <BitOffs>659143184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -81699,7 +82035,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659160768</BitOffs>
+            <BitOffs>659161024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -81712,7 +82048,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168704</BitOffs>
+            <BitOffs>659168960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -81725,7 +82061,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168712</BitOffs>
+            <BitOffs>659168968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -81738,7 +82074,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168720</BitOffs>
+            <BitOffs>659168976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -81761,7 +82097,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168736</BitOffs>
+            <BitOffs>659168992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -81774,7 +82110,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168768</BitOffs>
+            <BitOffs>659169024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -81787,7 +82123,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168832</BitOffs>
+            <BitOffs>659169088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -81800,7 +82136,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659168848</BitOffs>
+            <BitOffs>659169104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -81812,7 +82148,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659186688</BitOffs>
+            <BitOffs>659186944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -81825,7 +82161,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194624</BitOffs>
+            <BitOffs>659194880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -81838,7 +82174,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194632</BitOffs>
+            <BitOffs>659194888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -81851,7 +82187,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194640</BitOffs>
+            <BitOffs>659194896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -81874,7 +82210,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194656</BitOffs>
+            <BitOffs>659194912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -81887,7 +82223,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194688</BitOffs>
+            <BitOffs>659194944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -81900,7 +82236,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194752</BitOffs>
+            <BitOffs>659195008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -81913,7 +82249,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659194768</BitOffs>
+            <BitOffs>659195024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bError</Name>
@@ -81937,7 +82273,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490376</BitOffs>
+            <BitOffs>659490632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bUnderrange</Name>
@@ -81949,7 +82285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490384</BitOffs>
+            <BitOffs>659490640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.bOverrange</Name>
@@ -81961,7 +82297,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490392</BitOffs>
+            <BitOffs>659490648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple1.iRaw</Name>
@@ -81973,7 +82309,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490400</BitOffs>
+            <BitOffs>659490656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bError</Name>
@@ -81997,7 +82333,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490632</BitOffs>
+            <BitOffs>659490888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bUnderrange</Name>
@@ -82009,7 +82345,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490640</BitOffs>
+            <BitOffs>659490896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.bOverrange</Name>
@@ -82021,7 +82357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490648</BitOffs>
+            <BitOffs>659490904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbThermoCouple2.iRaw</Name>
@@ -82033,7 +82369,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490656</BitOffs>
+            <BitOffs>659490912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowSwitch.bFlowOk</Name>
@@ -82053,7 +82389,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490752</BitOffs>
+            <BitOffs>659491008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbFlowMeter.iRaw</Name>
@@ -82066,7 +82402,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659490880</BitOffs>
+            <BitOffs>659491136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82078,7 +82414,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659616448</BitOffs>
+            <BitOffs>659616704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82090,7 +82426,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>659943488</BitOffs>
+            <BitOffs>659943744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -82102,7 +82438,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661573632</BitOffs>
+            <BitOffs>661573888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -82115,7 +82451,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581568</BitOffs>
+            <BitOffs>661581824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -82128,7 +82464,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581576</BitOffs>
+            <BitOffs>661581832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHome</Name>
@@ -82141,7 +82477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581584</BitOffs>
+            <BitOffs>661581840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -82164,7 +82500,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581600</BitOffs>
+            <BitOffs>661581856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -82177,7 +82513,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581632</BitOffs>
+            <BitOffs>661581888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -82190,7 +82526,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581696</BitOffs>
+            <BitOffs>661581952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -82203,7 +82539,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661581712</BitOffs>
+            <BitOffs>661581968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -82215,7 +82551,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661599552</BitOffs>
+            <BitOffs>661599808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -82228,7 +82564,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607488</BitOffs>
+            <BitOffs>661607744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -82241,7 +82577,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607496</BitOffs>
+            <BitOffs>661607752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHome</Name>
@@ -82254,7 +82590,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607504</BitOffs>
+            <BitOffs>661607760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -82277,7 +82613,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607520</BitOffs>
+            <BitOffs>661607776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -82290,7 +82626,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607552</BitOffs>
+            <BitOffs>661607808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -82303,7 +82639,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607616</BitOffs>
+            <BitOffs>661607872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -82316,7 +82652,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661607632</BitOffs>
+            <BitOffs>661607888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -82328,7 +82664,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661625472</BitOffs>
+            <BitOffs>661625728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -82341,7 +82677,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633408</BitOffs>
+            <BitOffs>661633664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -82354,7 +82690,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633416</BitOffs>
+            <BitOffs>661633672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHome</Name>
@@ -82367,7 +82703,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633424</BitOffs>
+            <BitOffs>661633680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -82390,7 +82726,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633440</BitOffs>
+            <BitOffs>661633696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -82403,7 +82739,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633472</BitOffs>
+            <BitOffs>661633728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -82416,7 +82752,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633536</BitOffs>
+            <BitOffs>661633792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -82429,7 +82765,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661633552</BitOffs>
+            <BitOffs>661633808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bError</Name>
@@ -82453,7 +82789,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929160</BitOffs>
+            <BitOffs>661929416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bUnderrange</Name>
@@ -82465,7 +82801,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929168</BitOffs>
+            <BitOffs>661929424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.bOverrange</Name>
@@ -82477,7 +82813,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929176</BitOffs>
+            <BitOffs>661929432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple1.iRaw</Name>
@@ -82489,7 +82825,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929184</BitOffs>
+            <BitOffs>661929440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bError</Name>
@@ -82513,7 +82849,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929416</BitOffs>
+            <BitOffs>661929672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bUnderrange</Name>
@@ -82525,7 +82861,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929424</BitOffs>
+            <BitOffs>661929680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.bOverrange</Name>
@@ -82537,7 +82873,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929432</BitOffs>
+            <BitOffs>661929688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbThermoCouple2.iRaw</Name>
@@ -82549,7 +82885,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929440</BitOffs>
+            <BitOffs>661929696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowSwitch.bFlowOk</Name>
@@ -82569,7 +82905,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929536</BitOffs>
+            <BitOffs>661929792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbFlowMeter.iRaw</Name>
@@ -82582,7 +82918,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>661929664</BitOffs>
+            <BitOffs>661929920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82594,7 +82930,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662031360</BitOffs>
+            <BitOffs>662031616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82606,7 +82942,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662358400</BitOffs>
+            <BitOffs>662358656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82618,7 +82954,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>662685440</BitOffs>
+            <BitOffs>662685696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82630,7 +82966,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663012480</BitOffs>
+            <BitOffs>663012736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayReq</Name>
@@ -82642,67 +82978,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663494784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663503488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663830528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664157568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664484608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
-            <BitSize>96</BitSize>
-            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664966912</BitOffs>
+            <BitOffs>663495040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bHallInput1</Name>
@@ -82718,39 +82994,67 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664967064</BitOffs>
+            <BitOffs>663499192</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bHallInput2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[LensX_EL1004]^Channel 2^Input</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664971040</BitOffs>
+            <BitOffs>663503808</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.bTL1High</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>664971048</BitOffs>
+            <BitOffs>663830848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664157888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664484928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayReq</Name>
+            <BitSize>96</BitSize>
+            <BaseType GUID="{67AC048F-B785-4A4D-B941-B11E2213F502}">ST_PMPS_Aperture_IO</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664967232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xInsertedLS</Name>
@@ -82763,7 +83067,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665085952</BitOffs>
+            <BitOffs>665086208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.i_xRetractedLS</Name>
@@ -82775,7 +83079,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665085960</BitOffs>
+            <BitOffs>665086216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82787,7 +83091,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665123968</BitOffs>
+            <BitOffs>665124224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82799,7 +83103,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>665451008</BitOffs>
+            <BitOffs>665451264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bError</Name>
@@ -82823,7 +83127,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492040</BitOffs>
+            <BitOffs>666492296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bUnderrange</Name>
@@ -82835,7 +83139,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492048</BitOffs>
+            <BitOffs>666492304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.bOverrange</Name>
@@ -82847,7 +83151,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492056</BitOffs>
+            <BitOffs>666492312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbThermoCouple1.iRaw</Name>
@@ -82859,7 +83163,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492064</BitOffs>
+            <BitOffs>666492320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbFlowMeter.iRaw</Name>
@@ -82872,7 +83176,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666492160</BitOffs>
+            <BitOffs>666492416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82884,7 +83188,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666520256</BitOffs>
+            <BitOffs>666520512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82896,7 +83200,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>666847296</BitOffs>
+            <BitOffs>666847552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bError</Name>
@@ -82920,7 +83224,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880904</BitOffs>
+            <BitOffs>667881160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bUnderrange</Name>
@@ -82932,7 +83236,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880912</BitOffs>
+            <BitOffs>667881168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.bOverrange</Name>
@@ -82944,7 +83248,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880920</BitOffs>
+            <BitOffs>667881176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbThermoCouple1.iRaw</Name>
@@ -82956,7 +83260,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667880928</BitOffs>
+            <BitOffs>667881184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbFlowMeter.iRaw</Name>
@@ -82969,7 +83273,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667881024</BitOffs>
+            <BitOffs>667881280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82981,7 +83285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>667884864</BitOffs>
+            <BitOffs>667885120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82993,7 +83297,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668211904</BitOffs>
+            <BitOffs>668212160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83005,7 +83309,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668538944</BitOffs>
+            <BitOffs>668539200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83017,7 +83321,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>668865984</BitOffs>
+            <BitOffs>668866240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83029,7 +83333,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669193024</BitOffs>
+            <BitOffs>669193280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83041,7 +83345,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669520064</BitOffs>
+            <BitOffs>669520320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83053,7 +83357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>669847104</BitOffs>
+            <BitOffs>669847360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83065,7 +83369,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670174144</BitOffs>
+            <BitOffs>670174400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83077,7 +83381,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670501184</BitOffs>
+            <BitOffs>670501440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83089,7 +83393,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>670828224</BitOffs>
+            <BitOffs>670828480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83101,7 +83405,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671155264</BitOffs>
+            <BitOffs>671155520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83113,7 +83417,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671482304</BitOffs>
+            <BitOffs>671482560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83125,7 +83429,39 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>671809344</BitOffs>
+            <BitOffs>671809600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bHallInput2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[LensX_EL1004]^Channel 2^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>672134016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.bTL1High</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[SP1K4-TL1-EL1124]^Channel 1^Input</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>672134024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL1Low</Name>
@@ -83141,7 +83477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672133760</BitOffs>
+            <BitOffs>672134048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2High</Name>
@@ -83157,7 +83493,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672133768</BitOffs>
+            <BitOffs>672134056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bTL2Low</Name>
@@ -83173,7 +83509,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>672133808</BitOffs>
+            <BitOffs>672134096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -83185,7 +83521,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673438784</BitOffs>
+            <BitOffs>673439104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83198,7 +83534,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446720</BitOffs>
+            <BitOffs>673447040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83211,7 +83547,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446728</BitOffs>
+            <BitOffs>673447048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHome</Name>
@@ -83224,7 +83560,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446736</BitOffs>
+            <BitOffs>673447056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83247,7 +83583,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446752</BitOffs>
+            <BitOffs>673447072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83260,7 +83596,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446784</BitOffs>
+            <BitOffs>673447104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83273,7 +83609,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446848</BitOffs>
+            <BitOffs>673447168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83286,7 +83622,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673446864</BitOffs>
+            <BitOffs>673447184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83298,7 +83634,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673464704</BitOffs>
+            <BitOffs>673465024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83311,7 +83647,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472640</BitOffs>
+            <BitOffs>673472960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83324,7 +83660,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472648</BitOffs>
+            <BitOffs>673472968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHome</Name>
@@ -83337,7 +83673,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472656</BitOffs>
+            <BitOffs>673472976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83360,7 +83696,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472672</BitOffs>
+            <BitOffs>673472992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83373,7 +83709,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472704</BitOffs>
+            <BitOffs>673473024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83386,7 +83722,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472768</BitOffs>
+            <BitOffs>673473088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83399,7 +83735,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673472784</BitOffs>
+            <BitOffs>673473104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83411,7 +83747,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673490624</BitOffs>
+            <BitOffs>673490944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83424,7 +83760,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498560</BitOffs>
+            <BitOffs>673498880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83437,7 +83773,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498568</BitOffs>
+            <BitOffs>673498888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHome</Name>
@@ -83450,7 +83786,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498576</BitOffs>
+            <BitOffs>673498896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83473,7 +83809,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498592</BitOffs>
+            <BitOffs>673498912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83486,7 +83822,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498624</BitOffs>
+            <BitOffs>673498944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83499,7 +83835,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498688</BitOffs>
+            <BitOffs>673499008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83512,7 +83848,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673498704</BitOffs>
+            <BitOffs>673499024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -83524,7 +83860,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675250112</BitOffs>
+            <BitOffs>675250368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83537,7 +83873,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258048</BitOffs>
+            <BitOffs>675258304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83550,7 +83886,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258056</BitOffs>
+            <BitOffs>675258312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHome</Name>
@@ -83563,7 +83899,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258064</BitOffs>
+            <BitOffs>675258320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83586,7 +83922,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258080</BitOffs>
+            <BitOffs>675258336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83599,7 +83935,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258112</BitOffs>
+            <BitOffs>675258368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83612,7 +83948,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258176</BitOffs>
+            <BitOffs>675258432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83625,7 +83961,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675258192</BitOffs>
+            <BitOffs>675258448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83637,7 +83973,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675276032</BitOffs>
+            <BitOffs>675276288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83650,7 +83986,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675283968</BitOffs>
+            <BitOffs>675284224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83663,7 +83999,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675283976</BitOffs>
+            <BitOffs>675284232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHome</Name>
@@ -83676,7 +84012,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675283984</BitOffs>
+            <BitOffs>675284240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83699,7 +84035,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284000</BitOffs>
+            <BitOffs>675284256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83712,7 +84048,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284032</BitOffs>
+            <BitOffs>675284288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83725,7 +84061,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284096</BitOffs>
+            <BitOffs>675284352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83738,7 +84074,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675284112</BitOffs>
+            <BitOffs>675284368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83750,7 +84086,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675301952</BitOffs>
+            <BitOffs>675302208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83763,7 +84099,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309888</BitOffs>
+            <BitOffs>675310144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83776,7 +84112,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309896</BitOffs>
+            <BitOffs>675310152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHome</Name>
@@ -83789,7 +84125,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309904</BitOffs>
+            <BitOffs>675310160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83812,7 +84148,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309920</BitOffs>
+            <BitOffs>675310176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83825,7 +84161,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675309952</BitOffs>
+            <BitOffs>675310208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83838,7 +84174,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675310016</BitOffs>
+            <BitOffs>675310272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83851,7 +84187,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675310032</BitOffs>
+            <BitOffs>675310288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bError</Name>
@@ -83875,7 +84211,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701128</BitOffs>
+            <BitOffs>675701448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bUnderrange</Name>
@@ -83887,7 +84223,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701136</BitOffs>
+            <BitOffs>675701456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.bOverrange</Name>
@@ -83899,7 +84235,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701144</BitOffs>
+            <BitOffs>675701464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01.iRaw</Name>
@@ -83911,7 +84247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701152</BitOffs>
+            <BitOffs>675701472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bError</Name>
@@ -83935,7 +84271,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701384</BitOffs>
+            <BitOffs>675701704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bUnderrange</Name>
@@ -83947,7 +84283,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701392</BitOffs>
+            <BitOffs>675701712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.bOverrange</Name>
@@ -83959,7 +84295,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701400</BitOffs>
+            <BitOffs>675701720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02.iRaw</Name>
@@ -83971,7 +84307,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675701408</BitOffs>
+            <BitOffs>675701728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83983,7 +84319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>675704576</BitOffs>
+            <BitOffs>675705280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83995,10 +84331,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>676031616</BitOffs>
+            <BitOffs>676032320</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
             <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
@@ -84007,10 +84343,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677660800</BitOffs>
+            <BitOffs>677661888</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bLimitForwardEnable</Name>
             <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84020,10 +84356,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668736</BitOffs>
+            <BitOffs>677669824</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
             <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84033,10 +84369,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668744</BitOffs>
+            <BitOffs>677669832</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHome</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bHome</Name>
             <Comment> NO Home Switch: TRUE if at home</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84046,10 +84382,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668752</BitOffs>
+            <BitOffs>677669840</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bHardwareEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bHardwareEnable</Name>
             <Comment> NC STO Input: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84069,10 +84405,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668768</BitOffs>
+            <BitOffs>677669856</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].nRawEncoderULINT</Name>
             <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
@@ -84082,10 +84418,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668800</BitOffs>
+            <BitOffs>677669888</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].nRawEncoderUINT</Name>
             <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
@@ -84095,10 +84431,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668864</BitOffs>
+            <BitOffs>677669952</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].nRawEncoderINT</Name>
             <Comment> Raw encoder IO for INT (LVDT)</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
@@ -84108,10 +84444,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677668880</BitOffs>
+            <BitOffs>677669968</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
             <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
@@ -84120,10 +84456,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677686720</BitOffs>
+            <BitOffs>677687808</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bLimitForwardEnable</Name>
             <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84133,10 +84469,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694656</BitOffs>
+            <BitOffs>677695744</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
             <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84146,10 +84482,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694664</BitOffs>
+            <BitOffs>677695752</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHome</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bHome</Name>
             <Comment> NO Home Switch: TRUE if at home</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84159,10 +84495,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694672</BitOffs>
+            <BitOffs>677695760</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bHardwareEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bHardwareEnable</Name>
             <Comment> NC STO Input: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84182,10 +84518,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694688</BitOffs>
+            <BitOffs>677695776</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].nRawEncoderULINT</Name>
             <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
@@ -84195,10 +84531,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694720</BitOffs>
+            <BitOffs>677695808</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].nRawEncoderUINT</Name>
             <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
@@ -84208,10 +84544,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694784</BitOffs>
+            <BitOffs>677695872</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].nRawEncoderINT</Name>
             <Comment> Raw encoder IO for INT (LVDT)</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
@@ -84221,10 +84557,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677694800</BitOffs>
+            <BitOffs>677695888</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
             <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
@@ -84233,10 +84569,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677712640</BitOffs>
+            <BitOffs>677713728</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bLimitForwardEnable</Name>
             <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84246,10 +84582,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720576</BitOffs>
+            <BitOffs>677721664</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
             <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84259,10 +84595,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720584</BitOffs>
+            <BitOffs>677721672</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHome</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bHome</Name>
             <Comment> NO Home Switch: TRUE if at home</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84272,10 +84608,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720592</BitOffs>
+            <BitOffs>677721680</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bHardwareEnable</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bHardwareEnable</Name>
             <Comment> NC STO Input: TRUE if ok to move</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -84295,10 +84631,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720608</BitOffs>
+            <BitOffs>677721696</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].nRawEncoderULINT</Name>
             <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
@@ -84308,10 +84644,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720640</BitOffs>
+            <BitOffs>677721728</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].nRawEncoderUINT</Name>
             <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
@@ -84321,10 +84657,10 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720704</BitOffs>
+            <BitOffs>677721792</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].nRawEncoderINT</Name>
             <Comment> Raw encoder IO for INT (LVDT)</Comment>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
@@ -84334,7 +84670,346 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>677720720</BitOffs>
+            <BitOffs>677721808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679210240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679236160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679262080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84346,7 +85021,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>678114816</BitOffs>
+            <BitOffs>679667136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -84358,7 +85033,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679743872</BitOffs>
+            <BitOffs>681296192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -84371,7 +85046,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751808</BitOffs>
+            <BitOffs>681304128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -84384,7 +85059,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751816</BitOffs>
+            <BitOffs>681304136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHome</Name>
@@ -84397,7 +85072,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751824</BitOffs>
+            <BitOffs>681304144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -84420,7 +85095,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751840</BitOffs>
+            <BitOffs>681304160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -84433,7 +85108,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751872</BitOffs>
+            <BitOffs>681304192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -84446,7 +85121,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751936</BitOffs>
+            <BitOffs>681304256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -84459,7 +85134,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679751952</BitOffs>
+            <BitOffs>681304272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -84471,7 +85146,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679769792</BitOffs>
+            <BitOffs>681322112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -84484,7 +85159,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777728</BitOffs>
+            <BitOffs>681330048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -84497,7 +85172,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777736</BitOffs>
+            <BitOffs>681330056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHome</Name>
@@ -84510,7 +85185,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777744</BitOffs>
+            <BitOffs>681330064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -84533,7 +85208,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777760</BitOffs>
+            <BitOffs>681330080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -84546,7 +85221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777792</BitOffs>
+            <BitOffs>681330112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -84559,7 +85234,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777856</BitOffs>
+            <BitOffs>681330176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -84572,7 +85247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679777872</BitOffs>
+            <BitOffs>681330192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -84584,7 +85259,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679795712</BitOffs>
+            <BitOffs>681348032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -84597,7 +85272,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803648</BitOffs>
+            <BitOffs>681355968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -84610,7 +85285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803656</BitOffs>
+            <BitOffs>681355976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHome</Name>
@@ -84623,7 +85298,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803664</BitOffs>
+            <BitOffs>681355984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -84646,7 +85321,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803680</BitOffs>
+            <BitOffs>681356000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -84659,7 +85334,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803712</BitOffs>
+            <BitOffs>681356032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -84672,7 +85347,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803776</BitOffs>
+            <BitOffs>681356096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -84685,7 +85360,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679803792</BitOffs>
+            <BitOffs>681356112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -84701,7 +85376,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680141184</BitOffs>
+            <BitOffs>681693504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -84722,7 +85397,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680144704</BitOffs>
+            <BitOffs>681697024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -84743,7 +85418,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>680144705</BitOffs>
+            <BitOffs>681697025</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -84755,7 +85430,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690810048</BitOffs>
+            <BitOffs>692362368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -84768,7 +85443,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690817984</BitOffs>
+            <BitOffs>692370304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -84781,7 +85456,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690817992</BitOffs>
+            <BitOffs>692370312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -84794,7 +85469,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818000</BitOffs>
+            <BitOffs>692370320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -84817,7 +85492,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818016</BitOffs>
+            <BitOffs>692370336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -84830,7 +85505,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818048</BitOffs>
+            <BitOffs>692370368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -84843,7 +85518,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818112</BitOffs>
+            <BitOffs>692370432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -84856,7 +85531,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690818128</BitOffs>
+            <BitOffs>692370448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -84868,7 +85543,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690835968</BitOffs>
+            <BitOffs>692388288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -84881,7 +85556,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843904</BitOffs>
+            <BitOffs>692396224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -84894,7 +85569,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843912</BitOffs>
+            <BitOffs>692396232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -84907,7 +85582,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843920</BitOffs>
+            <BitOffs>692396240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -84930,7 +85605,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843936</BitOffs>
+            <BitOffs>692396256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -84943,7 +85618,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690843968</BitOffs>
+            <BitOffs>692396288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -84956,7 +85631,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690844032</BitOffs>
+            <BitOffs>692396352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -84969,7 +85644,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690844048</BitOffs>
+            <BitOffs>692396368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -84981,7 +85656,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690861888</BitOffs>
+            <BitOffs>692414208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -84994,7 +85669,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869824</BitOffs>
+            <BitOffs>692422144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -85007,7 +85682,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869832</BitOffs>
+            <BitOffs>692422152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -85020,7 +85695,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869840</BitOffs>
+            <BitOffs>692422160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -85043,7 +85718,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869856</BitOffs>
+            <BitOffs>692422176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -85056,7 +85731,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869888</BitOffs>
+            <BitOffs>692422208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -85069,7 +85744,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869952</BitOffs>
+            <BitOffs>692422272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -85082,7 +85757,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690869968</BitOffs>
+            <BitOffs>692422288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -85094,7 +85769,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690887808</BitOffs>
+            <BitOffs>692440128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -85107,7 +85782,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895744</BitOffs>
+            <BitOffs>692448064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -85120,7 +85795,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895752</BitOffs>
+            <BitOffs>692448072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -85133,7 +85808,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895760</BitOffs>
+            <BitOffs>692448080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -85156,7 +85831,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895776</BitOffs>
+            <BitOffs>692448096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -85169,7 +85844,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895808</BitOffs>
+            <BitOffs>692448128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -85182,7 +85857,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895872</BitOffs>
+            <BitOffs>692448192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -85195,7 +85870,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690895888</BitOffs>
+            <BitOffs>692448208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -85207,7 +85882,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690913728</BitOffs>
+            <BitOffs>692466048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -85220,7 +85895,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921664</BitOffs>
+            <BitOffs>692473984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -85233,7 +85908,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921672</BitOffs>
+            <BitOffs>692473992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -85246,7 +85921,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921680</BitOffs>
+            <BitOffs>692474000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -85269,7 +85944,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921696</BitOffs>
+            <BitOffs>692474016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -85282,7 +85957,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921728</BitOffs>
+            <BitOffs>692474048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -85295,7 +85970,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921792</BitOffs>
+            <BitOffs>692474112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -85308,7 +85983,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690921808</BitOffs>
+            <BitOffs>692474128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -85320,7 +85995,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690939648</BitOffs>
+            <BitOffs>692491968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -85333,7 +86008,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947584</BitOffs>
+            <BitOffs>692499904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -85346,7 +86021,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947592</BitOffs>
+            <BitOffs>692499912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -85359,7 +86034,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947600</BitOffs>
+            <BitOffs>692499920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -85382,7 +86057,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947616</BitOffs>
+            <BitOffs>692499936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -85395,7 +86070,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947648</BitOffs>
+            <BitOffs>692499968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -85408,7 +86083,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947712</BitOffs>
+            <BitOffs>692500032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -85421,7 +86096,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690947728</BitOffs>
+            <BitOffs>692500048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -85433,7 +86108,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690965568</BitOffs>
+            <BitOffs>692517888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -85446,7 +86121,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973504</BitOffs>
+            <BitOffs>692525824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -85459,7 +86134,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973512</BitOffs>
+            <BitOffs>692525832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -85472,7 +86147,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973520</BitOffs>
+            <BitOffs>692525840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -85495,7 +86170,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973536</BitOffs>
+            <BitOffs>692525856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -85508,7 +86183,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973568</BitOffs>
+            <BitOffs>692525888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -85521,7 +86196,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973632</BitOffs>
+            <BitOffs>692525952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -85534,7 +86209,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690973648</BitOffs>
+            <BitOffs>692525968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -85546,7 +86221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690991488</BitOffs>
+            <BitOffs>692543808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -85559,7 +86234,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999424</BitOffs>
+            <BitOffs>692551744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -85572,7 +86247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999432</BitOffs>
+            <BitOffs>692551752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -85585,7 +86260,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999440</BitOffs>
+            <BitOffs>692551760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -85608,7 +86283,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999456</BitOffs>
+            <BitOffs>692551776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -85621,7 +86296,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999488</BitOffs>
+            <BitOffs>692551808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -85634,7 +86309,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999552</BitOffs>
+            <BitOffs>692551872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -85647,7 +86322,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>690999568</BitOffs>
+            <BitOffs>692551888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -85659,7 +86334,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691017408</BitOffs>
+            <BitOffs>692569728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -85672,7 +86347,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025344</BitOffs>
+            <BitOffs>692577664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -85685,7 +86360,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025352</BitOffs>
+            <BitOffs>692577672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -85698,7 +86373,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025360</BitOffs>
+            <BitOffs>692577680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -85721,7 +86396,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025376</BitOffs>
+            <BitOffs>692577696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -85734,7 +86409,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025408</BitOffs>
+            <BitOffs>692577728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -85747,7 +86422,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025472</BitOffs>
+            <BitOffs>692577792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -85760,7 +86435,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691025488</BitOffs>
+            <BitOffs>692577808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -85772,7 +86447,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691043328</BitOffs>
+            <BitOffs>692595648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -85785,7 +86460,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051264</BitOffs>
+            <BitOffs>692603584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -85798,7 +86473,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051272</BitOffs>
+            <BitOffs>692603592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -85811,7 +86486,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051280</BitOffs>
+            <BitOffs>692603600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -85834,7 +86509,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051296</BitOffs>
+            <BitOffs>692603616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -85847,7 +86522,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051328</BitOffs>
+            <BitOffs>692603648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -85860,7 +86535,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051392</BitOffs>
+            <BitOffs>692603712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -85873,7 +86548,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691051408</BitOffs>
+            <BitOffs>692603728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -85885,7 +86560,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691069248</BitOffs>
+            <BitOffs>692621568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -85898,7 +86573,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077184</BitOffs>
+            <BitOffs>692629504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -85911,7 +86586,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077192</BitOffs>
+            <BitOffs>692629512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -85924,7 +86599,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077200</BitOffs>
+            <BitOffs>692629520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -85947,7 +86622,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077216</BitOffs>
+            <BitOffs>692629536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -85960,7 +86635,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077248</BitOffs>
+            <BitOffs>692629568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -85973,7 +86648,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077312</BitOffs>
+            <BitOffs>692629632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -85986,7 +86661,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691077328</BitOffs>
+            <BitOffs>692629648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -85998,7 +86673,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691095168</BitOffs>
+            <BitOffs>692647488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -86011,7 +86686,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103104</BitOffs>
+            <BitOffs>692655424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -86024,7 +86699,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103112</BitOffs>
+            <BitOffs>692655432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -86037,7 +86712,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103120</BitOffs>
+            <BitOffs>692655440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -86060,7 +86735,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103136</BitOffs>
+            <BitOffs>692655456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -86073,7 +86748,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103168</BitOffs>
+            <BitOffs>692655488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -86086,7 +86761,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103232</BitOffs>
+            <BitOffs>692655552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -86099,7 +86774,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691103248</BitOffs>
+            <BitOffs>692655568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -86111,7 +86786,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691121088</BitOffs>
+            <BitOffs>692673408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -86124,7 +86799,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129024</BitOffs>
+            <BitOffs>692681344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -86137,7 +86812,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129032</BitOffs>
+            <BitOffs>692681352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -86150,7 +86825,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129040</BitOffs>
+            <BitOffs>692681360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -86173,7 +86848,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129056</BitOffs>
+            <BitOffs>692681376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -86186,7 +86861,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129088</BitOffs>
+            <BitOffs>692681408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -86199,7 +86874,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129152</BitOffs>
+            <BitOffs>692681472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -86212,7 +86887,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691129168</BitOffs>
+            <BitOffs>692681488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -86224,7 +86899,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691147008</BitOffs>
+            <BitOffs>692699328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -86237,7 +86912,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154944</BitOffs>
+            <BitOffs>692707264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -86250,7 +86925,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154952</BitOffs>
+            <BitOffs>692707272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -86263,7 +86938,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154960</BitOffs>
+            <BitOffs>692707280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -86286,7 +86961,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691154976</BitOffs>
+            <BitOffs>692707296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -86299,7 +86974,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691155008</BitOffs>
+            <BitOffs>692707328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -86312,7 +86987,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691155072</BitOffs>
+            <BitOffs>692707392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -86325,7 +87000,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691155088</BitOffs>
+            <BitOffs>692707408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -86337,7 +87012,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691172928</BitOffs>
+            <BitOffs>692725248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -86350,7 +87025,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180864</BitOffs>
+            <BitOffs>692733184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -86363,7 +87038,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180872</BitOffs>
+            <BitOffs>692733192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -86376,7 +87051,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180880</BitOffs>
+            <BitOffs>692733200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -86399,7 +87074,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180896</BitOffs>
+            <BitOffs>692733216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -86412,7 +87087,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180928</BitOffs>
+            <BitOffs>692733248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -86425,7 +87100,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691180992</BitOffs>
+            <BitOffs>692733312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -86438,7 +87113,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691181008</BitOffs>
+            <BitOffs>692733328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -86450,7 +87125,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691198848</BitOffs>
+            <BitOffs>692751168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -86463,7 +87138,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206784</BitOffs>
+            <BitOffs>692759104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -86476,7 +87151,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206792</BitOffs>
+            <BitOffs>692759112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -86489,7 +87164,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206800</BitOffs>
+            <BitOffs>692759120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -86512,7 +87187,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206816</BitOffs>
+            <BitOffs>692759136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -86525,7 +87200,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206848</BitOffs>
+            <BitOffs>692759168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -86538,7 +87213,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206912</BitOffs>
+            <BitOffs>692759232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -86551,7 +87226,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691206928</BitOffs>
+            <BitOffs>692759248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -86563,7 +87238,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691224768</BitOffs>
+            <BitOffs>692777088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -86576,7 +87251,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232704</BitOffs>
+            <BitOffs>692785024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -86589,7 +87264,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232712</BitOffs>
+            <BitOffs>692785032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -86602,7 +87277,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232720</BitOffs>
+            <BitOffs>692785040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -86625,7 +87300,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232736</BitOffs>
+            <BitOffs>692785056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -86638,7 +87313,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232768</BitOffs>
+            <BitOffs>692785088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -86651,7 +87326,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232832</BitOffs>
+            <BitOffs>692785152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -86664,7 +87339,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691232848</BitOffs>
+            <BitOffs>692785168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -86676,7 +87351,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691250688</BitOffs>
+            <BitOffs>692803008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -86689,7 +87364,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258624</BitOffs>
+            <BitOffs>692810944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -86702,7 +87377,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258632</BitOffs>
+            <BitOffs>692810952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -86715,7 +87390,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258640</BitOffs>
+            <BitOffs>692810960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -86738,7 +87413,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258656</BitOffs>
+            <BitOffs>692810976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -86751,7 +87426,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258688</BitOffs>
+            <BitOffs>692811008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -86764,7 +87439,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258752</BitOffs>
+            <BitOffs>692811072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -86777,7 +87452,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691258768</BitOffs>
+            <BitOffs>692811088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -86789,7 +87464,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691276608</BitOffs>
+            <BitOffs>692828928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -86802,7 +87477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284544</BitOffs>
+            <BitOffs>692836864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -86815,7 +87490,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284552</BitOffs>
+            <BitOffs>692836872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -86828,7 +87503,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284560</BitOffs>
+            <BitOffs>692836880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -86851,7 +87526,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284576</BitOffs>
+            <BitOffs>692836896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -86864,7 +87539,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284608</BitOffs>
+            <BitOffs>692836928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -86877,7 +87552,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284672</BitOffs>
+            <BitOffs>692836992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -86890,7 +87565,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691284688</BitOffs>
+            <BitOffs>692837008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -86902,7 +87577,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691302528</BitOffs>
+            <BitOffs>692854848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -86915,7 +87590,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310464</BitOffs>
+            <BitOffs>692862784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -86928,7 +87603,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310472</BitOffs>
+            <BitOffs>692862792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -86941,7 +87616,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310480</BitOffs>
+            <BitOffs>692862800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -86964,7 +87639,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310496</BitOffs>
+            <BitOffs>692862816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -86977,7 +87652,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310528</BitOffs>
+            <BitOffs>692862848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -86990,7 +87665,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310592</BitOffs>
+            <BitOffs>692862912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -87003,7 +87678,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691310608</BitOffs>
+            <BitOffs>692862928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -87015,7 +87690,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691328448</BitOffs>
+            <BitOffs>692880768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -87028,7 +87703,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336384</BitOffs>
+            <BitOffs>692888704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -87041,7 +87716,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336392</BitOffs>
+            <BitOffs>692888712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -87054,7 +87729,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336400</BitOffs>
+            <BitOffs>692888720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -87077,7 +87752,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336416</BitOffs>
+            <BitOffs>692888736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -87090,7 +87765,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336448</BitOffs>
+            <BitOffs>692888768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -87103,7 +87778,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336512</BitOffs>
+            <BitOffs>692888832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -87116,7 +87791,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691336528</BitOffs>
+            <BitOffs>692888848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -87128,7 +87803,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691354368</BitOffs>
+            <BitOffs>692906688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -87141,7 +87816,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362304</BitOffs>
+            <BitOffs>692914624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -87154,7 +87829,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362312</BitOffs>
+            <BitOffs>692914632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -87167,7 +87842,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362320</BitOffs>
+            <BitOffs>692914640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -87190,7 +87865,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362336</BitOffs>
+            <BitOffs>692914656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -87203,7 +87878,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362368</BitOffs>
+            <BitOffs>692914688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -87216,7 +87891,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362432</BitOffs>
+            <BitOffs>692914752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -87229,7 +87904,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691362448</BitOffs>
+            <BitOffs>692914768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -87241,7 +87916,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691380288</BitOffs>
+            <BitOffs>692932608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -87254,7 +87929,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388224</BitOffs>
+            <BitOffs>692940544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -87267,7 +87942,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388232</BitOffs>
+            <BitOffs>692940552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -87280,7 +87955,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388240</BitOffs>
+            <BitOffs>692940560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -87303,7 +87978,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388256</BitOffs>
+            <BitOffs>692940576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -87316,7 +87991,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388288</BitOffs>
+            <BitOffs>692940608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -87329,7 +88004,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388352</BitOffs>
+            <BitOffs>692940672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -87342,7 +88017,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691388368</BitOffs>
+            <BitOffs>692940688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -87354,7 +88029,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691406208</BitOffs>
+            <BitOffs>692958528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -87367,7 +88042,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414144</BitOffs>
+            <BitOffs>692966464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -87380,7 +88055,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414152</BitOffs>
+            <BitOffs>692966472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -87393,7 +88068,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414160</BitOffs>
+            <BitOffs>692966480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -87416,7 +88091,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414176</BitOffs>
+            <BitOffs>692966496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -87429,7 +88104,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414208</BitOffs>
+            <BitOffs>692966528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -87442,7 +88117,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414272</BitOffs>
+            <BitOffs>692966592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -87455,7 +88130,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691414288</BitOffs>
+            <BitOffs>692966608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -87467,7 +88142,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691432128</BitOffs>
+            <BitOffs>692984448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -87480,7 +88155,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440064</BitOffs>
+            <BitOffs>692992384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -87493,7 +88168,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440072</BitOffs>
+            <BitOffs>692992392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -87506,7 +88181,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440080</BitOffs>
+            <BitOffs>692992400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -87529,7 +88204,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440096</BitOffs>
+            <BitOffs>692992416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -87542,7 +88217,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440128</BitOffs>
+            <BitOffs>692992448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -87555,7 +88230,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440192</BitOffs>
+            <BitOffs>692992512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -87568,7 +88243,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691440208</BitOffs>
+            <BitOffs>692992528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -87580,7 +88255,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691458048</BitOffs>
+            <BitOffs>693010368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -87593,7 +88268,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691465984</BitOffs>
+            <BitOffs>693018304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -87606,7 +88281,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691465992</BitOffs>
+            <BitOffs>693018312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -87619,7 +88294,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466000</BitOffs>
+            <BitOffs>693018320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -87642,7 +88317,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466016</BitOffs>
+            <BitOffs>693018336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -87655,7 +88330,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466048</BitOffs>
+            <BitOffs>693018368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -87668,7 +88343,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466112</BitOffs>
+            <BitOffs>693018432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -87681,7 +88356,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691466128</BitOffs>
+            <BitOffs>693018448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -87693,7 +88368,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691483968</BitOffs>
+            <BitOffs>693036288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -87706,7 +88381,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491904</BitOffs>
+            <BitOffs>693044224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -87719,7 +88394,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491912</BitOffs>
+            <BitOffs>693044232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -87732,7 +88407,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491920</BitOffs>
+            <BitOffs>693044240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -87755,7 +88430,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491936</BitOffs>
+            <BitOffs>693044256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -87768,7 +88443,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691491968</BitOffs>
+            <BitOffs>693044288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -87781,7 +88456,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691492032</BitOffs>
+            <BitOffs>693044352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -87794,7 +88469,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691492048</BitOffs>
+            <BitOffs>693044368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -87806,7 +88481,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691509888</BitOffs>
+            <BitOffs>693062208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -87819,7 +88494,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517824</BitOffs>
+            <BitOffs>693070144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -87832,7 +88507,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517832</BitOffs>
+            <BitOffs>693070152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -87845,7 +88520,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517840</BitOffs>
+            <BitOffs>693070160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -87868,7 +88543,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517856</BitOffs>
+            <BitOffs>693070176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -87881,7 +88556,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517888</BitOffs>
+            <BitOffs>693070208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -87894,7 +88569,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517952</BitOffs>
+            <BitOffs>693070272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -87907,7 +88582,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691517968</BitOffs>
+            <BitOffs>693070288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -87919,7 +88594,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691535808</BitOffs>
+            <BitOffs>693088128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -87932,7 +88607,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543744</BitOffs>
+            <BitOffs>693096064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -87945,7 +88620,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543752</BitOffs>
+            <BitOffs>693096072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -87958,7 +88633,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543760</BitOffs>
+            <BitOffs>693096080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -87981,7 +88656,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543776</BitOffs>
+            <BitOffs>693096096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -87994,7 +88669,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543808</BitOffs>
+            <BitOffs>693096128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -88007,7 +88682,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543872</BitOffs>
+            <BitOffs>693096192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -88020,7 +88695,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691543888</BitOffs>
+            <BitOffs>693096208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -88032,7 +88707,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691561728</BitOffs>
+            <BitOffs>693114048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -88045,7 +88720,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569664</BitOffs>
+            <BitOffs>693121984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -88058,7 +88733,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569672</BitOffs>
+            <BitOffs>693121992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -88071,7 +88746,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569680</BitOffs>
+            <BitOffs>693122000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -88094,7 +88769,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569696</BitOffs>
+            <BitOffs>693122016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -88107,7 +88782,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569728</BitOffs>
+            <BitOffs>693122048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -88120,7 +88795,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569792</BitOffs>
+            <BitOffs>693122112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -88133,7 +88808,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691569808</BitOffs>
+            <BitOffs>693122128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -88145,7 +88820,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691587648</BitOffs>
+            <BitOffs>693139968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -88158,7 +88833,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595584</BitOffs>
+            <BitOffs>693147904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -88171,7 +88846,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595592</BitOffs>
+            <BitOffs>693147912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -88184,7 +88859,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595600</BitOffs>
+            <BitOffs>693147920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -88207,7 +88882,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595616</BitOffs>
+            <BitOffs>693147936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -88220,7 +88895,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595648</BitOffs>
+            <BitOffs>693147968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -88233,7 +88908,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595712</BitOffs>
+            <BitOffs>693148032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -88246,7 +88921,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691595728</BitOffs>
+            <BitOffs>693148048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -88258,7 +88933,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691613568</BitOffs>
+            <BitOffs>693165888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -88271,7 +88946,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621504</BitOffs>
+            <BitOffs>693173824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -88284,7 +88959,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621512</BitOffs>
+            <BitOffs>693173832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -88297,7 +88972,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621520</BitOffs>
+            <BitOffs>693173840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -88320,7 +88995,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621536</BitOffs>
+            <BitOffs>693173856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -88333,7 +89008,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621568</BitOffs>
+            <BitOffs>693173888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -88346,7 +89021,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621632</BitOffs>
+            <BitOffs>693173952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -88359,7 +89034,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691621648</BitOffs>
+            <BitOffs>693173968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -88371,7 +89046,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691639488</BitOffs>
+            <BitOffs>693191808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -88384,7 +89059,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647424</BitOffs>
+            <BitOffs>693199744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -88397,7 +89072,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647432</BitOffs>
+            <BitOffs>693199752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -88410,7 +89085,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647440</BitOffs>
+            <BitOffs>693199760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -88433,7 +89108,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647456</BitOffs>
+            <BitOffs>693199776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -88446,7 +89121,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647488</BitOffs>
+            <BitOffs>693199808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -88459,7 +89134,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647552</BitOffs>
+            <BitOffs>693199872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -88472,7 +89147,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691647568</BitOffs>
+            <BitOffs>693199888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -88484,7 +89159,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691665408</BitOffs>
+            <BitOffs>693217728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -88497,7 +89172,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673344</BitOffs>
+            <BitOffs>693225664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -88510,7 +89185,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673352</BitOffs>
+            <BitOffs>693225672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -88523,7 +89198,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673360</BitOffs>
+            <BitOffs>693225680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -88546,7 +89221,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673376</BitOffs>
+            <BitOffs>693225696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -88559,7 +89234,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673408</BitOffs>
+            <BitOffs>693225728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -88572,7 +89247,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673472</BitOffs>
+            <BitOffs>693225792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -88585,7 +89260,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691673488</BitOffs>
+            <BitOffs>693225808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -88597,7 +89272,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691691328</BitOffs>
+            <BitOffs>693243648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -88610,7 +89285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699264</BitOffs>
+            <BitOffs>693251584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -88623,7 +89298,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699272</BitOffs>
+            <BitOffs>693251592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -88636,7 +89311,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699280</BitOffs>
+            <BitOffs>693251600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -88659,7 +89334,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699296</BitOffs>
+            <BitOffs>693251616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -88672,7 +89347,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699328</BitOffs>
+            <BitOffs>693251648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -88685,7 +89360,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699392</BitOffs>
+            <BitOffs>693251712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -88698,7 +89373,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691699408</BitOffs>
+            <BitOffs>693251728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -88710,7 +89385,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691717248</BitOffs>
+            <BitOffs>693269568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -88723,7 +89398,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725184</BitOffs>
+            <BitOffs>693277504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -88736,7 +89411,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725192</BitOffs>
+            <BitOffs>693277512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -88749,7 +89424,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725200</BitOffs>
+            <BitOffs>693277520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -88772,7 +89447,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725216</BitOffs>
+            <BitOffs>693277536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -88785,7 +89460,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725248</BitOffs>
+            <BitOffs>693277568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -88798,7 +89473,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725312</BitOffs>
+            <BitOffs>693277632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -88811,7 +89486,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691725328</BitOffs>
+            <BitOffs>693277648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -88823,7 +89498,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691743168</BitOffs>
+            <BitOffs>693295488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -88836,7 +89511,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751104</BitOffs>
+            <BitOffs>693303424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -88849,7 +89524,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751112</BitOffs>
+            <BitOffs>693303432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -88862,7 +89537,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751120</BitOffs>
+            <BitOffs>693303440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -88885,7 +89560,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751136</BitOffs>
+            <BitOffs>693303456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -88898,7 +89573,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751168</BitOffs>
+            <BitOffs>693303488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -88911,7 +89586,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751232</BitOffs>
+            <BitOffs>693303552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -88924,7 +89599,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691751248</BitOffs>
+            <BitOffs>693303568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -88936,7 +89611,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691769088</BitOffs>
+            <BitOffs>693321408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -88949,7 +89624,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777024</BitOffs>
+            <BitOffs>693329344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -88962,7 +89637,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777032</BitOffs>
+            <BitOffs>693329352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -88975,7 +89650,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777040</BitOffs>
+            <BitOffs>693329360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -88998,7 +89673,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777056</BitOffs>
+            <BitOffs>693329376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -89011,7 +89686,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777088</BitOffs>
+            <BitOffs>693329408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -89024,7 +89699,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777152</BitOffs>
+            <BitOffs>693329472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -89037,7 +89712,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691777168</BitOffs>
+            <BitOffs>693329488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -89049,7 +89724,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691795008</BitOffs>
+            <BitOffs>693347328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -89062,7 +89737,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802944</BitOffs>
+            <BitOffs>693355264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -89075,7 +89750,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802952</BitOffs>
+            <BitOffs>693355272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -89088,7 +89763,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802960</BitOffs>
+            <BitOffs>693355280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -89111,7 +89786,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691802976</BitOffs>
+            <BitOffs>693355296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -89124,7 +89799,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691803008</BitOffs>
+            <BitOffs>693355328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -89137,7 +89812,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691803072</BitOffs>
+            <BitOffs>693355392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -89150,7 +89825,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691803088</BitOffs>
+            <BitOffs>693355408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -89162,7 +89837,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691820928</BitOffs>
+            <BitOffs>693373248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -89175,7 +89850,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828864</BitOffs>
+            <BitOffs>693381184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -89188,7 +89863,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828872</BitOffs>
+            <BitOffs>693381192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -89201,7 +89876,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828880</BitOffs>
+            <BitOffs>693381200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -89224,7 +89899,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828896</BitOffs>
+            <BitOffs>693381216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -89237,7 +89912,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828928</BitOffs>
+            <BitOffs>693381248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -89250,7 +89925,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691828992</BitOffs>
+            <BitOffs>693381312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -89263,7 +89938,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691829008</BitOffs>
+            <BitOffs>693381328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -89275,7 +89950,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691846848</BitOffs>
+            <BitOffs>693399168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -89288,7 +89963,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854784</BitOffs>
+            <BitOffs>693407104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -89301,7 +89976,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854792</BitOffs>
+            <BitOffs>693407112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -89314,7 +89989,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854800</BitOffs>
+            <BitOffs>693407120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -89337,7 +90012,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854816</BitOffs>
+            <BitOffs>693407136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -89350,7 +90025,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854848</BitOffs>
+            <BitOffs>693407168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -89363,7 +90038,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854912</BitOffs>
+            <BitOffs>693407232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -89376,7 +90051,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691854928</BitOffs>
+            <BitOffs>693407248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -89388,7 +90063,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691872768</BitOffs>
+            <BitOffs>693425088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -89401,7 +90076,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880704</BitOffs>
+            <BitOffs>693433024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -89414,7 +90089,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880712</BitOffs>
+            <BitOffs>693433032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -89427,7 +90102,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880720</BitOffs>
+            <BitOffs>693433040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -89450,7 +90125,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880736</BitOffs>
+            <BitOffs>693433056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -89463,7 +90138,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880768</BitOffs>
+            <BitOffs>693433088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -89476,7 +90151,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880832</BitOffs>
+            <BitOffs>693433152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -89489,7 +90164,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691880848</BitOffs>
+            <BitOffs>693433168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -89501,7 +90176,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691898688</BitOffs>
+            <BitOffs>693451008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -89514,7 +90189,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906624</BitOffs>
+            <BitOffs>693458944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -89527,7 +90202,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906632</BitOffs>
+            <BitOffs>693458952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -89540,7 +90215,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906640</BitOffs>
+            <BitOffs>693458960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -89563,7 +90238,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906656</BitOffs>
+            <BitOffs>693458976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -89576,7 +90251,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906688</BitOffs>
+            <BitOffs>693459008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -89589,7 +90264,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906752</BitOffs>
+            <BitOffs>693459072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -89602,7 +90277,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691906768</BitOffs>
+            <BitOffs>693459088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -89614,7 +90289,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691924608</BitOffs>
+            <BitOffs>693476928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -89627,7 +90302,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932544</BitOffs>
+            <BitOffs>693484864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -89640,7 +90315,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932552</BitOffs>
+            <BitOffs>693484872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -89653,7 +90328,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932560</BitOffs>
+            <BitOffs>693484880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -89676,7 +90351,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932576</BitOffs>
+            <BitOffs>693484896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -89689,7 +90364,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932608</BitOffs>
+            <BitOffs>693484928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -89702,7 +90377,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932672</BitOffs>
+            <BitOffs>693484992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -89715,7 +90390,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691932688</BitOffs>
+            <BitOffs>693485008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.NcToPlc</Name>
@@ -89727,7 +90402,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691950528</BitOffs>
+            <BitOffs>693502848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitForwardEnable</Name>
@@ -89740,7 +90415,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958464</BitOffs>
+            <BitOffs>693510784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitBackwardEnable</Name>
@@ -89753,7 +90428,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958472</BitOffs>
+            <BitOffs>693510792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHome</Name>
@@ -89766,7 +90441,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958480</BitOffs>
+            <BitOffs>693510800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHardwareEnable</Name>
@@ -89789,7 +90464,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958496</BitOffs>
+            <BitOffs>693510816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderULINT</Name>
@@ -89802,7 +90477,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958528</BitOffs>
+            <BitOffs>693510848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderUINT</Name>
@@ -89815,7 +90490,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958592</BitOffs>
+            <BitOffs>693510912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderINT</Name>
@@ -89828,7 +90503,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691958608</BitOffs>
+            <BitOffs>693510928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.NcToPlc</Name>
@@ -89840,7 +90515,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691976448</BitOffs>
+            <BitOffs>693528768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitForwardEnable</Name>
@@ -89853,7 +90528,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984384</BitOffs>
+            <BitOffs>693536704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitBackwardEnable</Name>
@@ -89866,7 +90541,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984392</BitOffs>
+            <BitOffs>693536712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHome</Name>
@@ -89879,7 +90554,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984400</BitOffs>
+            <BitOffs>693536720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHardwareEnable</Name>
@@ -89902,7 +90577,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984416</BitOffs>
+            <BitOffs>693536736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderULINT</Name>
@@ -89915,7 +90590,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984448</BitOffs>
+            <BitOffs>693536768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderUINT</Name>
@@ -89928,7 +90603,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984512</BitOffs>
+            <BitOffs>693536832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderINT</Name>
@@ -89941,7 +90616,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>691984528</BitOffs>
+            <BitOffs>693536848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.NcToPlc</Name>
@@ -89953,7 +90628,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692002368</BitOffs>
+            <BitOffs>693554688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitForwardEnable</Name>
@@ -89966,7 +90641,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010304</BitOffs>
+            <BitOffs>693562624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitBackwardEnable</Name>
@@ -89979,7 +90654,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010312</BitOffs>
+            <BitOffs>693562632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHome</Name>
@@ -89992,7 +90667,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010320</BitOffs>
+            <BitOffs>693562640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHardwareEnable</Name>
@@ -90015,7 +90690,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010336</BitOffs>
+            <BitOffs>693562656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderULINT</Name>
@@ -90028,7 +90703,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010368</BitOffs>
+            <BitOffs>693562688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderUINT</Name>
@@ -90041,7 +90716,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010432</BitOffs>
+            <BitOffs>693562752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderINT</Name>
@@ -90054,14 +90729,14 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692010448</BitOffs>
+            <BitOffs>693562768</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -90072,7 +90747,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>639534272</BitOffs>
+            <BitOffs>639534528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90084,7 +90759,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641164416</BitOffs>
+            <BitOffs>641164672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90097,7 +90772,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641173400</BitOffs>
+            <BitOffs>641173656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90109,7 +90784,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641190336</BitOffs>
+            <BitOffs>641190592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90122,7 +90797,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641199320</BitOffs>
+            <BitOffs>641199576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90134,7 +90809,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641216256</BitOffs>
+            <BitOffs>641216512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90147,7 +90822,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641225240</BitOffs>
+            <BitOffs>641225496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iShutdownINT</Name>
@@ -90159,7 +90834,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641520960</BitOffs>
+            <BitOffs>641521216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.iLaserINT</Name>
@@ -90171,7 +90846,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641520976</BitOffs>
+            <BitOffs>641521232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbLaser.fbSetLasPercent.iRaw</Name>
@@ -90184,7 +90859,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641521984</BitOffs>
+            <BitOffs>641522240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90196,7 +90871,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>641641024</BitOffs>
+            <BitOffs>641641280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90208,7 +90883,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643271168</BitOffs>
+            <BitOffs>643271424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90221,7 +90896,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643280152</BitOffs>
+            <BitOffs>643280408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90233,7 +90908,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643297088</BitOffs>
+            <BitOffs>643297344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90246,7 +90921,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643306072</BitOffs>
+            <BitOffs>643306328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90258,7 +90933,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643323008</BitOffs>
+            <BitOffs>643323264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90271,7 +90946,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>643331992</BitOffs>
+            <BitOffs>643332248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.iIlluminatorINT</Name>
@@ -90283,7 +90958,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644206976</BitOffs>
+            <BitOffs>644207232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.bGigePower</Name>
@@ -90303,7 +90978,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644206992</BitOffs>
+            <BitOffs>644207248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90316,7 +90991,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644208064</BitOffs>
+            <BitOffs>644208320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90328,7 +91003,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>644325824</BitOffs>
+            <BitOffs>644326080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90340,7 +91015,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645955968</BitOffs>
+            <BitOffs>645956224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90353,7 +91028,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645964952</BitOffs>
+            <BitOffs>645965208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90365,7 +91040,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645981888</BitOffs>
+            <BitOffs>645982144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90378,7 +91053,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>645990872</BitOffs>
+            <BitOffs>645991128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90390,7 +91065,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646007808</BitOffs>
+            <BitOffs>646008064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90403,7 +91078,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646016792</BitOffs>
+            <BitOffs>646017048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.iIlluminatorINT</Name>
@@ -90415,7 +91090,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646891776</BitOffs>
+            <BitOffs>646892032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.bGigePower</Name>
@@ -90435,7 +91110,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646891792</BitOffs>
+            <BitOffs>646892048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90448,7 +91123,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>646892864</BitOffs>
+            <BitOffs>646893120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90460,7 +91135,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>647010624</BitOffs>
+            <BitOffs>647010880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90472,7 +91147,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648640768</BitOffs>
+            <BitOffs>648641024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90485,7 +91160,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648649752</BitOffs>
+            <BitOffs>648650008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90497,7 +91172,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648666688</BitOffs>
+            <BitOffs>648666944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90510,7 +91185,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648675672</BitOffs>
+            <BitOffs>648675928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90522,7 +91197,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648692608</BitOffs>
+            <BitOffs>648692864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90535,7 +91210,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>648701592</BitOffs>
+            <BitOffs>648701848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.iIlluminatorINT</Name>
@@ -90547,7 +91222,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649576576</BitOffs>
+            <BitOffs>649576832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.bGigePower</Name>
@@ -90567,7 +91242,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649576592</BitOffs>
+            <BitOffs>649576848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90580,7 +91255,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649577664</BitOffs>
+            <BitOffs>649577920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90592,7 +91267,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>649695424</BitOffs>
+            <BitOffs>649695680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90604,7 +91279,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651325568</BitOffs>
+            <BitOffs>651325824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90617,7 +91292,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651334552</BitOffs>
+            <BitOffs>651334808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90629,7 +91304,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651351488</BitOffs>
+            <BitOffs>651351744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90642,7 +91317,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651360472</BitOffs>
+            <BitOffs>651360728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90654,7 +91329,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651377408</BitOffs>
+            <BitOffs>651377664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90667,7 +91342,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>651386392</BitOffs>
+            <BitOffs>651386648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.iIlluminatorINT</Name>
@@ -90679,7 +91354,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652261376</BitOffs>
+            <BitOffs>652261632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.bGigePower</Name>
@@ -90699,7 +91374,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652261392</BitOffs>
+            <BitOffs>652261648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90712,7 +91387,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652262464</BitOffs>
+            <BitOffs>652262720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90724,7 +91399,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>652380224</BitOffs>
+            <BitOffs>652380480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90736,7 +91411,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654010368</BitOffs>
+            <BitOffs>654010624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90749,7 +91424,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654019352</BitOffs>
+            <BitOffs>654019608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90761,7 +91436,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654036288</BitOffs>
+            <BitOffs>654036544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90774,7 +91449,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654045272</BitOffs>
+            <BitOffs>654045528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90786,7 +91461,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654062208</BitOffs>
+            <BitOffs>654062464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90799,7 +91474,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654071192</BitOffs>
+            <BitOffs>654071448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.iIlluminatorINT</Name>
@@ -90811,7 +91486,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654946176</BitOffs>
+            <BitOffs>654946432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.bGigePower</Name>
@@ -90831,7 +91506,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654946192</BitOffs>
+            <BitOffs>654946448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4.fbGige.fbSetIllPercent.iRaw</Name>
@@ -90844,7 +91519,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>654947264</BitOffs>
+            <BitOffs>654947520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90856,7 +91531,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>655065344</BitOffs>
+            <BitOffs>655065600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90868,7 +91543,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656695488</BitOffs>
+            <BitOffs>656695744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90881,7 +91556,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656704472</BitOffs>
+            <BitOffs>656704728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90893,7 +91568,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656721408</BitOffs>
+            <BitOffs>656721664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -90906,7 +91581,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656730392</BitOffs>
+            <BitOffs>656730648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -90918,7 +91593,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656747328</BitOffs>
+            <BitOffs>656747584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -90931,7 +91606,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>656756312</BitOffs>
+            <BitOffs>656756568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90943,7 +91618,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657176640</BitOffs>
+            <BitOffs>657176896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -90955,7 +91630,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>657503680</BitOffs>
+            <BitOffs>657503936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -90967,7 +91642,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659133824</BitOffs>
+            <BitOffs>659134080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -90980,7 +91655,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659142808</BitOffs>
+            <BitOffs>659143064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -90992,7 +91667,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659159744</BitOffs>
+            <BitOffs>659160000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91005,7 +91680,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659168728</BitOffs>
+            <BitOffs>659168984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91017,7 +91692,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659185664</BitOffs>
+            <BitOffs>659185920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91030,7 +91705,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659194648</BitOffs>
+            <BitOffs>659194904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91042,7 +91717,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659615424</BitOffs>
+            <BitOffs>659615680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbZStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91054,7 +91729,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>659942464</BitOffs>
+            <BitOffs>659942720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91066,7 +91741,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661572608</BitOffs>
+            <BitOffs>661572864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91079,7 +91754,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661581592</BitOffs>
+            <BitOffs>661581848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91091,7 +91766,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661598528</BitOffs>
+            <BitOffs>661598784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91104,7 +91779,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661607512</BitOffs>
+            <BitOffs>661607768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91116,7 +91791,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661624448</BitOffs>
+            <BitOffs>661624704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4.fbStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91129,7 +91804,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>661633432</BitOffs>
+            <BitOffs>661633688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91141,7 +91816,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662030336</BitOffs>
+            <BitOffs>662030592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91153,7 +91828,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662357376</BitOffs>
+            <BitOffs>662357632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91165,7 +91840,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>662684416</BitOffs>
+            <BitOffs>662684672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91177,7 +91852,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663011456</BitOffs>
+            <BitOffs>663011712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4.AptArrayStatus</Name>
@@ -91189,7 +91864,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663494688</BitOffs>
+            <BitOffs>663494944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbTopBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91201,7 +91876,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663502464</BitOffs>
+            <BitOffs>663502784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbBottomBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91213,7 +91888,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663829504</BitOffs>
+            <BitOffs>663829824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbNorthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91225,7 +91900,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664156544</BitOffs>
+            <BitOffs>664156864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.fbSouthBlade.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91237,7 +91912,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664483584</BitOffs>
+            <BitOffs>664483904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.fbSL2K4.AptArrayStatus</Name>
@@ -91249,7 +91924,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664966816</BitOffs>
+            <BitOffs>664967136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xInsert_DO</Name>
@@ -91261,7 +91936,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665085968</BitOffs>
+            <BitOffs>665086224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4.q_xRetract_DO</Name>
@@ -91273,7 +91948,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665085976</BitOffs>
+            <BitOffs>665086232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91285,7 +91960,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665122944</BitOffs>
+            <BitOffs>665123200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91297,7 +91972,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>665449984</BitOffs>
+            <BitOffs>665450240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91309,7 +91984,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666519232</BitOffs>
+            <BitOffs>666519488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4.fbXStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91321,7 +91996,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>666846272</BitOffs>
+            <BitOffs>666846528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91333,7 +92008,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>667883840</BitOffs>
+            <BitOffs>667884096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91345,7 +92020,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668210880</BitOffs>
+            <BitOffs>668211136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91357,7 +92032,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668537920</BitOffs>
+            <BitOffs>668538176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91369,7 +92044,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>668864960</BitOffs>
+            <BitOffs>668865216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91381,7 +92056,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669192000</BitOffs>
+            <BitOffs>669192256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91393,7 +92068,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669519040</BitOffs>
+            <BitOffs>669519296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91405,7 +92080,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>669846080</BitOffs>
+            <BitOffs>669846336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91417,7 +92092,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670173120</BitOffs>
+            <BitOffs>670173376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91429,7 +92104,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670500160</BitOffs>
+            <BitOffs>670500416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91441,7 +92116,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>670827200</BitOffs>
+            <BitOffs>670827456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91453,7 +92128,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671154240</BitOffs>
+            <BitOffs>671154496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91465,7 +92140,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671481280</BitOffs>
+            <BitOffs>671481536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91477,7 +92152,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>671808320</BitOffs>
+            <BitOffs>671808576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91489,7 +92164,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673437760</BitOffs>
+            <BitOffs>673438080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91502,7 +92177,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673446744</BitOffs>
+            <BitOffs>673447064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91514,7 +92189,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673463680</BitOffs>
+            <BitOffs>673464000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91527,7 +92202,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673472664</BitOffs>
+            <BitOffs>673472984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91539,7 +92214,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673489600</BitOffs>
+            <BitOffs>673489920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91552,7 +92227,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>673498584</BitOffs>
+            <BitOffs>673498904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91564,7 +92239,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675249088</BitOffs>
+            <BitOffs>675249344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91577,7 +92252,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675258072</BitOffs>
+            <BitOffs>675258328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91589,7 +92264,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675275008</BitOffs>
+            <BitOffs>675275264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91602,7 +92277,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675283992</BitOffs>
+            <BitOffs>675284248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91614,7 +92289,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675300928</BitOffs>
+            <BitOffs>675301184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91627,7 +92302,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675309912</BitOffs>
+            <BitOffs>675310168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91639,7 +92314,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>675703552</BitOffs>
+            <BitOffs>675704256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91651,10 +92326,10 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>676030592</BitOffs>
+            <BitOffs>676031296</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -91663,10 +92338,10 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677659776</BitOffs>
+            <BitOffs>677660864</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[1].bBrakeRelease</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[1].bBrakeRelease</Name>
             <Comment> NC Brake Output: TRUE to release brake</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -91676,10 +92351,10 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677668760</BitOffs>
+            <BitOffs>677669848</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -91688,10 +92363,10 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677685696</BitOffs>
+            <BitOffs>677686784</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[2].bBrakeRelease</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[2].bBrakeRelease</Name>
             <Comment> NC Brake Output: TRUE to release brake</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -91701,10 +92376,10 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677694680</BitOffs>
+            <BitOffs>677695768</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -91713,10 +92388,10 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677711616</BitOffs>
+            <BitOffs>677712704</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States.astMotionStageMax[3].bBrakeRelease</Name>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates.astMotionStageMax[3].bBrakeRelease</Name>
             <Comment> NC Brake Output: TRUE to release brake</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -91726,7 +92401,82 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>677720600</BitOffs>
+            <BitOffs>677721688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679209216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679218200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679235136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679244120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679261056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>679270040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -91738,7 +92488,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>678113792</BitOffs>
+            <BitOffs>679666112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -91750,7 +92500,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679742848</BitOffs>
+            <BitOffs>681295168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -91763,7 +92513,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679751832</BitOffs>
+            <BitOffs>681304152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -91775,7 +92525,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679768768</BitOffs>
+            <BitOffs>681321088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -91788,7 +92538,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679777752</BitOffs>
+            <BitOffs>681330072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -91800,7 +92550,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679794688</BitOffs>
+            <BitOffs>681347008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -91813,7 +92563,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679803672</BitOffs>
+            <BitOffs>681355992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -91829,7 +92579,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>680142944</BitOffs>
+            <BitOffs>681695264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -91848,7 +92598,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680313224</BitOffs>
+            <BitOffs>681865560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -91867,7 +92617,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680313232</BitOffs>
+            <BitOffs>681865568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -91887,7 +92637,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>687322856</BitOffs>
+            <BitOffs>688875176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -91907,7 +92657,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>689066024</BitOffs>
+            <BitOffs>690618344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -91919,7 +92669,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690809024</BitOffs>
+            <BitOffs>692361344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -91932,7 +92682,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690818008</BitOffs>
+            <BitOffs>692370328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -91944,7 +92694,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690834944</BitOffs>
+            <BitOffs>692387264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -91957,7 +92707,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690843928</BitOffs>
+            <BitOffs>692396248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -91969,7 +92719,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690860864</BitOffs>
+            <BitOffs>692413184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -91982,7 +92732,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690869848</BitOffs>
+            <BitOffs>692422168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -91994,7 +92744,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690886784</BitOffs>
+            <BitOffs>692439104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -92007,7 +92757,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690895768</BitOffs>
+            <BitOffs>692448088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -92019,7 +92769,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690912704</BitOffs>
+            <BitOffs>692465024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -92032,7 +92782,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690921688</BitOffs>
+            <BitOffs>692474008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -92044,7 +92794,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690938624</BitOffs>
+            <BitOffs>692490944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -92057,7 +92807,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690947608</BitOffs>
+            <BitOffs>692499928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -92069,7 +92819,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690964544</BitOffs>
+            <BitOffs>692516864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -92082,7 +92832,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690973528</BitOffs>
+            <BitOffs>692525848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -92094,7 +92844,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690990464</BitOffs>
+            <BitOffs>692542784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -92107,7 +92857,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690999448</BitOffs>
+            <BitOffs>692551768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -92119,7 +92869,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691016384</BitOffs>
+            <BitOffs>692568704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -92132,7 +92882,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691025368</BitOffs>
+            <BitOffs>692577688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -92144,7 +92894,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691042304</BitOffs>
+            <BitOffs>692594624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -92157,7 +92907,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691051288</BitOffs>
+            <BitOffs>692603608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -92169,7 +92919,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691068224</BitOffs>
+            <BitOffs>692620544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -92182,7 +92932,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691077208</BitOffs>
+            <BitOffs>692629528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -92194,7 +92944,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691094144</BitOffs>
+            <BitOffs>692646464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -92207,7 +92957,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691103128</BitOffs>
+            <BitOffs>692655448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -92219,7 +92969,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691120064</BitOffs>
+            <BitOffs>692672384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -92232,7 +92982,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691129048</BitOffs>
+            <BitOffs>692681368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -92244,7 +92994,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691145984</BitOffs>
+            <BitOffs>692698304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -92257,7 +93007,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691154968</BitOffs>
+            <BitOffs>692707288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -92269,7 +93019,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691171904</BitOffs>
+            <BitOffs>692724224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -92282,7 +93032,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691180888</BitOffs>
+            <BitOffs>692733208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -92294,7 +93044,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691197824</BitOffs>
+            <BitOffs>692750144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -92307,7 +93057,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691206808</BitOffs>
+            <BitOffs>692759128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -92319,7 +93069,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691223744</BitOffs>
+            <BitOffs>692776064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -92332,7 +93082,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691232728</BitOffs>
+            <BitOffs>692785048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -92344,7 +93094,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691249664</BitOffs>
+            <BitOffs>692801984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -92357,7 +93107,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691258648</BitOffs>
+            <BitOffs>692810968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -92369,7 +93119,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691275584</BitOffs>
+            <BitOffs>692827904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -92382,7 +93132,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691284568</BitOffs>
+            <BitOffs>692836888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -92394,7 +93144,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691301504</BitOffs>
+            <BitOffs>692853824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -92407,7 +93157,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691310488</BitOffs>
+            <BitOffs>692862808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -92419,7 +93169,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691327424</BitOffs>
+            <BitOffs>692879744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -92432,7 +93182,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691336408</BitOffs>
+            <BitOffs>692888728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -92444,7 +93194,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691353344</BitOffs>
+            <BitOffs>692905664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -92457,7 +93207,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691362328</BitOffs>
+            <BitOffs>692914648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -92469,7 +93219,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691379264</BitOffs>
+            <BitOffs>692931584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -92482,7 +93232,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691388248</BitOffs>
+            <BitOffs>692940568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -92494,7 +93244,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691405184</BitOffs>
+            <BitOffs>692957504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -92507,7 +93257,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691414168</BitOffs>
+            <BitOffs>692966488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -92519,7 +93269,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691431104</BitOffs>
+            <BitOffs>692983424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -92532,7 +93282,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691440088</BitOffs>
+            <BitOffs>692992408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -92544,7 +93294,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691457024</BitOffs>
+            <BitOffs>693009344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -92557,7 +93307,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691466008</BitOffs>
+            <BitOffs>693018328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -92569,7 +93319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691482944</BitOffs>
+            <BitOffs>693035264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -92582,7 +93332,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691491928</BitOffs>
+            <BitOffs>693044248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -92594,7 +93344,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691508864</BitOffs>
+            <BitOffs>693061184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -92607,7 +93357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691517848</BitOffs>
+            <BitOffs>693070168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -92619,7 +93369,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691534784</BitOffs>
+            <BitOffs>693087104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -92632,7 +93382,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691543768</BitOffs>
+            <BitOffs>693096088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -92644,7 +93394,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691560704</BitOffs>
+            <BitOffs>693113024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -92657,7 +93407,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691569688</BitOffs>
+            <BitOffs>693122008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -92669,7 +93419,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691586624</BitOffs>
+            <BitOffs>693138944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -92682,7 +93432,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691595608</BitOffs>
+            <BitOffs>693147928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -92694,7 +93444,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691612544</BitOffs>
+            <BitOffs>693164864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -92707,7 +93457,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691621528</BitOffs>
+            <BitOffs>693173848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -92719,7 +93469,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691638464</BitOffs>
+            <BitOffs>693190784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -92732,7 +93482,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691647448</BitOffs>
+            <BitOffs>693199768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -92744,7 +93494,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691664384</BitOffs>
+            <BitOffs>693216704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -92757,7 +93507,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691673368</BitOffs>
+            <BitOffs>693225688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -92769,7 +93519,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691690304</BitOffs>
+            <BitOffs>693242624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -92782,7 +93532,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691699288</BitOffs>
+            <BitOffs>693251608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -92794,7 +93544,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691716224</BitOffs>
+            <BitOffs>693268544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -92807,7 +93557,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691725208</BitOffs>
+            <BitOffs>693277528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -92819,7 +93569,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691742144</BitOffs>
+            <BitOffs>693294464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -92832,7 +93582,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691751128</BitOffs>
+            <BitOffs>693303448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -92844,7 +93594,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691768064</BitOffs>
+            <BitOffs>693320384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -92857,7 +93607,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691777048</BitOffs>
+            <BitOffs>693329368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -92869,7 +93619,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691793984</BitOffs>
+            <BitOffs>693346304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -92882,7 +93632,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691802968</BitOffs>
+            <BitOffs>693355288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -92894,7 +93644,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691819904</BitOffs>
+            <BitOffs>693372224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -92907,7 +93657,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691828888</BitOffs>
+            <BitOffs>693381208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -92919,7 +93669,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691845824</BitOffs>
+            <BitOffs>693398144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -92932,7 +93682,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691854808</BitOffs>
+            <BitOffs>693407128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -92944,7 +93694,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691871744</BitOffs>
+            <BitOffs>693424064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -92957,7 +93707,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691880728</BitOffs>
+            <BitOffs>693433048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -92969,7 +93719,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691897664</BitOffs>
+            <BitOffs>693449984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -92982,7 +93732,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691906648</BitOffs>
+            <BitOffs>693458968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -92994,7 +93744,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691923584</BitOffs>
+            <BitOffs>693475904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -93007,7 +93757,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691932568</BitOffs>
+            <BitOffs>693484888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.PlcToNc</Name>
@@ -93019,7 +93769,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691949504</BitOffs>
+            <BitOffs>693501824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bBrakeRelease</Name>
@@ -93032,7 +93782,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691958488</BitOffs>
+            <BitOffs>693510808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.PlcToNc</Name>
@@ -93044,7 +93794,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691975424</BitOffs>
+            <BitOffs>693527744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bBrakeRelease</Name>
@@ -93057,7 +93807,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>691984408</BitOffs>
+            <BitOffs>693536728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.PlcToNc</Name>
@@ -93069,7 +93819,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692001344</BitOffs>
+            <BitOffs>693553664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bBrakeRelease</Name>
@@ -93082,14 +93832,14 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692010328</BitOffs>
+            <BitOffs>693562648</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -93254,7 +94004,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#1ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93269,7 +94019,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#100ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93284,7 +94034,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10s</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93299,7 +94049,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10m</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -99230,6 +99980,46 @@ second version of targets paddle 2</Comment>
             <BitOffs>8583808</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Global_Version.stLibVersion_PMPS</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8584192</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
@@ -99263,35 +100053,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8584192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>1000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
             <BitOffs>8584480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8584496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -99302,7 +100064,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8584512</BitOffs>
+            <BitOffs>8584768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -99316,7 +100078,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8591616</BitOffs>
+            <BitOffs>8591872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -99330,7 +100092,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8591680</BitOffs>
+            <BitOffs>8591936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -99366,7 +100128,35 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8591744</BitOffs>
+            <BitOffs>8592000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8592288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8592304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -99380,7 +100170,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592032</BitOffs>
+            <BitOffs>8592320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
@@ -99407,7 +100197,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592048</BitOffs>
+            <BitOffs>8592336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -99422,7 +100212,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592056</BitOffs>
+            <BitOffs>8592344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
@@ -99437,7 +100227,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592064</BitOffs>
+            <BitOffs>8592352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
@@ -99452,7 +100242,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8592096</BitOffs>
+            <BitOffs>8592384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -99470,7 +100260,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594144</BitOffs>
+            <BitOffs>8594432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -99482,7 +100272,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594160</BitOffs>
+            <BitOffs>8594448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
@@ -99494,7 +100284,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594168</BitOffs>
+            <BitOffs>8594456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -99503,14 +100293,49 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#0MS</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594176</BitOffs>
+            <BitOffs>8594464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TcUnitRunner</Name>
+            <BitSize>621828480</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>8594496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
+            <Comment> Pointer to current test suite being called </Comment>
+            <BitSize>64</BitSize>
+            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>630422976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
+            <Comment> Current name of test being called </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>630423040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
@@ -99524,7 +100349,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594208</BitOffs>
+            <BitOffs>630425088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.bSP1K4AttOut</Name>
@@ -99532,7 +100357,7 @@ second version of targets paddle 2</Comment>
     bInit: BOOL;</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>8594216</BitOffs>
+            <BitOffs>630425096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -99548,42 +100373,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>8594224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.TcUnitRunner</Name>
-            <BitSize>621828480</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TcUnitRunner</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>8594240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
-            <Comment> Pointer to current test suite being called </Comment>
-            <BitSize>64</BitSize>
-            <BaseType PointerTo="1" Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>630422720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
-            <Comment> Current name of test being called </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>630422784</BitOffs>
+            <BitOffs>630425104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -99598,7 +100388,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>630424832</BitOffs>
+            <BitOffs>630425152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -99616,7 +100406,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>630488832</BitOffs>
+            <BitOffs>630489152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -99628,7 +100418,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>630504832</BitOffs>
+            <BitOffs>630505152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -99664,7 +100454,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638825984</BitOffs>
+            <BitOffs>638826304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_IPCDiag</Name>
@@ -99704,7 +100494,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638826272</BitOffs>
+            <BitOffs>638826592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_DynamicMemory</Name>
@@ -99744,17 +100534,6 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638827840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Physics.fbScatteringFactors</Name>
-            <BitSize>576000</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
             <BitOffs>638828160</BitOffs>
           </Symbol>
           <Symbol>
@@ -99766,70 +100545,30 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarStatic</Name>
               </Property>
             </Properties>
-            <BitOffs>639492800</BitOffs>
+            <BitOffs>638828448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.bSP1K4FzpOut</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>639492816</BitOffs>
+            <BitOffs>638828464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.bSP1K4Out</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>639492824</BitOffs>
+            <BitOffs>638828472</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <BitOffs>639492832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
+            <Name>GVL_Physics.fbScatteringFactors</Name>
+            <BitSize>576000</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components.lcls_twincat_physics">FB_ScatteringFactorLUT</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: SL1K4:SCATTER:GO;
-    io: io;
-    field: ZNAM False;
-    field: ONAM True;
-    </Value>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>639492840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.bTest</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <BitOffs>639492848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
-            <Comment>GET PMPS Move Ok bit
- Default True until it is properly linked to PMPS bit</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <BitOffs>639492856</BitOffs>
+            <BitOffs>638828480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4</Name>
@@ -99849,13 +100588,13 @@ second version of targets paddle 2</Comment>
                               .fbLaser.iShutdownINT := TIIB[AL1K4-EL4004-E4]^AO Outputs Channel 2^Analog output</Value>
               </Property>
             </Properties>
-            <BitOffs>639521024</BitOffs>
+            <BitOffs>639521280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>641522240</BitOffs>
+            <BitOffs>641522496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.stDefault</Name>
@@ -99875,7 +100614,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>641614272</BitOffs>
+            <BitOffs>641614528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbIM2K4</Name>
@@ -99905,14 +100644,14 @@ second version of targets paddle 2</Comment>
                               .fbFlowSwitch.bFlowOk := TIIB[IM2K4-EL1004-E8]^Channel 1^Input</Value>
               </Property>
             </Properties>
-            <BitOffs>641620288</BitOffs>
+            <BitOffs>641620544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.fbStateSetup</Name>
             <Comment>    fStartupVelo: LREAL := 13;</Comment>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>644209344</BitOffs>
+            <BitOffs>644209600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM2K4_PPM.stDefault</Name>
@@ -99932,7 +100671,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>644301376</BitOffs>
+            <BitOffs>644301632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbIM3K4</Name>
@@ -99963,13 +100702,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>644305088</BitOffs>
+            <BitOffs>644305344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>646894144</BitOffs>
+            <BitOffs>646894400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM3K4_PPM.stDefault</Name>
@@ -99989,7 +100728,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>646986176</BitOffs>
+            <BitOffs>646986432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbIM4K4</Name>
@@ -100019,13 +100758,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM4K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>646989888</BitOffs>
+            <BitOffs>646990144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>649578944</BitOffs>
+            <BitOffs>649579200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM4K4_PPM.stDefault</Name>
@@ -100045,7 +100784,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>649670976</BitOffs>
+            <BitOffs>649671232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbIM5K4</Name>
@@ -100075,13 +100814,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>649674688</BitOffs>
+            <BitOffs>649674944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>652263744</BitOffs>
+            <BitOffs>652264000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM5K4_PPM.stDefault</Name>
@@ -100101,7 +100840,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>652355776</BitOffs>
+            <BitOffs>652356032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbIM6K4</Name>
@@ -100131,13 +100870,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw                         := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>652359488</BitOffs>
+            <BitOffs>652359744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>654948544</BitOffs>
+            <BitOffs>654948800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_IM6K4_PPM.stDefault</Name>
@@ -100157,7 +100896,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>655040576</BitOffs>
+            <BitOffs>655040832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbLI1K4</Name>
@@ -100172,13 +100911,13 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>655044672</BitOffs>
+            <BitOffs>655044928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>657052032</BitOffs>
+            <BitOffs>657052288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI1K4_IP1.stDefault</Name>
@@ -100198,7 +100937,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>657144064</BitOffs>
+            <BitOffs>657144320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbPF1K4</Name>
@@ -100226,13 +100965,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw             := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>657148480</BitOffs>
+            <BitOffs>657148736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>659491520</BitOffs>
+            <BitOffs>659491776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF1K4_WFS_TARGET.stDefault</Name>
@@ -100248,7 +100987,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>659583552</BitOffs>
+            <BitOffs>659583808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbPF2K4</Name>
@@ -100276,13 +101015,13 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw             := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>659587264</BitOffs>
+            <BitOffs>659587520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>661930304</BitOffs>
+            <BitOffs>661930560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_PF2K4_WFS_TARGET.stDefault</Name>
@@ -100302,7 +101041,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>662022336</BitOffs>
+            <BitOffs>662022592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.fbSL1K4</Name>
@@ -100317,7 +101056,68 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662027392</BitOffs>
+            <BitOffs>662027648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <BitOffs>663495168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bExecuteMotion</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: SL1K4:SCATTER:GO;
+    io: io;
+    field: ZNAM False;
+    field: ONAM True;
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663495176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.bTest</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <BitOffs>663495184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.bMoveOk</Name>
+            <Comment>GET PMPS Move Ok bit
+ Default True until it is properly linked to PMPS bit</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <BitOffs>663495192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>663495200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.mcPower</Name>
@@ -100328,17 +101128,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>663494912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>663498752</BitOffs>
+            <BitOffs>663495232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -100348,7 +101138,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663498784</BitOffs>
+            <BitOffs>663499072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -100358,7 +101148,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663498816</BitOffs>
+            <BitOffs>663499104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -100368,22 +101158,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>663498848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
-            <BitSize>1467520</BitSize>
-            <BaseType>FB_SLITS</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL2K4:SCATTER
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>663499520</BitOffs>
+            <BitOffs>663499136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bExecuteMotion</Name>
@@ -100403,7 +101178,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664967040</BitOffs>
+            <BitOffs>663499168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.bTest</Name>
@@ -100412,23 +101187,28 @@ second version of targets paddle 2</Comment>
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>664967048</BitOffs>
+            <BitOffs>663499176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ibPMPS_OK</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>664967056</BitOffs>
+            <BitOffs>663499184</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
-            <Comment> 0+(-15)</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>-15</Value>
-            </Default>
-            <BitOffs>664967072</BitOffs>
+            <Name>PRG_SL2K4_SCATTER.fbSL2K4</Name>
+            <BitSize>1467520</BitSize>
+            <BaseType>FB_SLITS</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL2K4:SCATTER
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663499840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.mcPower</Name>
@@ -100439,7 +101219,17 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>4</Elements>
             </ArrayInfo>
-            <BitOffs>664967104</BitOffs>
+            <BitOffs>664967360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL2K4_SCATTER.rEncoderOffsetTop</Name>
+            <Comment> 0+(-15)</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>-15</Value>
+            </Default>
+            <BitOffs>664971200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetBottom</Name>
@@ -100449,7 +101239,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664970944</BitOffs>
+            <BitOffs>664971232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetNorth</Name>
@@ -100459,7 +101249,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664970976</BitOffs>
+            <BitOffs>664971264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL2K4_SCATTER.rEncoderOffsetSouth</Name>
@@ -100469,13 +101259,7 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>-15</Value>
             </Default>
-            <BitOffs>664971008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.nTL1HighCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>664971056</BitOffs>
+            <BitOffs>664971296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST4K4_TMO_TERM.ST4K4</Name>
@@ -100494,7 +101278,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>664971584</BitOffs>
+            <BitOffs>664971840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM1K4.fbTM1K4</Name>
@@ -100518,7 +101302,7 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw := TIIB[IM5K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>665089984</BitOffs>
+            <BitOffs>665090240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_TM2K4.fbTM2K4</Name>
@@ -100542,97 +101326,103 @@ second version of targets paddle 2</Comment>
                               .fbFlowMeter.iRaw := TIIB[IM6K4-EL3052-E5]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>666493696</BitOffs>
+            <BitOffs>666493952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionLensX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>667882240</BitOffs>
+            <BitOffs>667882496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668209280</BitOffs>
+            <BitOffs>668209536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668536320</BitOffs>
+            <BitOffs>668536576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>668863360</BitOffs>
+            <BitOffs>668863616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionZPZ</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669190400</BitOffs>
+            <BitOffs>669190656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669517440</BitOffs>
+            <BitOffs>669517696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>669844480</BitOffs>
+            <BitOffs>669844736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGZ</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670171520</BitOffs>
+            <BitOffs>670171776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionYAGR</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670498560</BitOffs>
+            <BitOffs>670498816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL1</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>670825600</BitOffs>
+            <BitOffs>670825856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTL2</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671152640</BitOffs>
+            <BitOffs>671152896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionTLX</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671479680</BitOffs>
+            <BitOffs>671479936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbMotionFoilY</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>671806720</BitOffs>
+            <BitOffs>671806976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.nTL1HighCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>672134032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL1LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672133776</BitOffs>
+            <BitOffs>672134064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2HighCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672133792</BitOffs>
+            <BitOffs>672134080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bInit</Name>
@@ -100641,13 +101431,13 @@ second version of targets paddle 2</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>672133816</BitOffs>
+            <BitOffs>672134104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nTL2LowCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>672133824</BitOffs>
+            <BitOffs>672134112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.nNumCyclesNeeded</Name>
@@ -100656,20 +101446,20 @@ second version of targets paddle 2</Comment>
             <Default>
               <Value>100</Value>
             </Default>
-            <BitOffs>672133840</BitOffs>
+            <BitOffs>672134128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bAttIn</Name>
             <Comment> Placeholder, later this should be TRUE if the attenuator is in and FALSE otherwise</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>672133856</BitOffs>
+            <BitOffs>672134144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.bPF1K4Out</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>672133864</BitOffs>
+            <BitOffs>672134152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumSet</Name>
@@ -100684,22 +101474,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>672133872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K4.fbZPStates</Name>
-            <Comment>/ZP states start</Comment>
-            <BitSize>1548608</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K4:FZP
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>672133888</BitOffs>
+            <BitOffs>672134160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.zp_enumGet</Name>
@@ -100714,7 +101489,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673682496</BitOffs>
+            <BitOffs>672134176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.att_enumSet</Name>
@@ -100729,43 +101504,28 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673682512</BitOffs>
+            <BitOffs>672134192</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K4.att_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Name>PRG_SP1K4.fbZPStates</Name>
+            <Comment>/ZP states start</Comment>
+            <BitSize>1548608</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS3D</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: SP1K4:ATT:STATE:GET
-        io: i
+        pv: SP1K4:FZP
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673682528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_LaserCoupling_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: LI2K4:IP1:STATE:SET
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>673682544</BitOffs>
+            <BitOffs>672134208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>673682560</BitOffs>
+            <BitOffs>673682816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbZPDefault</Name>
@@ -100785,7 +101545,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>673774592</BitOffs>
+            <BitOffs>673774848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPXStates</Name>
@@ -100795,7 +101555,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673778304</BitOffs>
+            <BitOffs>673778560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPYStates</Name>
@@ -100805,7 +101565,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673833984</BitOffs>
+            <BitOffs>673834240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aZPZStates</Name>
@@ -100815,7 +101575,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>673889664</BitOffs>
+            <BitOffs>673889920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTStates</Name>
@@ -100830,13 +101590,75 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673945344</BitOffs>
+            <BitOffs>673945600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K4.att_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_SolidAttenuator_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K4:ATT:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.bLI2K4StatesReset</Name>
+            <Comment>{attribute 'pytmc' := '
+     pv: LI2K4:IP1
+    io: io
+ '}
+ fbLI2K4States: FB_PositionStatePMPS2D;</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>675494096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>675494104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_LaserCoupling_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: LI2K4:IP1:STATE:SET
+        io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.li2k4_enumGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>ENUM_LaserCoupling_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: LI2K4:IP1:STATE:GET
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>675494128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>675493824</BitOffs>
+            <BitOffs>675494144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.fbATTDefault</Name>
@@ -100856,7 +101678,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>675585856</BitOffs>
+            <BitOffs>675586176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTXStates</Name>
@@ -100866,7 +101688,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>675589568</BitOffs>
+            <BitOffs>675589888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.aATTYStates</Name>
@@ -100876,7 +101698,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>675645248</BitOffs>
+            <BitOffs>675645568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_01</Name>
@@ -100900,7 +101722,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675700928</BitOffs>
+            <BitOffs>675701248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K4.SP1K4_ATT_RTD_02</Name>
@@ -100923,49 +101745,39 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>675701184</BitOffs>
+            <BitOffs>675701504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4X</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>675701952</BitOffs>
+            <BitOffs>675702656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbMotionLI2K4Y</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>676028992</BitOffs>
+            <BitOffs>676029696</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.fbLI2K4States</Name>
-            <BitSize>1548480</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: LI2K4:IP1
-        io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>676356032</BitOffs>
+            <Name>PRG_LI2K4_IP1.anStateSequenceOrderLI2K4Y</Name>
+            <BitSize>240</BitSize>
+            <BaseType>UINT</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>676356736</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_LI2K4_IP1.li2k4_enumGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>ENUM_LaserCoupling_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: LI2K4:IP1:STATE:GET
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>677904512</BitOffs>
+            <Name>PRG_LI2K4_IP1.anStateSequenceOrderLI2K4X</Name>
+            <BitSize>240</BitSize>
+            <BaseType>UINT</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>676356976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.at2k4_enumSet</Name>
@@ -100980,7 +101792,7 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>677904528</BitOffs>
+            <BitOffs>676357216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.at2k4_enumGet</Name>
@@ -100995,26 +101807,25 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>677904544</BitOffs>
+            <BitOffs>676357232</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bST3K4_Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>677904560</BitOffs>
+            <Name>PRG_LI2K4_IP1.fbLI2K4YStates</Name>
+            <BitSize>1548352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
+            <BitOffs>676357248</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
-            <Comment>	bST1K4_Veto: BOOL;</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>677904568</BitOffs>
+            <Name>PRG_LI2K4_IP1.fbLI2K4XStates</Name>
+            <BitSize>1548352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
+            <BitOffs>677905600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>677904576</BitOffs>
+            <BitOffs>679456896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.stDefault</Name>
@@ -101034,7 +101845,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>677996608</BitOffs>
+            <BitOffs>679548928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4XStates</Name>
@@ -101044,7 +101855,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>678000320</BitOffs>
+            <BitOffs>679552640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4YStates</Name>
@@ -101054,37 +101865,37 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>678056000</BitOffs>
+            <BitOffs>679608320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678111680</BitOffs>
+            <BitOffs>679664000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678111808</BitOffs>
+            <BitOffs>679664128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678111936</BitOffs>
+            <BitOffs>679664256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>678112064</BitOffs>
+            <BitOffs>679664384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>678112192</BitOffs>
+            <BitOffs>679664512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States</Name>
@@ -101099,13 +101910,13 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>678439232</BitOffs>
+            <BitOffs>679991552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>679987584</BitOffs>
+            <BitOffs>681539904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.stDefault</Name>
@@ -101129,7 +101940,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>680079616</BitOffs>
+            <BitOffs>681631936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.aAT2K4States</Name>
@@ -101139,25 +101950,38 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>680083328</BitOffs>
+            <BitOffs>681635648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>144640</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>680140224</BitOffs>
+            <BitOffs>681692544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>680284864</BitOffs>
+            <BitOffs>681837184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
+            <Comment>	bST1K4_Veto: BOOL;</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>681865536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_3_PMPS_POST.bM1K3Veto</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>681865544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>680313216</BitOffs>
+            <BitOffs>681865552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF1K4State</Name>
@@ -101168,24 +101992,13 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>680313248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcGVL.ePF2K4State</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>680313264</BitOffs>
+            <BitOffs>681865584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5802176</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>680320640</BitOffs>
+            <BitOffs>681872960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -101204,7 +102017,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686128576</BitOffs>
+            <BitOffs>687680896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -101223,7 +102036,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>686725568</BitOffs>
+            <BitOffs>688277888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -101253,7 +102066,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>687322560</BitOffs>
+            <BitOffs>688874880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -101283,7 +102096,18 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>689065728</BitOffs>
+            <BitOffs>690618048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcGVL.ePF2K4State</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="lcls_twincat_common_components">E_WFS_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>692361216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4ATT</Name>
@@ -101294,7 +102118,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808896</BitOffs>
+            <BitOffs>692361232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4FZP</Name>
@@ -101305,7 +102129,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808912</BitOffs>
+            <BitOffs>692361248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -101320,7 +102144,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808928</BitOffs>
+            <BitOffs>692361264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -101335,22 +102159,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>690808944</BitOffs>
+            <BitOffs>692361272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -101379,7 +102188,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690808960</BitOffs>
+            <BitOffs>692361280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -101391,7 +102200,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690834880</BitOffs>
+            <BitOffs>692387200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -101402,7 +102211,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690860800</BitOffs>
+            <BitOffs>692413120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -101413,7 +102222,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690886720</BitOffs>
+            <BitOffs>692439040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -101424,7 +102233,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690912640</BitOffs>
+            <BitOffs>692464960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -101435,7 +102244,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690938560</BitOffs>
+            <BitOffs>692490880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -101446,7 +102255,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690964480</BitOffs>
+            <BitOffs>692516800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -101457,7 +102266,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690990400</BitOffs>
+            <BitOffs>692542720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -101486,7 +102295,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691016320</BitOffs>
+            <BitOffs>692568640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -101514,7 +102323,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691042240</BitOffs>
+            <BitOffs>692594560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -101541,7 +102350,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691068160</BitOffs>
+            <BitOffs>692620480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -101568,7 +102377,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691094080</BitOffs>
+            <BitOffs>692646400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -101595,7 +102404,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691120000</BitOffs>
+            <BitOffs>692672320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -101607,7 +102416,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691145920</BitOffs>
+            <BitOffs>692698240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -101636,7 +102445,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691171840</BitOffs>
+            <BitOffs>692724160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -101665,7 +102474,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691197760</BitOffs>
+            <BitOffs>692750080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -101694,7 +102503,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691223680</BitOffs>
+            <BitOffs>692776000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -101723,7 +102532,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691249600</BitOffs>
+            <BitOffs>692801920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -101748,7 +102557,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691275520</BitOffs>
+            <BitOffs>692827840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -101777,7 +102586,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691301440</BitOffs>
+            <BitOffs>692853760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -101806,7 +102615,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691327360</BitOffs>
+            <BitOffs>692879680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -101831,7 +102640,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691353280</BitOffs>
+            <BitOffs>692905600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -101859,7 +102668,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691379200</BitOffs>
+            <BitOffs>692931520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -101886,7 +102695,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691405120</BitOffs>
+            <BitOffs>692957440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -101913,7 +102722,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691431040</BitOffs>
+            <BitOffs>692983360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -101940,7 +102749,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691456960</BitOffs>
+            <BitOffs>693009280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -101969,7 +102778,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691482880</BitOffs>
+            <BitOffs>693035200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -101998,7 +102807,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691508800</BitOffs>
+            <BitOffs>693061120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -102023,7 +102832,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691534720</BitOffs>
+            <BitOffs>693087040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -102052,7 +102861,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691560640</BitOffs>
+            <BitOffs>693112960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -102077,7 +102886,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691586560</BitOffs>
+            <BitOffs>693138880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -102114,7 +102923,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691612480</BitOffs>
+            <BitOffs>693164800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -102159,7 +102968,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691638400</BitOffs>
+            <BitOffs>693190720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -102200,7 +103009,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691664320</BitOffs>
+            <BitOffs>693216640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -102241,7 +103050,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691690240</BitOffs>
+            <BitOffs>693242560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -102282,7 +103091,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691716160</BitOffs>
+            <BitOffs>693268480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -102323,7 +103132,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691742080</BitOffs>
+            <BitOffs>693294400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -102364,7 +103173,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691768000</BitOffs>
+            <BitOffs>693320320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -102405,7 +103214,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691793920</BitOffs>
+            <BitOffs>693346240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -102446,7 +103255,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691819840</BitOffs>
+            <BitOffs>693372160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -102482,7 +103291,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691845760</BitOffs>
+            <BitOffs>693398080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -102518,7 +103327,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691871680</BitOffs>
+            <BitOffs>693424000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -102554,7 +103363,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691897600</BitOffs>
+            <BitOffs>693449920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -102599,7 +103408,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691923520</BitOffs>
+            <BitOffs>693475840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45</Name>
@@ -102645,7 +103454,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691949440</BitOffs>
+            <BitOffs>693501760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46</Name>
@@ -102691,7 +103500,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>691975360</BitOffs>
+            <BitOffs>693527680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47</Name>
@@ -102735,7 +103544,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692001280</BitOffs>
+            <BitOffs>693553600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -102765,7 +103574,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027200</BitOffs>
+            <BitOffs>693579520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -102795,7 +103604,22 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027264</BitOffs>
+            <BitOffs>693579584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>693579648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -102810,7 +103634,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027328</BitOffs>
+            <BitOffs>693579664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -102825,7 +103649,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027344</BitOffs>
+            <BitOffs>693579680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -102839,7 +103663,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027352</BitOffs>
+            <BitOffs>693579688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -102854,7 +103678,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027360</BitOffs>
+            <BitOffs>693579712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -102869,21 +103693,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>692027424</BitOffs>
+            <BitOffs>693579744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -102897,7 +103707,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692027456</BitOffs>
+            <BitOffs>693579776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -102915,7 +103725,21 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692029504</BitOffs>
+            <BitOffs>693581824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>693582848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -102929,7 +103753,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692030528</BitOffs>
+            <BitOffs>693582880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -102950,7 +103774,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692030592</BitOffs>
+            <BitOffs>693582912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -103022,7 +103846,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692046976</BitOffs>
+            <BitOffs>693599296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -103094,7 +103918,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047104</BitOffs>
+            <BitOffs>693599424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -103166,7 +103990,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047232</BitOffs>
+            <BitOffs>693599552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -103238,7 +104062,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047360</BitOffs>
+            <BitOffs>693599680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -103310,7 +104134,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047488</BitOffs>
+            <BitOffs>693599808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -103382,7 +104206,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047616</BitOffs>
+            <BitOffs>693599936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -103454,7 +104278,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047744</BitOffs>
+            <BitOffs>693600064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -103526,7 +104350,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692047872</BitOffs>
+            <BitOffs>693600192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -103552,60 +104376,20 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692080896</BitOffs>
+            <BitOffs>693633216</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_3_PMPS_POST.bM1K3Veto</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>692119056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_PMPS</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>3.3.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>701552896</BitOffs>
+            <Name>PRG_LI2K4_IP1.fbLI2K4States</Name>
+            <BitSize>3008</BitSize>
+            <BaseType>FB_SequenceMover2D</BaseType>
+            <BitOffs>700954944</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>87949312</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -103691,15 +104475,15 @@ second version of targets paddle 2</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-06-20T09:57:47</Value>
+          <Value>2024-07-18T14:20:52</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1277952</Value>
+          <Value>1220608</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>86159360</Value>
+          <Value>86351872</Value>
         </Property>
       </Properties>
     </Module>

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D1BDC03F-6A1A-3E16-2A99-08EBC64CAE32}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{71335523-D1BE-63BE-B51D-6AC18BBF0850}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -181,31 +181,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86733216</GetCodeOffs>
+        <GetCodeOffs>86733952</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86733280</GetCodeOffs>
+        <GetCodeOffs>86734016</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86733296</GetCodeOffs>
+        <GetCodeOffs>86734032</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86733264</GetCodeOffs>
+        <GetCodeOffs>86734000</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86733288</GetCodeOffs>
+        <GetCodeOffs>86734024</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1427,15 +1427,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86733096</GetCodeOffs>
-        <SetCodeOffs>86733144</SetCodeOffs>
+        <GetCodeOffs>86733832</GetCodeOffs>
+        <SetCodeOffs>86733880</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86733168</GetCodeOffs>
-        <SetCodeOffs>86733192</SetCodeOffs>
+        <GetCodeOffs>86733904</GetCodeOffs>
+        <SetCodeOffs>86733928</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1698,25 +1698,25 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>86733392</GetCodeOffs>
+        <GetCodeOffs>86734128</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86733352</GetCodeOffs>
+        <GetCodeOffs>86734088</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86733528</GetCodeOffs>
+        <GetCodeOffs>86734264</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86733448</GetCodeOffs>
+        <GetCodeOffs>86734184</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -1728,7 +1728,7 @@
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86733536</GetCodeOffs>
+        <GetCodeOffs>86734272</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -2299,7 +2299,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86733592</GetCodeOffs>
+        <GetCodeOffs>86734328</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -19640,14 +19640,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86739408</GetCodeOffs>
+        <GetCodeOffs>86740144</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86739312</GetCodeOffs>
+        <GetCodeOffs>86740048</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -20743,7 +20743,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86739560</GetCodeOffs>
+        <GetCodeOffs>86740296</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -21402,7 +21402,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86739672</GetCodeOffs>
+        <GetCodeOffs>86740408</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -59530,7 +59530,7 @@ second version of targets paddle 2</Comment>
     </DataType>
     <DataType>
       <Name>FB_SequenceMover2D</Name>
-      <BitSize>3008</BitSize>
+      <BitSize>8896</BitSize>
       <SubItem>
         <Name>eEnumSet</Name>
         <Type ReferenceTo="true">UINT</Type>
@@ -59611,6 +59611,14 @@ second version of targets paddle 2</Comment>
             <Name>ItemType</Name>
             <Value>InOut</Value>
           </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE:M1
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
         </Properties>
       </SubItem>
       <SubItem>
@@ -59640,6 +59648,14 @@ second version of targets paddle 2</Comment>
           <Property>
             <Name>ItemType</Name>
             <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE:M2
+        io: io
+        expand: :%.2d
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -59789,6 +59805,10 @@ second version of targets paddle 2</Comment>
             <Name>ItemType</Name>
             <Value>Input</Value>
           </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
         </Properties>
       </SubItem>
       <SubItem>
@@ -59801,6 +59821,10 @@ second version of targets paddle 2</Comment>
           <Property>
             <Name>ItemType</Name>
             <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -59818,16 +59842,63 @@ second version of targets paddle 2</Comment>
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>2592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>2560</BitSize>
+        <BitOffs>3360</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2560</BitSize>
+        <BitOffs>5920</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>tonStateSequenceTimeout</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>2624</BitOffs>
+        <BitOffs>8512</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tStateSequenceTimeoutTime</Name>
         <Type>TIME</Type>
         <BitSize>32</BitSize>
-        <BitOffs>2880</BitOffs>
+        <BitOffs>8768</BitOffs>
         <Default>
           <DateTime>T#5s</DateTime>
         </Default>
@@ -59836,27 +59907,27 @@ second version of targets paddle 2</Comment>
         <Name>nGoal</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>2912</BitOffs>
+        <BitOffs>8800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nState</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>2928</BitOffs>
+        <BitOffs>8816</BitOffs>
       </SubItem>
       <SubItem>
         <Name>eEnumGet1</Name>
         <Type>UINT</Type>
         <Comment> The current state index of the 1st axis state mover</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>2944</BitOffs>
+        <BitOffs>8832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>eEnumGet2</Name>
         <Type>UINT</Type>
         <Comment> The current state index of the 2nd axis state mover</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>2960</BitOffs>
+        <BitOffs>8848</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -60493,8 +60564,8 @@ second version of targets paddle 2</Comment>
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>86748664</GetCodeOffs>
-        <SetCodeOffs>86748680</SetCodeOffs>
+        <GetCodeOffs>86749400</GetCodeOffs>
+        <SetCodeOffs>86749416</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -61671,31 +61742,31 @@ second version of targets paddle 2</Comment>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86747792</GetCodeOffs>
+        <GetCodeOffs>86748528</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>86747856</GetCodeOffs>
+        <GetCodeOffs>86748592</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86747864</GetCodeOffs>
+        <GetCodeOffs>86748600</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>86747840</GetCodeOffs>
+        <GetCodeOffs>86748576</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>86747880</GetCodeOffs>
+        <GetCodeOffs>86748616</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -78513,7 +78584,7 @@ second version of targets paddle 2</Comment>
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>88080384</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -85022,7 +85093,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>679667200</BitOffs>
+            <BitOffs>679673088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -85034,7 +85105,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681296256</BitOffs>
+            <BitOffs>681302144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -85047,7 +85118,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304192</BitOffs>
+            <BitOffs>681310080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -85060,7 +85131,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304200</BitOffs>
+            <BitOffs>681310088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHome</Name>
@@ -85073,7 +85144,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304208</BitOffs>
+            <BitOffs>681310096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bHardwareEnable</Name>
@@ -85096,7 +85167,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304224</BitOffs>
+            <BitOffs>681310112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -85109,7 +85180,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304256</BitOffs>
+            <BitOffs>681310144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -85122,7 +85193,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304320</BitOffs>
+            <BitOffs>681310208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -85135,7 +85206,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681304336</BitOffs>
+            <BitOffs>681310224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -85147,7 +85218,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681322176</BitOffs>
+            <BitOffs>681328064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -85160,7 +85231,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330112</BitOffs>
+            <BitOffs>681336000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -85173,7 +85244,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330120</BitOffs>
+            <BitOffs>681336008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHome</Name>
@@ -85186,7 +85257,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330128</BitOffs>
+            <BitOffs>681336016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bHardwareEnable</Name>
@@ -85209,7 +85280,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330144</BitOffs>
+            <BitOffs>681336032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -85222,7 +85293,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330176</BitOffs>
+            <BitOffs>681336064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -85235,7 +85306,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330240</BitOffs>
+            <BitOffs>681336128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -85248,7 +85319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681330256</BitOffs>
+            <BitOffs>681336144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -85260,7 +85331,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681348096</BitOffs>
+            <BitOffs>681353984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -85273,7 +85344,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356032</BitOffs>
+            <BitOffs>681361920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -85286,7 +85357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356040</BitOffs>
+            <BitOffs>681361928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHome</Name>
@@ -85299,7 +85370,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356048</BitOffs>
+            <BitOffs>681361936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bHardwareEnable</Name>
@@ -85322,7 +85393,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356064</BitOffs>
+            <BitOffs>681361952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -85335,7 +85406,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356096</BitOffs>
+            <BitOffs>681361984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -85348,7 +85419,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356160</BitOffs>
+            <BitOffs>681362048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -85361,7 +85432,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681356176</BitOffs>
+            <BitOffs>681362064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -85377,7 +85448,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681693568</BitOffs>
+            <BitOffs>681699456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -85398,7 +85469,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681697088</BitOffs>
+            <BitOffs>681702976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -85419,7 +85490,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>681697089</BitOffs>
+            <BitOffs>681702977</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -85431,7 +85502,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692362432</BitOffs>
+            <BitOffs>692368320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -85444,7 +85515,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370368</BitOffs>
+            <BitOffs>692376256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -85457,7 +85528,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370376</BitOffs>
+            <BitOffs>692376264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -85470,7 +85541,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370384</BitOffs>
+            <BitOffs>692376272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -85493,7 +85564,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370400</BitOffs>
+            <BitOffs>692376288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -85506,7 +85577,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370432</BitOffs>
+            <BitOffs>692376320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -85519,7 +85590,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370496</BitOffs>
+            <BitOffs>692376384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -85532,7 +85603,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692370512</BitOffs>
+            <BitOffs>692376400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -85544,7 +85615,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692388352</BitOffs>
+            <BitOffs>692394240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -85557,7 +85628,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396288</BitOffs>
+            <BitOffs>692402176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -85570,7 +85641,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396296</BitOffs>
+            <BitOffs>692402184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -85583,7 +85654,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396304</BitOffs>
+            <BitOffs>692402192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -85606,7 +85677,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396320</BitOffs>
+            <BitOffs>692402208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -85619,7 +85690,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396352</BitOffs>
+            <BitOffs>692402240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -85632,7 +85703,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396416</BitOffs>
+            <BitOffs>692402304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -85645,7 +85716,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692396432</BitOffs>
+            <BitOffs>692402320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -85657,7 +85728,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692414272</BitOffs>
+            <BitOffs>692420160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -85670,7 +85741,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422208</BitOffs>
+            <BitOffs>692428096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -85683,7 +85754,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422216</BitOffs>
+            <BitOffs>692428104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -85696,7 +85767,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422224</BitOffs>
+            <BitOffs>692428112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -85719,7 +85790,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422240</BitOffs>
+            <BitOffs>692428128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -85732,7 +85803,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422272</BitOffs>
+            <BitOffs>692428160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -85745,7 +85816,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422336</BitOffs>
+            <BitOffs>692428224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -85758,7 +85829,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692422352</BitOffs>
+            <BitOffs>692428240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -85770,7 +85841,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692440192</BitOffs>
+            <BitOffs>692446080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -85783,7 +85854,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448128</BitOffs>
+            <BitOffs>692454016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -85796,7 +85867,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448136</BitOffs>
+            <BitOffs>692454024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -85809,7 +85880,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448144</BitOffs>
+            <BitOffs>692454032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -85832,7 +85903,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448160</BitOffs>
+            <BitOffs>692454048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -85845,7 +85916,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448192</BitOffs>
+            <BitOffs>692454080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -85858,7 +85929,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448256</BitOffs>
+            <BitOffs>692454144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -85871,7 +85942,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692448272</BitOffs>
+            <BitOffs>692454160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -85883,7 +85954,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692466112</BitOffs>
+            <BitOffs>692472000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -85896,7 +85967,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474048</BitOffs>
+            <BitOffs>692479936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -85909,7 +85980,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474056</BitOffs>
+            <BitOffs>692479944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -85922,7 +85993,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474064</BitOffs>
+            <BitOffs>692479952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -85945,7 +86016,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474080</BitOffs>
+            <BitOffs>692479968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -85958,7 +86029,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474112</BitOffs>
+            <BitOffs>692480000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -85971,7 +86042,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474176</BitOffs>
+            <BitOffs>692480064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -85984,7 +86055,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692474192</BitOffs>
+            <BitOffs>692480080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -85996,7 +86067,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692492032</BitOffs>
+            <BitOffs>692497920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -86009,7 +86080,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692499968</BitOffs>
+            <BitOffs>692505856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -86022,7 +86093,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692499976</BitOffs>
+            <BitOffs>692505864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -86035,7 +86106,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692499984</BitOffs>
+            <BitOffs>692505872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -86058,7 +86129,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692500000</BitOffs>
+            <BitOffs>692505888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -86071,7 +86142,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692500032</BitOffs>
+            <BitOffs>692505920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -86084,7 +86155,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692500096</BitOffs>
+            <BitOffs>692505984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -86097,7 +86168,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692500112</BitOffs>
+            <BitOffs>692506000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -86109,7 +86180,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692517952</BitOffs>
+            <BitOffs>692523840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -86122,7 +86193,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692525888</BitOffs>
+            <BitOffs>692531776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -86135,7 +86206,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692525896</BitOffs>
+            <BitOffs>692531784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -86148,7 +86219,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692525904</BitOffs>
+            <BitOffs>692531792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -86171,7 +86242,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692525920</BitOffs>
+            <BitOffs>692531808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -86184,7 +86255,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692525952</BitOffs>
+            <BitOffs>692531840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -86197,7 +86268,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692526016</BitOffs>
+            <BitOffs>692531904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -86210,7 +86281,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692526032</BitOffs>
+            <BitOffs>692531920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -86222,7 +86293,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692543872</BitOffs>
+            <BitOffs>692549760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -86235,7 +86306,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551808</BitOffs>
+            <BitOffs>692557696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -86248,7 +86319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551816</BitOffs>
+            <BitOffs>692557704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -86261,7 +86332,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551824</BitOffs>
+            <BitOffs>692557712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -86284,7 +86355,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551840</BitOffs>
+            <BitOffs>692557728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -86297,7 +86368,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551872</BitOffs>
+            <BitOffs>692557760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -86310,7 +86381,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551936</BitOffs>
+            <BitOffs>692557824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -86323,7 +86394,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692551952</BitOffs>
+            <BitOffs>692557840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -86335,7 +86406,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692569792</BitOffs>
+            <BitOffs>692575680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -86348,7 +86419,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577728</BitOffs>
+            <BitOffs>692583616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -86361,7 +86432,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577736</BitOffs>
+            <BitOffs>692583624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -86374,7 +86445,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577744</BitOffs>
+            <BitOffs>692583632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -86397,7 +86468,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577760</BitOffs>
+            <BitOffs>692583648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -86410,7 +86481,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577792</BitOffs>
+            <BitOffs>692583680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -86423,7 +86494,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577856</BitOffs>
+            <BitOffs>692583744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -86436,7 +86507,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692577872</BitOffs>
+            <BitOffs>692583760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -86448,7 +86519,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692595712</BitOffs>
+            <BitOffs>692601600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -86461,7 +86532,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603648</BitOffs>
+            <BitOffs>692609536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -86474,7 +86545,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603656</BitOffs>
+            <BitOffs>692609544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -86487,7 +86558,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603664</BitOffs>
+            <BitOffs>692609552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -86510,7 +86581,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603680</BitOffs>
+            <BitOffs>692609568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -86523,7 +86594,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603712</BitOffs>
+            <BitOffs>692609600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -86536,7 +86607,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603776</BitOffs>
+            <BitOffs>692609664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -86549,7 +86620,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692603792</BitOffs>
+            <BitOffs>692609680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -86561,7 +86632,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692621632</BitOffs>
+            <BitOffs>692627520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -86574,7 +86645,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629568</BitOffs>
+            <BitOffs>692635456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -86587,7 +86658,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629576</BitOffs>
+            <BitOffs>692635464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -86600,7 +86671,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629584</BitOffs>
+            <BitOffs>692635472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -86623,7 +86694,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629600</BitOffs>
+            <BitOffs>692635488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -86636,7 +86707,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629632</BitOffs>
+            <BitOffs>692635520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -86649,7 +86720,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629696</BitOffs>
+            <BitOffs>692635584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -86662,7 +86733,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692629712</BitOffs>
+            <BitOffs>692635600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -86674,7 +86745,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692647552</BitOffs>
+            <BitOffs>692653440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -86687,7 +86758,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655488</BitOffs>
+            <BitOffs>692661376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -86700,7 +86771,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655496</BitOffs>
+            <BitOffs>692661384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -86713,7 +86784,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655504</BitOffs>
+            <BitOffs>692661392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -86736,7 +86807,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655520</BitOffs>
+            <BitOffs>692661408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -86749,7 +86820,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655552</BitOffs>
+            <BitOffs>692661440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -86762,7 +86833,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655616</BitOffs>
+            <BitOffs>692661504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -86775,7 +86846,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692655632</BitOffs>
+            <BitOffs>692661520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -86787,7 +86858,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692673472</BitOffs>
+            <BitOffs>692679360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -86800,7 +86871,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681408</BitOffs>
+            <BitOffs>692687296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -86813,7 +86884,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681416</BitOffs>
+            <BitOffs>692687304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -86826,7 +86897,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681424</BitOffs>
+            <BitOffs>692687312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -86849,7 +86920,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681440</BitOffs>
+            <BitOffs>692687328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -86862,7 +86933,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681472</BitOffs>
+            <BitOffs>692687360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -86875,7 +86946,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681536</BitOffs>
+            <BitOffs>692687424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -86888,7 +86959,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692681552</BitOffs>
+            <BitOffs>692687440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -86900,7 +86971,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692699392</BitOffs>
+            <BitOffs>692705280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -86913,7 +86984,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707328</BitOffs>
+            <BitOffs>692713216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -86926,7 +86997,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707336</BitOffs>
+            <BitOffs>692713224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -86939,7 +87010,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707344</BitOffs>
+            <BitOffs>692713232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -86962,7 +87033,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707360</BitOffs>
+            <BitOffs>692713248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -86975,7 +87046,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707392</BitOffs>
+            <BitOffs>692713280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -86988,7 +87059,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707456</BitOffs>
+            <BitOffs>692713344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -87001,7 +87072,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692707472</BitOffs>
+            <BitOffs>692713360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -87013,7 +87084,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692725312</BitOffs>
+            <BitOffs>692731200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -87026,7 +87097,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733248</BitOffs>
+            <BitOffs>692739136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -87039,7 +87110,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733256</BitOffs>
+            <BitOffs>692739144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -87052,7 +87123,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733264</BitOffs>
+            <BitOffs>692739152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -87075,7 +87146,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733280</BitOffs>
+            <BitOffs>692739168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -87088,7 +87159,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733312</BitOffs>
+            <BitOffs>692739200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -87101,7 +87172,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733376</BitOffs>
+            <BitOffs>692739264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -87114,7 +87185,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692733392</BitOffs>
+            <BitOffs>692739280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -87126,7 +87197,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692751232</BitOffs>
+            <BitOffs>692757120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -87139,7 +87210,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759168</BitOffs>
+            <BitOffs>692765056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -87152,7 +87223,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759176</BitOffs>
+            <BitOffs>692765064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -87165,7 +87236,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759184</BitOffs>
+            <BitOffs>692765072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -87188,7 +87259,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759200</BitOffs>
+            <BitOffs>692765088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -87201,7 +87272,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759232</BitOffs>
+            <BitOffs>692765120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -87214,7 +87285,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759296</BitOffs>
+            <BitOffs>692765184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -87227,7 +87298,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692759312</BitOffs>
+            <BitOffs>692765200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -87239,7 +87310,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692777152</BitOffs>
+            <BitOffs>692783040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -87252,7 +87323,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785088</BitOffs>
+            <BitOffs>692790976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -87265,7 +87336,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785096</BitOffs>
+            <BitOffs>692790984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -87278,7 +87349,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785104</BitOffs>
+            <BitOffs>692790992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -87301,7 +87372,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785120</BitOffs>
+            <BitOffs>692791008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -87314,7 +87385,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785152</BitOffs>
+            <BitOffs>692791040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -87327,7 +87398,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785216</BitOffs>
+            <BitOffs>692791104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -87340,7 +87411,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692785232</BitOffs>
+            <BitOffs>692791120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -87352,7 +87423,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692803072</BitOffs>
+            <BitOffs>692808960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -87365,7 +87436,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811008</BitOffs>
+            <BitOffs>692816896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -87378,7 +87449,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811016</BitOffs>
+            <BitOffs>692816904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -87391,7 +87462,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811024</BitOffs>
+            <BitOffs>692816912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -87414,7 +87485,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811040</BitOffs>
+            <BitOffs>692816928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -87427,7 +87498,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811072</BitOffs>
+            <BitOffs>692816960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -87440,7 +87511,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811136</BitOffs>
+            <BitOffs>692817024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -87453,7 +87524,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692811152</BitOffs>
+            <BitOffs>692817040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -87465,7 +87536,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692828992</BitOffs>
+            <BitOffs>692834880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -87478,7 +87549,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692836928</BitOffs>
+            <BitOffs>692842816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -87491,7 +87562,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692836936</BitOffs>
+            <BitOffs>692842824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -87504,7 +87575,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692836944</BitOffs>
+            <BitOffs>692842832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -87527,7 +87598,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692836960</BitOffs>
+            <BitOffs>692842848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -87540,7 +87611,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692836992</BitOffs>
+            <BitOffs>692842880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -87553,7 +87624,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692837056</BitOffs>
+            <BitOffs>692842944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -87566,7 +87637,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692837072</BitOffs>
+            <BitOffs>692842960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -87578,7 +87649,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692854912</BitOffs>
+            <BitOffs>692860800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -87591,7 +87662,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862848</BitOffs>
+            <BitOffs>692868736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -87604,7 +87675,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862856</BitOffs>
+            <BitOffs>692868744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -87617,7 +87688,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862864</BitOffs>
+            <BitOffs>692868752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -87640,7 +87711,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862880</BitOffs>
+            <BitOffs>692868768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -87653,7 +87724,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862912</BitOffs>
+            <BitOffs>692868800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -87666,7 +87737,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862976</BitOffs>
+            <BitOffs>692868864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -87679,7 +87750,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692862992</BitOffs>
+            <BitOffs>692868880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -87691,7 +87762,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692880832</BitOffs>
+            <BitOffs>692886720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -87704,7 +87775,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888768</BitOffs>
+            <BitOffs>692894656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -87717,7 +87788,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888776</BitOffs>
+            <BitOffs>692894664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -87730,7 +87801,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888784</BitOffs>
+            <BitOffs>692894672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -87753,7 +87824,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888800</BitOffs>
+            <BitOffs>692894688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -87766,7 +87837,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888832</BitOffs>
+            <BitOffs>692894720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -87779,7 +87850,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888896</BitOffs>
+            <BitOffs>692894784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -87792,7 +87863,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692888912</BitOffs>
+            <BitOffs>692894800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -87804,7 +87875,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692906752</BitOffs>
+            <BitOffs>692912640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -87817,7 +87888,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914688</BitOffs>
+            <BitOffs>692920576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -87830,7 +87901,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914696</BitOffs>
+            <BitOffs>692920584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -87843,7 +87914,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914704</BitOffs>
+            <BitOffs>692920592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -87866,7 +87937,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914720</BitOffs>
+            <BitOffs>692920608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -87879,7 +87950,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914752</BitOffs>
+            <BitOffs>692920640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -87892,7 +87963,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914816</BitOffs>
+            <BitOffs>692920704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -87905,7 +87976,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692914832</BitOffs>
+            <BitOffs>692920720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -87917,7 +87988,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692932672</BitOffs>
+            <BitOffs>692938560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -87930,7 +88001,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940608</BitOffs>
+            <BitOffs>692946496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -87943,7 +88014,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940616</BitOffs>
+            <BitOffs>692946504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -87956,7 +88027,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940624</BitOffs>
+            <BitOffs>692946512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -87979,7 +88050,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940640</BitOffs>
+            <BitOffs>692946528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -87992,7 +88063,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940672</BitOffs>
+            <BitOffs>692946560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -88005,7 +88076,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940736</BitOffs>
+            <BitOffs>692946624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -88018,7 +88089,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692940752</BitOffs>
+            <BitOffs>692946640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -88030,7 +88101,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692958592</BitOffs>
+            <BitOffs>692964480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -88043,7 +88114,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966528</BitOffs>
+            <BitOffs>692972416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -88056,7 +88127,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966536</BitOffs>
+            <BitOffs>692972424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -88069,7 +88140,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966544</BitOffs>
+            <BitOffs>692972432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -88092,7 +88163,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966560</BitOffs>
+            <BitOffs>692972448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -88105,7 +88176,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966592</BitOffs>
+            <BitOffs>692972480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -88118,7 +88189,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966656</BitOffs>
+            <BitOffs>692972544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -88131,7 +88202,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692966672</BitOffs>
+            <BitOffs>692972560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -88143,7 +88214,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692984512</BitOffs>
+            <BitOffs>692990400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -88156,7 +88227,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992448</BitOffs>
+            <BitOffs>692998336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -88169,7 +88240,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992456</BitOffs>
+            <BitOffs>692998344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -88182,7 +88253,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992464</BitOffs>
+            <BitOffs>692998352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -88205,7 +88276,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992480</BitOffs>
+            <BitOffs>692998368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -88218,7 +88289,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992512</BitOffs>
+            <BitOffs>692998400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -88231,7 +88302,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992576</BitOffs>
+            <BitOffs>692998464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -88244,7 +88315,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>692992592</BitOffs>
+            <BitOffs>692998480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -88256,7 +88327,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693010432</BitOffs>
+            <BitOffs>693016320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -88269,7 +88340,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018368</BitOffs>
+            <BitOffs>693024256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -88282,7 +88353,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018376</BitOffs>
+            <BitOffs>693024264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -88295,7 +88366,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018384</BitOffs>
+            <BitOffs>693024272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -88318,7 +88389,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018400</BitOffs>
+            <BitOffs>693024288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -88331,7 +88402,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018432</BitOffs>
+            <BitOffs>693024320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -88344,7 +88415,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018496</BitOffs>
+            <BitOffs>693024384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -88357,7 +88428,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693018512</BitOffs>
+            <BitOffs>693024400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -88369,7 +88440,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693036352</BitOffs>
+            <BitOffs>693042240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -88382,7 +88453,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044288</BitOffs>
+            <BitOffs>693050176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -88395,7 +88466,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044296</BitOffs>
+            <BitOffs>693050184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -88408,7 +88479,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044304</BitOffs>
+            <BitOffs>693050192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -88431,7 +88502,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044320</BitOffs>
+            <BitOffs>693050208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -88444,7 +88515,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044352</BitOffs>
+            <BitOffs>693050240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -88457,7 +88528,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044416</BitOffs>
+            <BitOffs>693050304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -88470,7 +88541,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693044432</BitOffs>
+            <BitOffs>693050320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -88482,7 +88553,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693062272</BitOffs>
+            <BitOffs>693068160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -88495,7 +88566,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070208</BitOffs>
+            <BitOffs>693076096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -88508,7 +88579,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070216</BitOffs>
+            <BitOffs>693076104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -88521,7 +88592,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070224</BitOffs>
+            <BitOffs>693076112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -88544,7 +88615,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070240</BitOffs>
+            <BitOffs>693076128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -88557,7 +88628,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070272</BitOffs>
+            <BitOffs>693076160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -88570,7 +88641,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070336</BitOffs>
+            <BitOffs>693076224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -88583,7 +88654,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693070352</BitOffs>
+            <BitOffs>693076240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -88595,7 +88666,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693088192</BitOffs>
+            <BitOffs>693094080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -88608,7 +88679,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096128</BitOffs>
+            <BitOffs>693102016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -88621,7 +88692,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096136</BitOffs>
+            <BitOffs>693102024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -88634,7 +88705,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096144</BitOffs>
+            <BitOffs>693102032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -88657,7 +88728,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096160</BitOffs>
+            <BitOffs>693102048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -88670,7 +88741,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096192</BitOffs>
+            <BitOffs>693102080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -88683,7 +88754,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096256</BitOffs>
+            <BitOffs>693102144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -88696,7 +88767,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693096272</BitOffs>
+            <BitOffs>693102160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -88708,7 +88779,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693114112</BitOffs>
+            <BitOffs>693120000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -88721,7 +88792,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122048</BitOffs>
+            <BitOffs>693127936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -88734,7 +88805,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122056</BitOffs>
+            <BitOffs>693127944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -88747,7 +88818,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122064</BitOffs>
+            <BitOffs>693127952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -88770,7 +88841,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122080</BitOffs>
+            <BitOffs>693127968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -88783,7 +88854,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122112</BitOffs>
+            <BitOffs>693128000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -88796,7 +88867,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122176</BitOffs>
+            <BitOffs>693128064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -88809,7 +88880,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693122192</BitOffs>
+            <BitOffs>693128080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -88821,7 +88892,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693140032</BitOffs>
+            <BitOffs>693145920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -88834,7 +88905,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693147968</BitOffs>
+            <BitOffs>693153856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -88847,7 +88918,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693147976</BitOffs>
+            <BitOffs>693153864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -88860,7 +88931,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693147984</BitOffs>
+            <BitOffs>693153872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -88883,7 +88954,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693148000</BitOffs>
+            <BitOffs>693153888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -88896,7 +88967,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693148032</BitOffs>
+            <BitOffs>693153920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -88909,7 +88980,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693148096</BitOffs>
+            <BitOffs>693153984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -88922,7 +88993,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693148112</BitOffs>
+            <BitOffs>693154000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -88934,7 +89005,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693165952</BitOffs>
+            <BitOffs>693171840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -88947,7 +89018,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693173888</BitOffs>
+            <BitOffs>693179776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -88960,7 +89031,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693173896</BitOffs>
+            <BitOffs>693179784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -88973,7 +89044,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693173904</BitOffs>
+            <BitOffs>693179792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -88996,7 +89067,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693173920</BitOffs>
+            <BitOffs>693179808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -89009,7 +89080,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693173952</BitOffs>
+            <BitOffs>693179840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -89022,7 +89093,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693174016</BitOffs>
+            <BitOffs>693179904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -89035,7 +89106,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693174032</BitOffs>
+            <BitOffs>693179920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -89047,7 +89118,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693191872</BitOffs>
+            <BitOffs>693197760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -89060,7 +89131,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199808</BitOffs>
+            <BitOffs>693205696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -89073,7 +89144,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199816</BitOffs>
+            <BitOffs>693205704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -89086,7 +89157,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199824</BitOffs>
+            <BitOffs>693205712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -89109,7 +89180,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199840</BitOffs>
+            <BitOffs>693205728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -89122,7 +89193,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199872</BitOffs>
+            <BitOffs>693205760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -89135,7 +89206,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199936</BitOffs>
+            <BitOffs>693205824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -89148,7 +89219,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693199952</BitOffs>
+            <BitOffs>693205840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -89160,7 +89231,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693217792</BitOffs>
+            <BitOffs>693223680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -89173,7 +89244,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225728</BitOffs>
+            <BitOffs>693231616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -89186,7 +89257,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225736</BitOffs>
+            <BitOffs>693231624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -89199,7 +89270,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225744</BitOffs>
+            <BitOffs>693231632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -89222,7 +89293,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225760</BitOffs>
+            <BitOffs>693231648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -89235,7 +89306,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225792</BitOffs>
+            <BitOffs>693231680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -89248,7 +89319,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225856</BitOffs>
+            <BitOffs>693231744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -89261,7 +89332,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693225872</BitOffs>
+            <BitOffs>693231760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -89273,7 +89344,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693243712</BitOffs>
+            <BitOffs>693249600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -89286,7 +89357,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251648</BitOffs>
+            <BitOffs>693257536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -89299,7 +89370,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251656</BitOffs>
+            <BitOffs>693257544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -89312,7 +89383,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251664</BitOffs>
+            <BitOffs>693257552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -89335,7 +89406,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251680</BitOffs>
+            <BitOffs>693257568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -89348,7 +89419,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251712</BitOffs>
+            <BitOffs>693257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -89361,7 +89432,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251776</BitOffs>
+            <BitOffs>693257664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -89374,7 +89445,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693251792</BitOffs>
+            <BitOffs>693257680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -89386,7 +89457,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693269632</BitOffs>
+            <BitOffs>693275520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -89399,7 +89470,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277568</BitOffs>
+            <BitOffs>693283456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -89412,7 +89483,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277576</BitOffs>
+            <BitOffs>693283464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -89425,7 +89496,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277584</BitOffs>
+            <BitOffs>693283472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -89448,7 +89519,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277600</BitOffs>
+            <BitOffs>693283488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -89461,7 +89532,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277632</BitOffs>
+            <BitOffs>693283520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -89474,7 +89545,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277696</BitOffs>
+            <BitOffs>693283584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -89487,7 +89558,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693277712</BitOffs>
+            <BitOffs>693283600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -89499,7 +89570,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693295552</BitOffs>
+            <BitOffs>693301440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -89512,7 +89583,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303488</BitOffs>
+            <BitOffs>693309376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -89525,7 +89596,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303496</BitOffs>
+            <BitOffs>693309384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -89538,7 +89609,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303504</BitOffs>
+            <BitOffs>693309392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -89561,7 +89632,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303520</BitOffs>
+            <BitOffs>693309408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -89574,7 +89645,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303552</BitOffs>
+            <BitOffs>693309440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -89587,7 +89658,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303616</BitOffs>
+            <BitOffs>693309504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -89600,7 +89671,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693303632</BitOffs>
+            <BitOffs>693309520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.NcToPlc</Name>
@@ -89612,7 +89683,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693321472</BitOffs>
+            <BitOffs>693327360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitForwardEnable</Name>
@@ -89625,7 +89696,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329408</BitOffs>
+            <BitOffs>693335296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bLimitBackwardEnable</Name>
@@ -89638,7 +89709,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329416</BitOffs>
+            <BitOffs>693335304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHome</Name>
@@ -89651,7 +89722,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329424</BitOffs>
+            <BitOffs>693335312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bHardwareEnable</Name>
@@ -89674,7 +89745,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329440</BitOffs>
+            <BitOffs>693335328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderULINT</Name>
@@ -89687,7 +89758,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329472</BitOffs>
+            <BitOffs>693335360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderUINT</Name>
@@ -89700,7 +89771,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329536</BitOffs>
+            <BitOffs>693335424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.nRawEncoderINT</Name>
@@ -89713,7 +89784,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693329552</BitOffs>
+            <BitOffs>693335440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.NcToPlc</Name>
@@ -89725,7 +89796,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693347392</BitOffs>
+            <BitOffs>693353280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitForwardEnable</Name>
@@ -89738,7 +89809,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355328</BitOffs>
+            <BitOffs>693361216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bLimitBackwardEnable</Name>
@@ -89751,7 +89822,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355336</BitOffs>
+            <BitOffs>693361224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHome</Name>
@@ -89764,7 +89835,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355344</BitOffs>
+            <BitOffs>693361232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bHardwareEnable</Name>
@@ -89787,7 +89858,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355360</BitOffs>
+            <BitOffs>693361248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderULINT</Name>
@@ -89800,7 +89871,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355392</BitOffs>
+            <BitOffs>693361280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderUINT</Name>
@@ -89813,7 +89884,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355456</BitOffs>
+            <BitOffs>693361344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.nRawEncoderINT</Name>
@@ -89826,7 +89897,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693355472</BitOffs>
+            <BitOffs>693361360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.NcToPlc</Name>
@@ -89838,7 +89909,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693373312</BitOffs>
+            <BitOffs>693379200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitForwardEnable</Name>
@@ -89851,7 +89922,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381248</BitOffs>
+            <BitOffs>693387136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bLimitBackwardEnable</Name>
@@ -89864,7 +89935,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381256</BitOffs>
+            <BitOffs>693387144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHome</Name>
@@ -89877,7 +89948,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381264</BitOffs>
+            <BitOffs>693387152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bHardwareEnable</Name>
@@ -89900,7 +89971,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381280</BitOffs>
+            <BitOffs>693387168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderULINT</Name>
@@ -89913,7 +89984,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381312</BitOffs>
+            <BitOffs>693387200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderUINT</Name>
@@ -89926,7 +89997,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381376</BitOffs>
+            <BitOffs>693387264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.nRawEncoderINT</Name>
@@ -89939,7 +90010,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693381392</BitOffs>
+            <BitOffs>693387280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.NcToPlc</Name>
@@ -89951,7 +90022,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693399232</BitOffs>
+            <BitOffs>693405120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitForwardEnable</Name>
@@ -89964,7 +90035,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407168</BitOffs>
+            <BitOffs>693413056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bLimitBackwardEnable</Name>
@@ -89977,7 +90048,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407176</BitOffs>
+            <BitOffs>693413064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHome</Name>
@@ -89990,7 +90061,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407184</BitOffs>
+            <BitOffs>693413072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bHardwareEnable</Name>
@@ -90013,7 +90084,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407200</BitOffs>
+            <BitOffs>693413088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderULINT</Name>
@@ -90026,7 +90097,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407232</BitOffs>
+            <BitOffs>693413120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderUINT</Name>
@@ -90039,7 +90110,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407296</BitOffs>
+            <BitOffs>693413184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.nRawEncoderINT</Name>
@@ -90052,7 +90123,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693407312</BitOffs>
+            <BitOffs>693413200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.NcToPlc</Name>
@@ -90064,7 +90135,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693425152</BitOffs>
+            <BitOffs>693431040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitForwardEnable</Name>
@@ -90077,7 +90148,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433088</BitOffs>
+            <BitOffs>693438976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bLimitBackwardEnable</Name>
@@ -90090,7 +90161,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433096</BitOffs>
+            <BitOffs>693438984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHome</Name>
@@ -90103,7 +90174,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433104</BitOffs>
+            <BitOffs>693438992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bHardwareEnable</Name>
@@ -90126,7 +90197,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433120</BitOffs>
+            <BitOffs>693439008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderULINT</Name>
@@ -90139,7 +90210,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433152</BitOffs>
+            <BitOffs>693439040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderUINT</Name>
@@ -90152,7 +90223,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433216</BitOffs>
+            <BitOffs>693439104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.nRawEncoderINT</Name>
@@ -90165,7 +90236,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693433232</BitOffs>
+            <BitOffs>693439120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.NcToPlc</Name>
@@ -90177,7 +90248,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693451072</BitOffs>
+            <BitOffs>693456960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitForwardEnable</Name>
@@ -90190,7 +90261,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459008</BitOffs>
+            <BitOffs>693464896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bLimitBackwardEnable</Name>
@@ -90203,7 +90274,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459016</BitOffs>
+            <BitOffs>693464904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHome</Name>
@@ -90216,7 +90287,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459024</BitOffs>
+            <BitOffs>693464912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bHardwareEnable</Name>
@@ -90239,7 +90310,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459040</BitOffs>
+            <BitOffs>693464928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderULINT</Name>
@@ -90252,7 +90323,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459072</BitOffs>
+            <BitOffs>693464960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderUINT</Name>
@@ -90265,7 +90336,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459136</BitOffs>
+            <BitOffs>693465024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.nRawEncoderINT</Name>
@@ -90278,7 +90349,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693459152</BitOffs>
+            <BitOffs>693465040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.NcToPlc</Name>
@@ -90290,7 +90361,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693476992</BitOffs>
+            <BitOffs>693482880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitForwardEnable</Name>
@@ -90303,7 +90374,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693484928</BitOffs>
+            <BitOffs>693490816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bLimitBackwardEnable</Name>
@@ -90316,7 +90387,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693484936</BitOffs>
+            <BitOffs>693490824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHome</Name>
@@ -90329,7 +90400,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693484944</BitOffs>
+            <BitOffs>693490832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bHardwareEnable</Name>
@@ -90352,7 +90423,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693484960</BitOffs>
+            <BitOffs>693490848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderULINT</Name>
@@ -90365,7 +90436,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693484992</BitOffs>
+            <BitOffs>693490880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderUINT</Name>
@@ -90378,7 +90449,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693485056</BitOffs>
+            <BitOffs>693490944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.nRawEncoderINT</Name>
@@ -90391,7 +90462,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693485072</BitOffs>
+            <BitOffs>693490960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.NcToPlc</Name>
@@ -90403,7 +90474,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693502912</BitOffs>
+            <BitOffs>693508800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitForwardEnable</Name>
@@ -90416,7 +90487,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510848</BitOffs>
+            <BitOffs>693516736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bLimitBackwardEnable</Name>
@@ -90429,7 +90500,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510856</BitOffs>
+            <BitOffs>693516744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHome</Name>
@@ -90442,7 +90513,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510864</BitOffs>
+            <BitOffs>693516752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bHardwareEnable</Name>
@@ -90465,7 +90536,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510880</BitOffs>
+            <BitOffs>693516768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderULINT</Name>
@@ -90478,7 +90549,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510912</BitOffs>
+            <BitOffs>693516800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderUINT</Name>
@@ -90491,7 +90562,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510976</BitOffs>
+            <BitOffs>693516864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.nRawEncoderINT</Name>
@@ -90504,7 +90575,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693510992</BitOffs>
+            <BitOffs>693516880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.NcToPlc</Name>
@@ -90516,7 +90587,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693528832</BitOffs>
+            <BitOffs>693534720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitForwardEnable</Name>
@@ -90529,7 +90600,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536768</BitOffs>
+            <BitOffs>693542656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bLimitBackwardEnable</Name>
@@ -90542,7 +90613,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536776</BitOffs>
+            <BitOffs>693542664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHome</Name>
@@ -90555,7 +90626,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536784</BitOffs>
+            <BitOffs>693542672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bHardwareEnable</Name>
@@ -90578,7 +90649,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536800</BitOffs>
+            <BitOffs>693542688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderULINT</Name>
@@ -90591,7 +90662,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536832</BitOffs>
+            <BitOffs>693542720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderUINT</Name>
@@ -90604,7 +90675,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536896</BitOffs>
+            <BitOffs>693542784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.nRawEncoderINT</Name>
@@ -90617,7 +90688,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693536912</BitOffs>
+            <BitOffs>693542800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.NcToPlc</Name>
@@ -90629,7 +90700,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693554752</BitOffs>
+            <BitOffs>693560640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitForwardEnable</Name>
@@ -90642,7 +90713,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562688</BitOffs>
+            <BitOffs>693568576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bLimitBackwardEnable</Name>
@@ -90655,7 +90726,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562696</BitOffs>
+            <BitOffs>693568584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHome</Name>
@@ -90668,7 +90739,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562704</BitOffs>
+            <BitOffs>693568592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bHardwareEnable</Name>
@@ -90691,7 +90762,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562720</BitOffs>
+            <BitOffs>693568608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderULINT</Name>
@@ -90704,7 +90775,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562752</BitOffs>
+            <BitOffs>693568640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderUINT</Name>
@@ -90717,7 +90788,7 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562816</BitOffs>
+            <BitOffs>693568704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.nRawEncoderINT</Name>
@@ -90730,14 +90801,14 @@ second version of targets paddle 2</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>693562832</BitOffs>
+            <BitOffs>693568720</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>88080384</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>PRG_AL1K4_L2SI.fbAL1K4.fbYStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -92489,7 +92560,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>679666176</BitOffs>
+            <BitOffs>679672064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -92501,7 +92572,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681295232</BitOffs>
+            <BitOffs>681301120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[1].bBrakeRelease</Name>
@@ -92514,7 +92585,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681304216</BitOffs>
+            <BitOffs>681310104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -92526,7 +92597,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681321152</BitOffs>
+            <BitOffs>681327040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[2].bBrakeRelease</Name>
@@ -92539,7 +92610,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681330136</BitOffs>
+            <BitOffs>681336024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -92551,7 +92622,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681347072</BitOffs>
+            <BitOffs>681352960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States.astMotionStageMax[3].bBrakeRelease</Name>
@@ -92564,7 +92635,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681356056</BitOffs>
+            <BitOffs>681361944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -92580,7 +92651,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>681695328</BitOffs>
+            <BitOffs>681701216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_IN</Name>
@@ -92599,7 +92670,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>681865624</BitOffs>
+            <BitOffs>681871512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.PMPS_ST4K4_OUT</Name>
@@ -92618,7 +92689,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>681865632</BitOffs>
+            <BitOffs>681871520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -92638,7 +92709,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>688875240</BitOffs>
+            <BitOffs>688881128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -92658,7 +92729,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>690618408</BitOffs>
+            <BitOffs>690624296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -92670,7 +92741,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692361408</BitOffs>
+            <BitOffs>692367296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -92683,7 +92754,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692370392</BitOffs>
+            <BitOffs>692376280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -92695,7 +92766,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692387328</BitOffs>
+            <BitOffs>692393216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -92708,7 +92779,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692396312</BitOffs>
+            <BitOffs>692402200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -92720,7 +92791,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692413248</BitOffs>
+            <BitOffs>692419136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -92733,7 +92804,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692422232</BitOffs>
+            <BitOffs>692428120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -92745,7 +92816,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692439168</BitOffs>
+            <BitOffs>692445056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -92758,7 +92829,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692448152</BitOffs>
+            <BitOffs>692454040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -92770,7 +92841,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692465088</BitOffs>
+            <BitOffs>692470976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -92783,7 +92854,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692474072</BitOffs>
+            <BitOffs>692479960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -92795,7 +92866,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692491008</BitOffs>
+            <BitOffs>692496896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -92808,7 +92879,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692499992</BitOffs>
+            <BitOffs>692505880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -92820,7 +92891,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692516928</BitOffs>
+            <BitOffs>692522816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -92833,7 +92904,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692525912</BitOffs>
+            <BitOffs>692531800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -92845,7 +92916,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692542848</BitOffs>
+            <BitOffs>692548736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -92858,7 +92929,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692551832</BitOffs>
+            <BitOffs>692557720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -92870,7 +92941,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692568768</BitOffs>
+            <BitOffs>692574656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -92883,7 +92954,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692577752</BitOffs>
+            <BitOffs>692583640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -92895,7 +92966,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692594688</BitOffs>
+            <BitOffs>692600576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -92908,7 +92979,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692603672</BitOffs>
+            <BitOffs>692609560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -92920,7 +92991,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692620608</BitOffs>
+            <BitOffs>692626496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -92933,7 +93004,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692629592</BitOffs>
+            <BitOffs>692635480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -92945,7 +93016,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692646528</BitOffs>
+            <BitOffs>692652416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -92958,7 +93029,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692655512</BitOffs>
+            <BitOffs>692661400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -92970,7 +93041,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692672448</BitOffs>
+            <BitOffs>692678336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -92983,7 +93054,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692681432</BitOffs>
+            <BitOffs>692687320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -92995,7 +93066,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692698368</BitOffs>
+            <BitOffs>692704256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -93008,7 +93079,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692707352</BitOffs>
+            <BitOffs>692713240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -93020,7 +93091,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692724288</BitOffs>
+            <BitOffs>692730176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -93033,7 +93104,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692733272</BitOffs>
+            <BitOffs>692739160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -93045,7 +93116,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692750208</BitOffs>
+            <BitOffs>692756096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -93058,7 +93129,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692759192</BitOffs>
+            <BitOffs>692765080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -93070,7 +93141,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692776128</BitOffs>
+            <BitOffs>692782016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -93083,7 +93154,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692785112</BitOffs>
+            <BitOffs>692791000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -93095,7 +93166,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692802048</BitOffs>
+            <BitOffs>692807936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -93108,7 +93179,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692811032</BitOffs>
+            <BitOffs>692816920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -93120,7 +93191,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692827968</BitOffs>
+            <BitOffs>692833856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -93133,7 +93204,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692836952</BitOffs>
+            <BitOffs>692842840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -93145,7 +93216,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692853888</BitOffs>
+            <BitOffs>692859776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -93158,7 +93229,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692862872</BitOffs>
+            <BitOffs>692868760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -93170,7 +93241,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692879808</BitOffs>
+            <BitOffs>692885696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -93183,7 +93254,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692888792</BitOffs>
+            <BitOffs>692894680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -93195,7 +93266,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692905728</BitOffs>
+            <BitOffs>692911616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -93208,7 +93279,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692914712</BitOffs>
+            <BitOffs>692920600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -93220,7 +93291,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692931648</BitOffs>
+            <BitOffs>692937536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -93233,7 +93304,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692940632</BitOffs>
+            <BitOffs>692946520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -93245,7 +93316,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692957568</BitOffs>
+            <BitOffs>692963456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -93258,7 +93329,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692966552</BitOffs>
+            <BitOffs>692972440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -93270,7 +93341,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692983488</BitOffs>
+            <BitOffs>692989376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -93283,7 +93354,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>692992472</BitOffs>
+            <BitOffs>692998360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -93295,7 +93366,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693009408</BitOffs>
+            <BitOffs>693015296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -93308,7 +93379,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693018392</BitOffs>
+            <BitOffs>693024280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -93320,7 +93391,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693035328</BitOffs>
+            <BitOffs>693041216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -93333,7 +93404,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693044312</BitOffs>
+            <BitOffs>693050200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -93345,7 +93416,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693061248</BitOffs>
+            <BitOffs>693067136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -93358,7 +93429,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693070232</BitOffs>
+            <BitOffs>693076120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -93370,7 +93441,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693087168</BitOffs>
+            <BitOffs>693093056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -93383,7 +93454,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693096152</BitOffs>
+            <BitOffs>693102040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -93395,7 +93466,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693113088</BitOffs>
+            <BitOffs>693118976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -93408,7 +93479,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693122072</BitOffs>
+            <BitOffs>693127960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -93420,7 +93491,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693139008</BitOffs>
+            <BitOffs>693144896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -93433,7 +93504,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693147992</BitOffs>
+            <BitOffs>693153880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -93445,7 +93516,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693164928</BitOffs>
+            <BitOffs>693170816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -93458,7 +93529,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693173912</BitOffs>
+            <BitOffs>693179800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -93470,7 +93541,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693190848</BitOffs>
+            <BitOffs>693196736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -93483,7 +93554,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693199832</BitOffs>
+            <BitOffs>693205720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -93495,7 +93566,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693216768</BitOffs>
+            <BitOffs>693222656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -93508,7 +93579,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693225752</BitOffs>
+            <BitOffs>693231640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -93520,7 +93591,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693242688</BitOffs>
+            <BitOffs>693248576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -93533,7 +93604,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693251672</BitOffs>
+            <BitOffs>693257560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -93545,7 +93616,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693268608</BitOffs>
+            <BitOffs>693274496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -93558,7 +93629,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693277592</BitOffs>
+            <BitOffs>693283480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -93570,7 +93641,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693294528</BitOffs>
+            <BitOffs>693300416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -93583,7 +93654,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693303512</BitOffs>
+            <BitOffs>693309400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.Axis.PlcToNc</Name>
@@ -93595,7 +93666,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693320448</BitOffs>
+            <BitOffs>693326336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38.bBrakeRelease</Name>
@@ -93608,7 +93679,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693329432</BitOffs>
+            <BitOffs>693335320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.Axis.PlcToNc</Name>
@@ -93620,7 +93691,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693346368</BitOffs>
+            <BitOffs>693352256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39.bBrakeRelease</Name>
@@ -93633,7 +93704,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693355352</BitOffs>
+            <BitOffs>693361240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.Axis.PlcToNc</Name>
@@ -93645,7 +93716,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693372288</BitOffs>
+            <BitOffs>693378176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40.bBrakeRelease</Name>
@@ -93658,7 +93729,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693381272</BitOffs>
+            <BitOffs>693387160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.Axis.PlcToNc</Name>
@@ -93670,7 +93741,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693398208</BitOffs>
+            <BitOffs>693404096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41.bBrakeRelease</Name>
@@ -93683,7 +93754,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693407192</BitOffs>
+            <BitOffs>693413080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.Axis.PlcToNc</Name>
@@ -93695,7 +93766,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693424128</BitOffs>
+            <BitOffs>693430016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42.bBrakeRelease</Name>
@@ -93708,7 +93779,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693433112</BitOffs>
+            <BitOffs>693439000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.Axis.PlcToNc</Name>
@@ -93720,7 +93791,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693450048</BitOffs>
+            <BitOffs>693455936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43.bBrakeRelease</Name>
@@ -93733,7 +93804,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693459032</BitOffs>
+            <BitOffs>693464920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.Axis.PlcToNc</Name>
@@ -93745,7 +93816,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693475968</BitOffs>
+            <BitOffs>693481856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44.bBrakeRelease</Name>
@@ -93758,7 +93829,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693484952</BitOffs>
+            <BitOffs>693490840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.Axis.PlcToNc</Name>
@@ -93770,7 +93841,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693501888</BitOffs>
+            <BitOffs>693507776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45.bBrakeRelease</Name>
@@ -93783,7 +93854,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693510872</BitOffs>
+            <BitOffs>693516760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.Axis.PlcToNc</Name>
@@ -93795,7 +93866,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693527808</BitOffs>
+            <BitOffs>693533696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46.bBrakeRelease</Name>
@@ -93808,7 +93879,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693536792</BitOffs>
+            <BitOffs>693542680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.Axis.PlcToNc</Name>
@@ -93820,7 +93891,7 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693553728</BitOffs>
+            <BitOffs>693559616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47.bBrakeRelease</Name>
@@ -93833,14 +93904,14 @@ second version of targets paddle 2</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>693562712</BitOffs>
+            <BitOffs>693568600</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>88080384</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -101610,11 +101681,6 @@ second version of targets paddle 2</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.bLI2K4StatesReset</Name>
-            <Comment>{attribute 'pytmc' := '
-     pv: LI2K4:IP1
-    io: io
- '}
- fbLI2K4States: FB_PositionStatePMPS2D;</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <BitOffs>675494096</BitOffs>
@@ -101627,6 +101693,7 @@ second version of targets paddle 2</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.li2k4_enumSet</Name>
+            <Comment>fbLI2K4States : FB_PositionStatePMPS2D;</Comment>
             <BitSize>16</BitSize>
             <BaseType>ENUM_LaserCoupling_States</BaseType>
             <Properties>
@@ -101824,15 +101891,24 @@ second version of targets paddle 2</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbLI2K4States</Name>
-            <BitSize>3008</BitSize>
+            <BitSize>8896</BitSize>
             <BaseType>FB_SequenceMover2D</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: LI2K4:IP1
+        io: io
+    </Value>
+              </Property>
+            </Properties>
             <BitOffs>679453952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>679456960</BitOffs>
+            <BitOffs>679462848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.stDefault</Name>
@@ -101852,7 +101928,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>679548992</BitOffs>
+            <BitOffs>679554880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4XStates</Name>
@@ -101862,7 +101938,7 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>679552704</BitOffs>
+            <BitOffs>679558592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.aLI2K4YStates</Name>
@@ -101872,37 +101948,37 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>679608384</BitOffs>
+            <BitOffs>679614272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>679664064</BitOffs>
+            <BitOffs>679669952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4Y_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>679664192</BitOffs>
+            <BitOffs>679670080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Positive</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>679664320</BitOffs>
+            <BitOffs>679670208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_LI2K4_IP1.EPS_LI2K4X_Negative</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="LCLS_General">FB_EPS</BaseType>
-            <BitOffs>679664448</BitOffs>
+            <BitOffs>679670336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbMotionAT2K4</Name>
             <BitSize>327040</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>679664576</BitOffs>
+            <BitOffs>679670464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbAT2K4States</Name>
@@ -101917,13 +101993,13 @@ second version of targets paddle 2</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>679991616</BitOffs>
+            <BitOffs>679997504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.fbStateSetup</Name>
             <BitSize>92032</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>681539968</BitOffs>
+            <BitOffs>681545856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.stDefault</Name>
@@ -101947,7 +102023,7 @@ second version of targets paddle 2</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>681632000</BitOffs>
+            <BitOffs>681637888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_AT2K4_IP1.aAT2K4States</Name>
@@ -101957,38 +102033,38 @@ second version of targets paddle 2</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>681635712</BitOffs>
+            <BitOffs>681641600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fbArbiterIO</Name>
             <BitSize>144640</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>681692608</BitOffs>
+            <BitOffs>681698496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>681837248</BitOffs>
+            <BitOffs>681843136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bM1K1Veto</Name>
             <Comment>	bST1K4_Veto: BOOL;</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>681865600</BitOffs>
+            <BitOffs>681871488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bM1K3Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>681865608</BitOffs>
+            <BitOffs>681871496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_3_PMPS_POST.bST4K4_Veto</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>681865616</BitOffs>
+            <BitOffs>681871504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF1K4State</Name>
@@ -101999,13 +102075,13 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>681865648</BitOffs>
+            <BitOffs>681871536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_4_LOG.fbLogHandler</Name>
             <BitSize>5802176</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>681873024</BitOffs>
+            <BitOffs>681878912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter</Name>
@@ -102024,7 +102100,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>687680960</BitOffs>
+            <BitOffs>687686848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -102043,7 +102119,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>688277952</BitOffs>
+            <BitOffs>688283840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -102073,7 +102149,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>688874944</BitOffs>
+            <BitOffs>688880832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -102103,7 +102179,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>690618112</BitOffs>
+            <BitOffs>690624000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.ePF2K4State</Name>
@@ -102114,7 +102190,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692361280</BitOffs>
+            <BitOffs>692367168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4ATT</Name>
@@ -102125,7 +102201,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692361296</BitOffs>
+            <BitOffs>692367184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcGVL.eSP1K4FZP</Name>
@@ -102136,7 +102212,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692361312</BitOffs>
+            <BitOffs>692367200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -102151,7 +102227,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692361328</BitOffs>
+            <BitOffs>692367216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -102166,7 +102242,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692361336</BitOffs>
+            <BitOffs>692367224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -102195,7 +102271,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692361344</BitOffs>
+            <BitOffs>692367232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -102207,7 +102283,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692387264</BitOffs>
+            <BitOffs>692393152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -102218,7 +102294,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692413184</BitOffs>
+            <BitOffs>692419072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -102229,7 +102305,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692439104</BitOffs>
+            <BitOffs>692444992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -102240,7 +102316,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692465024</BitOffs>
+            <BitOffs>692470912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -102251,7 +102327,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692490944</BitOffs>
+            <BitOffs>692496832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -102262,7 +102338,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692516864</BitOffs>
+            <BitOffs>692522752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -102273,7 +102349,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692542784</BitOffs>
+            <BitOffs>692548672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -102302,7 +102378,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692568704</BitOffs>
+            <BitOffs>692574592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -102330,7 +102406,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692594624</BitOffs>
+            <BitOffs>692600512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -102357,7 +102433,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692620544</BitOffs>
+            <BitOffs>692626432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -102384,7 +102460,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692646464</BitOffs>
+            <BitOffs>692652352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -102411,7 +102487,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692672384</BitOffs>
+            <BitOffs>692678272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -102423,7 +102499,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692698304</BitOffs>
+            <BitOffs>692704192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -102452,7 +102528,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692724224</BitOffs>
+            <BitOffs>692730112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -102481,7 +102557,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692750144</BitOffs>
+            <BitOffs>692756032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -102510,7 +102586,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692776064</BitOffs>
+            <BitOffs>692781952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -102539,7 +102615,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692801984</BitOffs>
+            <BitOffs>692807872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -102564,7 +102640,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692827904</BitOffs>
+            <BitOffs>692833792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -102593,7 +102669,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692853824</BitOffs>
+            <BitOffs>692859712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -102622,7 +102698,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692879744</BitOffs>
+            <BitOffs>692885632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -102647,7 +102723,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692905664</BitOffs>
+            <BitOffs>692911552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -102675,7 +102751,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692931584</BitOffs>
+            <BitOffs>692937472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -102702,7 +102778,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692957504</BitOffs>
+            <BitOffs>692963392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -102729,7 +102805,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>692983424</BitOffs>
+            <BitOffs>692989312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -102756,7 +102832,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693009344</BitOffs>
+            <BitOffs>693015232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -102785,7 +102861,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693035264</BitOffs>
+            <BitOffs>693041152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -102814,7 +102890,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693061184</BitOffs>
+            <BitOffs>693067072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -102839,7 +102915,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693087104</BitOffs>
+            <BitOffs>693092992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -102868,7 +102944,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693113024</BitOffs>
+            <BitOffs>693118912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -102893,7 +102969,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693138944</BitOffs>
+            <BitOffs>693144832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -102930,7 +103006,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693164864</BitOffs>
+            <BitOffs>693170752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -102975,7 +103051,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693190784</BitOffs>
+            <BitOffs>693196672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -103016,7 +103092,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693216704</BitOffs>
+            <BitOffs>693222592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -103057,7 +103133,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693242624</BitOffs>
+            <BitOffs>693248512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -103098,7 +103174,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693268544</BitOffs>
+            <BitOffs>693274432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -103139,7 +103215,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693294464</BitOffs>
+            <BitOffs>693300352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M38</Name>
@@ -103180,7 +103256,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693320384</BitOffs>
+            <BitOffs>693326272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M39</Name>
@@ -103221,7 +103297,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693346304</BitOffs>
+            <BitOffs>693352192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M40</Name>
@@ -103262,7 +103338,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693372224</BitOffs>
+            <BitOffs>693378112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M41</Name>
@@ -103298,7 +103374,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693398144</BitOffs>
+            <BitOffs>693404032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M42</Name>
@@ -103334,7 +103410,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693424064</BitOffs>
+            <BitOffs>693429952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M43</Name>
@@ -103370,7 +103446,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693449984</BitOffs>
+            <BitOffs>693455872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M44</Name>
@@ -103415,7 +103491,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693475904</BitOffs>
+            <BitOffs>693481792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M45</Name>
@@ -103461,7 +103537,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693501824</BitOffs>
+            <BitOffs>693507712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M46</Name>
@@ -103507,7 +103583,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693527744</BitOffs>
+            <BitOffs>693533632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M47</Name>
@@ -103553,7 +103629,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693553664</BitOffs>
+            <BitOffs>693559552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -103583,7 +103659,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579584</BitOffs>
+            <BitOffs>693585472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -103613,7 +103689,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579648</BitOffs>
+            <BitOffs>693585536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -103628,7 +103704,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579712</BitOffs>
+            <BitOffs>693585600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -103643,7 +103719,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579728</BitOffs>
+            <BitOffs>693585616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -103658,7 +103734,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579744</BitOffs>
+            <BitOffs>693585632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -103672,7 +103748,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579752</BitOffs>
+            <BitOffs>693585640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -103687,7 +103763,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579776</BitOffs>
+            <BitOffs>693585664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -103702,7 +103778,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579808</BitOffs>
+            <BitOffs>693585696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -103716,7 +103792,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693579840</BitOffs>
+            <BitOffs>693585728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -103734,7 +103810,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693581888</BitOffs>
+            <BitOffs>693587776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -103748,7 +103824,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693582912</BitOffs>
+            <BitOffs>693588800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -103762,7 +103838,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693582944</BitOffs>
+            <BitOffs>693588832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -103783,7 +103859,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693582976</BitOffs>
+            <BitOffs>693588864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -103855,7 +103931,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693599360</BitOffs>
+            <BitOffs>693605248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -103927,7 +104003,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693599488</BitOffs>
+            <BitOffs>693605376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -103999,7 +104075,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693599616</BitOffs>
+            <BitOffs>693605504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -104071,7 +104147,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693599744</BitOffs>
+            <BitOffs>693605632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -104143,7 +104219,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693599872</BitOffs>
+            <BitOffs>693605760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -104215,7 +104291,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693600000</BitOffs>
+            <BitOffs>693605888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -104287,7 +104363,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693600384</BitOffs>
+            <BitOffs>693606272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -104359,7 +104435,7 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693600512</BitOffs>
+            <BitOffs>693606400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -104385,14 +104461,20 @@ second version of targets paddle 2</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>693633280</BitOffs>
+            <BitOffs>693639168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_LI2K4_IP1.fbFastFault</Name>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="PMPS">FB_FastFault</BaseType>
+            <BitOffs>700946240</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>88080384</ByteSize>
+          <ByteSize>88276992</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -104478,15 +104560,15 @@ second version of targets paddle 2</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-07-25T14:05:43</Value>
+          <Value>2024-07-25T16:43:05</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1282048</Value>
+          <Value>1286144</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>86351872</Value>
+          <Value>86355968</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Implemented rudimentary sequence mover for 2 dimensional motion in TMO motion leveraging the 1D state mover PMPS function block.
Kept the function block very simple for now. There is definitely a better way to do arbitrary sequenced state moves but didn't have time to do that.
Checked to make sure it was playing nicely with PMPS.
Was complicated to get it to work with PMPS, had to add a new fast fault for condition when the two 1D pmps state movers disagree on the current state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked to make sure the PMPS id codes are being reported properly. Ended up adding a fast fault to account for mismatching states.
Moved from OUT to MIRROR1 and back successfully multiple times.
Checked to make sure maintenance mode is being set correctly.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
