### PR TITLE
Increasing motion library version to 4.2.1

### DIFF
--- a/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
+++ b/plc-tmo-motion/tmo_motion/tmo_motion.plcproj
@@ -217,7 +217,7 @@
       <Resolution>lcls-twincat-common-components, 3.9.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 4.1.1 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, 4.2.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, 3.3.0 (SLAC - LCLS)</Resolution>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Using v4.2.1 of lcls-twincat-motion
This is to fix the bug where toggling the arbiter off and on without changing the position results in the pre-emptive request disappearing until the device is moved to another position. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-6609

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to fixed versions and not ``Always Newest``
- [x] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
