### PR TITLE
modifying li2k4 parameters for new mirror

### DIFF
--- a/plc-tmo-motion/_Config/NC/Axes/Axis 46 LI2K4-MMS-X.xti
+++ b/plc-tmo-motion/_Config/NC/Axes/Axis 46 LI2K4-MMS-X.xti
@@ -1324,8 +1324,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-05" Offset="-214728.674" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-4"/>
-				<SoftEndMaxControl Enable="true" Range="1.5"/>
+				<SoftEndMinControl Range="-4"/>
+				<SoftEndMaxControl Range="1.5"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/plc-tmo-motion/_Config/PLC/tmo_motion.xti
+++ b/plc-tmo-motion/_Config/PLC/tmo_motion.xti
@@ -1260,7 +1260,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{9DD0BA81-4A92-4D5E-8BD9-E101C02702D4}" Name="tmo_motion" PrjFilePath="..\..\tmo_motion\tmo_motion.plcproj" TmcFilePath="..\..\tmo_motion\tmo_motion.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{D35A4FBA-A1D6-D1F8-D559-116E09A79F07}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_motion\tmo_motion.tmc" TmcHash="{A51EA576-8248-980F-6098-1C92D2FCBEA6}">
 			<Name>tmo_motion Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/plc-tmo-motion/plc-tmo-motion.tsproj
+++ b/plc-tmo-motion/plc-tmo-motion.tsproj
@@ -9,8 +9,8 @@
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
-					<TargetSelect TargetId="2">{E008E3C8-6BD9-491C-B673-DC45CC7AA4F1}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
+					<TargetSelect TargetId="2">{E008E3C8-6BD9-491C-B673-DC45CC7AA4F1}</TargetSelect>
 					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020003" DongleLevel="50" DongleSystemId="{48EB253C-818D-610A-0B70-DC68309EB817}"/>
 				</Target>
 			</Licenses>

--- a/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_LI2K4_IP1.TcPOU
@@ -63,8 +63,8 @@ fbStateSetup(stPositionState:=stDefault, bSetDefault:=TRUE);
 fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.OUT], fDelta := 0.5, sName := 'OUT', fPosition:=-0.75);
 
 fbStateSetup(stPositionState:=aLI2K4YStates[ENUM_LaserCoupling_States.OUT], fDelta := 0.5,  sName := 'OUT', fPosition:=133.0);
-fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 1.5, sName := 'MIRROR1', fPosition:=-3.375);
-fbStateSetup(stPositionState:=aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 0.5, sName := 'MIRROR1', fPosition:=84.5);
+fbStateSetup(stPositionState:=aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 5.0, sName := 'MIRROR1', fPosition:=-3.375);
+fbStateSetup(stPositionState:=aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1],fDelta := 5.0, sName := 'MIRROR1', fPosition:=84.5);
 
 aLI2K4YStates[ENUM_LaserCoupling_States.OUT].stPMPS.sPmpsState := 'LI2K4:IP1-OUT';
 aLI2K4YStates[ENUM_LaserCoupling_States.Mirror1].stPMPS.sPmpsState := 'LI2K4:IP1-MIRROR1';
@@ -73,6 +73,7 @@ aLI2K4XStates[ENUM_LaserCoupling_States.Mirror1].stPMPS.sPmpsState := 'LI2K4:IP1
 
 //LI2K4 EPS condition: OUT->In move Y then move X + IN->OUT move X thenm move Y
 //Y only can move up and down when X is OUT
+{*
 EPS_LI2K4Y_Positive(eps:=Main.M45.stEPSForwardEnable);
 EPS_LI2K4Y_Positive.setBit(nBits := 0, bValue:= Main.M46.stAxisStatus.fActPosition > -0.8 OR Main.M45.stAxisStatus.fActPosition < 85);
 EPS_LI2K4Y_Negative(eps:=Main.M45.stEPSBackwardEnable);
@@ -83,7 +84,7 @@ EPS_LI2K4X_Positive.setBit(nBits := 0, bValue:= Main.M45.stAxisStatus.fActPositi
 EPS_LI2K4X_Negative(eps:=Main.M46.stEPSBackwardEnable);
 EPS_LI2K4X_Negative.setBit(nBits := 0, bValue:= Main.M45.stAxisStatus.fActPosition < 85 OR Main.M46.stAxisStatus.fActPosition > -0.85);
 
-
+*}
 
 //LI2K4 sequenct move : OUT->IN Y move first and then X moves IN->OUT X moves first then Y
 

--- a/plc-tmo-motion/tmo_motion/tmo_motion.tmc
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D35A4FBA-A1D6-D1F8-D559-116E09A79F07}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{A51EA576-8248-980F-6098-1C92D2FCBEA6}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -1457,9 +1457,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-      </Method>
-      <Method>
         <Name>ExtendName</Name>
         <Comment> extends the source name on the right side of the string by the given extension.
  If the source name string size is exceeded nothing more is extended.
@@ -1515,19 +1512,7 @@
         </Local>
       </Method>
       <Method>
-        <Name>__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Name>Clear</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__setnId</Name>
@@ -1571,6 +1556,21 @@
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
@@ -1795,7 +1795,7 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -1994,9 +1994,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="10">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2157,6 +2154,9 @@
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -2680,7 +2680,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T#1ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2696,7 +2696,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T#100ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2712,7 +2712,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T#10m</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -3633,7 +3633,7 @@
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#300MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -4132,6 +4132,69 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
+      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>index</Name>
+        <Type>BYTE</Type>
+        <Comment> Returns the current task index of the calling task. </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCurTaskIndex</Name>
+        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General.Tc2_Utilities">E_TypeFieldParam</Name>
       <Comment> String format argument types </Comment>
       <BitSize>16</BitSize>
@@ -4614,69 +4677,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">GETCURTASKINDEX</Name>
-      <Comment> This function block GETCURTASKINDEX finds the task index of the task from which it is called. </Comment>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>index</Name>
-        <Type>BYTE</Type>
-        <Comment> Returns the current task index of the calling task. </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCurTaskIndex</Name>
-        <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General.TcUnit">FB_Test</Name>
       <Comment>
     This function block holds all data that defines a test.
@@ -4707,15 +4707,15 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetFailed</Name>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFailed</Name>
       </Method>
       <Method>
         <Name>IsFailed</Name>
@@ -5000,12 +5000,91 @@
         <BitOffs>8224416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>Expected</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Type>AnyType</Type>
+          <BitSize>128</BitSize>
+          <Properties>
+            <Property>
+              <Name>anytypeclass</Name>
+              <Value>ANY</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+        <Properties>
+          <Property>
+            <Name>hasanytype</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
@@ -5054,53 +5133,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>Expected</Name>
           <Type>AnyType</Type>
@@ -5315,44 +5347,12 @@
         </Properties>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>Expected</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Type>AnyType</Type>
-          <BitSize>128</BitSize>
-          <Properties>
-            <Property>
-              <Name>anytypeclass</Name>
-              <Value>ANY</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>hasanytype</Name>
-          </Property>
-        </Properties>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -5669,6 +5669,14 @@
         <BitOffs>4240416</BitOffs>
       </SubItem>
       <Method>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>IncreaseDetectionCountThisCycleByOne</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -5708,46 +5716,6 @@
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -5944,7 +5912,39 @@
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -6288,6 +6288,103 @@
         <BitOffs>12701056</BitOffs>
       </SubItem>
       <Method>
+        <Name>AssertArrayEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> DINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> DINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_REAL</Name>
         <Parameter>
           <Name>Expecteds</Name>
@@ -6529,21 +6626,21 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -6699,113 +6796,6 @@
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> BYTE array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> BYTE array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualByteString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFailed</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6942,21 +6932,6 @@
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7345,14 +7320,29 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_DINT</Name>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_BYTE</Name>
         <Comment>
-    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> DINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -7366,8 +7356,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> DINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">DINT</Type>
+          <Comment> BYTE array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">BYTE</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -7431,6 +7421,16 @@
           <BitSize>32</BitSize>
         </Local>
         <Local>
+          <Name>ExpectedByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualByteString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
           <Name>ExpectedsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
@@ -7440,45 +7440,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
@@ -7518,6 +7479,210 @@
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Comment> String formatter for output messages</Comment>
+          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -7724,14 +7889,20 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -7740,6 +7911,16 @@
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -7998,40 +8179,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertEquals_REAL</Name>
         <Comment>
     Asserts that two REALs are equal to within a positive delta. If they are not, an assertion error is created.
@@ -8106,37 +8253,18 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LTIME</Name>
-        <Comment>
-    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LTIME expected value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LTIME actual value</Comment>
-          <Type>LTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -8305,341 +8433,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Comment> String formatter for output messages</Comment>
-          <Type Namespace="LCLS_General.Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -8737,6 +8530,208 @@
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -8770,14 +8765,14 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -8791,8 +8786,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9293,19 +9288,22 @@
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -9353,6 +9351,40 @@
           <Name>TrimmedTestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LTIME</Name>
+        <Comment>
+    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LTIME expected value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LTIME actual value</Comment>
+          <Type>LTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -9463,103 +9495,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -9657,11 +9592,48 @@
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9675,8 +9647,8 @@
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -9687,12 +9659,6 @@
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the Expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -9754,6 +9720,40 @@
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Properties>
@@ -10067,7 +10067,7 @@
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#50MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -10095,7 +10095,7 @@
         <BitSize>32</BitSize>
         <BitOffs>4129120</BitOffs>
         <Default>
-          <DateTime>T#50MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
@@ -13140,6 +13140,14 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -13192,6 +13200,20 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -13205,25 +13227,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -13248,10 +13260,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -13271,23 +13279,36 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -13314,20 +13335,6 @@
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -13371,22 +13378,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -13438,36 +13429,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>CopyDocument</Name>
-        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pDoc</Name>
-          <Comment> target string buffer where the document should be copied to</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nDoc</Name>
-          <Comment> size in bytes of the target string buffer</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
       </Method>
       <Method>
         <Name>GetMaxDecimalPlaces</Name>
@@ -13480,20 +13443,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
+        <Name>AddRawObject</Name>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -13503,11 +13455,22 @@
             </Property>
           </Properties>
         </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBool</Name>
@@ -13516,6 +13479,22 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddBase64</Name>
@@ -13539,7 +13518,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
+        <Name>AddKeyDateTime</Name>
         <Parameter>
           <Name>key</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
@@ -13550,6 +13529,11 @@
               <Value>InOut</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -13562,10 +13546,26 @@
         <Name>StartArray</Name>
       </Method>
       <Method>
-        <Name>AddReal</Name>
+        <Name>CopyDocument</Name>
+        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>pDoc</Name>
+          <Comment> target string buffer where the document should be copied to</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nDoc</Name>
+          <Comment> size in bytes of the target string buffer</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -13884,22 +13884,11 @@
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -13958,41 +13947,14 @@
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -14030,14 +13992,52 @@
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14305,23 +14305,13 @@
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14407,19 +14397,15 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -14463,32 +14449,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14512,16 +14472,6 @@
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14556,34 +14506,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -14623,6 +14562,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14638,7 +14587,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -14648,8 +14597,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14714,16 +14663,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14760,7 +14699,60 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -14770,8 +14762,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -14790,9 +14782,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -14805,6 +14797,16 @@
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -14815,12 +14817,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -14893,36 +14900,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -14933,25 +14910,19 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -15004,9 +14975,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15014,7 +14985,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -15113,7 +15084,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -15122,15 +15093,9 @@
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15150,21 +15115,6 @@
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -15212,6 +15162,38 @@
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15248,39 +15230,46 @@
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15314,34 +15303,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -15404,9 +15368,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15414,7 +15378,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -15423,26 +15397,9 @@
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -15476,9 +15433,9 @@
         </Local>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15578,14 +15535,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15668,59 +15617,17 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15774,6 +15681,42 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -15800,13 +15743,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -15895,9 +15848,9 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -15915,7 +15868,22 @@
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -15947,17 +15915,28 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -15972,11 +15951,136 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -16014,7 +16118,7 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -16024,112 +16128,8 @@
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -19527,12 +19527,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetMDPTableID</Name>
-        <Comment> returns the MDP table id (part of MDP address) </Comment>
-        <ReturnType>BYTE</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>GetMDPSubIndex</Name>
         <ReturnType>BYTE</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19558,6 +19552,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetMDPModuleType</Name>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>IsListParam</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19573,9 +19572,10 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetMDPModuleType</Name>
-        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>GetMDPTableID</Name>
+        <Comment> returns the MDP table id (part of MDP address) </Comment>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetKey</Name>
@@ -21405,112 +21405,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <GetCodeOffs>87236888</GetCodeOffs>
       </PropertyItem>
       <Method>
-        <Name>Clear</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetFreeSpaceOfVol</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
-        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Local>
-          <Name>ipMemMan</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetMDPVersion</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nLen</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetTCVersion</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nLen</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetParameterStrings</Name>
-        <Comment>| access a read string parameter with multiple values.
-| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pBuffer</Name>
-          <Comment> parameter buffer with a given size of nBufferSize</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBufferSize</Name>
-          <Comment> buffer size in bytes (for one or more values)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nStrings</Name>
-          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>ReadFreeSpaceOfVol</Name>
         <Local>
           <Name>nState</Name>
@@ -21578,6 +21472,112 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetFreeSpaceOfVol</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMDPVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTCVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetParameterStrings</Name>
+        <Comment>| access a read string parameter with multiple values.
+| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nStrings</Name>
+          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
+        <ReturnType Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipMemMan</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>ReadMDPVersion</Name>
@@ -24978,21 +24978,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -25011,22 +25012,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysFile.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -25225,100 +25225,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -25377,6 +25283,100 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -25580,6 +25580,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -25610,36 +25617,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -25655,9 +25632,29 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -25678,17 +25675,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -26062,6 +26062,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -26073,14 +26079,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -26097,9 +26095,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -26139,15 +26137,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -26432,35 +26432,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -26508,9 +26525,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -26734,47 +26769,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -26920,37 +26920,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -26958,9 +26928,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -27177,7 +27145,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -27745,21 +27745,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -28496,6 +28496,688 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -28805,533 +29487,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -29876,6 +30031,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -30367,56 +30537,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -30487,45 +30625,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -30534,22 +30648,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -30557,124 +30656,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -30948,18 +30929,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -31306,7 +31306,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -31325,13 +31325,40 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T#10MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -31368,33 +31395,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls_twincat_common_components.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -35573,37 +35573,6 @@ External Setpoint Generation:
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -35648,6 +35617,37 @@ External Setpoint Generation:
     </Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -36263,28 +36263,28 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -36511,7 +36511,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>339528</BitOffs>
         <Default>
-          <Bool> : u</Bool>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -36545,42 +36545,30 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>511296</BitOffs>
       </SubItem>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>85696</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36711,6 +36699,42 @@ ELSE:
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -36752,44 +36776,20 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>85696</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -44606,7 +44606,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -48369,13 +48369,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -48396,7 +48396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -48554,7 +48554,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>1088</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -49388,7 +49388,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>2720</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -55655,19 +55655,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Motion</Name>
-      </Action>
-      <Action>
         <Name>ACT_Zero</Name>
       </Action>
       <Action>
         <Name>ACT_Home</Name>
       </Action>
       <Action>
-        <Name>ACT_CalculatePositions</Name>
+        <Name>ACT_BLOCK</Name>
       </Action>
       <Action>
-        <Name>ACT_BLOCK</Name>
+        <Name>ACT_Motion</Name>
+      </Action>
+      <Action>
+        <Name>ACT_CalculatePositions</Name>
       </Action>
       <Action>
         <Name>ACT_Init</Name>
@@ -56307,7 +56307,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>27200</BitOffs>
         <Default>
-          <DateTime>T#10S</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -56329,7 +56329,7 @@ Digital outputs</Comment>
         <BitSize>32</BitSize>
         <BitOffs>27776</BitOffs>
         <Default>
-          <DateTime>T#1S</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -56426,10 +56426,10 @@ Digital outputs</Comment>
         </Properties>
       </SubItem>
       <Action>
-        <Name>ACT_Logger</Name>
+        <Name>ACT_IO</Name>
       </Action>
       <Action>
-        <Name>ACT_IO</Name>
+        <Name>ACT_Logger</Name>
       </Action>
       <Properties>
         <Property>
@@ -58595,7 +58595,7 @@ second version of targets paddle 2</Comment>
         <BitSize>32</BitSize>
         <BitOffs>8768</BitOffs>
         <Default>
-          <DateTime>T#5s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -58647,6 +58647,26 @@ second version of targets paddle 2</Comment>
         </Properties>
       </SubItem>
       <Method>
+        <Name>setDescription</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>desciption</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>setMessage</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>message</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>setBit</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -58670,26 +58690,6 @@ second version of targets paddle 2</Comment>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>setMessage</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>message</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>setDescription</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>desciption</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -59259,8 +59259,7 @@ second version of targets paddle 2</Comment>
         <BitSize>8</BitSize>
         <BitOffs>144576</BitOffs>
         <Default>
-          <Bool>,
-  </Bool>
+          <Bool>,</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -59781,47 +59780,6 @@ second version of targets paddle 2</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -59869,6 +59827,21 @@ second version of targets paddle 2</Comment>
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -59971,19 +59944,45 @@ second version of targets paddle 2</Comment>
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -60692,6 +60691,26 @@ second version of targets paddle 2</Comment>
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -60734,26 +60753,6 @@ second version of targets paddle 2</Comment>
         <Local>
           <Name>b32HasError</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -60881,10 +60880,11 @@ second version of targets paddle 2</Comment>
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> generates a JSON string from a given symbol (via address/size)</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -60898,29 +60898,27 @@ second version of targets paddle 2</Comment>
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
           <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -61003,47 +61001,6 @@ second version of targets paddle 2</Comment>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Local>
           <Name>nSize</Name>
@@ -61179,6 +61136,48 @@ second version of targets paddle 2</Comment>
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> generates a JSON string from a given symbol (via address/size)</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -61882,46 +61881,12 @@ second version of targets paddle 2</Comment>
         </Parameter>
       </Method>
       <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -62051,6 +62016,40 @@ second version of targets paddle 2</Comment>
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -62261,7 +62260,7 @@ second version of targets paddle 2</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -63018,7 +63017,7 @@ second version of targets paddle 2</Comment>
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -63440,7 +63439,7 @@ second version of targets paddle 2</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1h</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -63452,7 +63451,7 @@ second version of targets paddle 2</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -63464,7 +63463,7 @@ second version of targets paddle 2</Comment>
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -93851,7 +93850,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#1ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93866,7 +93865,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#100ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93881,7 +93880,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10s</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -93896,7 +93895,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10m</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -100140,7 +100139,7 @@ second version of targets paddle 2</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#0MS</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -104347,11 +104346,11 @@ second version of targets paddle 2</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-08-08T09:41:45</Value>
+          <Value>2024-08-13T14:54:07</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1282048</Value>
+          <Value>1216512</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Scientists swap a new mirror for LI2K4, and they asks me to lift  all EPS and PMPS parameter for them to tune
<!--- Describe your changes in detail -->
close EPS, close soft limit of LI2K4-X, change fdelta for X in IN position
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists swap a new mirror in LI2K4 and need  to lift control to let them test.
All changes here are temporary. After they install and tune again, I need to put new parameters in. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Not test, just lift PMPS and EPS protection for them to tune.
I activate config, log in, and I can move other motors. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
