### PR TITLE
ENH: tmo spectrometer uses TMO:SPEC as happi prefix

### DIFF
--- a/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
+++ b/plc-tmo-motion/tmo_motion/POUs/PRG_SP1K4.TcPOU
@@ -120,7 +120,7 @@ VAR
     SP1K4_ATT_RTD_02 : FB_CC_TempSensor;
 
     {attribute 'TcLinkTo' := '.iRaw := TIIB[EP3174-FWM-E2]^AI Standard Channel 2^Value'}
-    {attribute 'pytmc' :='pv: SP1K4'}
+    {attribute 'pytmc' :='pv: TMO:SPEC'}
     fbFlowMeter: FB_FDQ_FlowMeter;
 END_VAR
 ]]></Declaration>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
change flow meter PV name to match TMO-Motion Spectrometer style:
 ` - {attribute 'pytmc' :='pv: SP1K4'}`
 ` + {attribute 'pytmc' :='pv: TMO:SPEC'}`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
